### PR TITLE
[codex] Make Remote UI prompt Enter submit

### DIFF
--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1463,7 +1463,7 @@ function renderAgentAttachmentView(agent, attachmentId) {
 function renderAgentComposer(agent, skills, options = {}) {
   return `
     <form id="composer" class="composer" data-agent-key="${escapeAttr(agent.key)}">
-      <textarea id="prompt-input" rows="4" placeholder="Send a prompt" aria-label="Prompt"></textarea>
+      <textarea id="prompt-input" rows="4" placeholder="Send a prompt" aria-label="Prompt" enterkeyhint="send"></textarea>
       ${renderPromptAttachmentInput(agent)}
       ${renderPendingAttachments(agent)}
       ${renderAgentAttachments(agent)}
@@ -4111,11 +4111,28 @@ document.addEventListener("click", (event) => {
 
 els.view.addEventListener("keydown", (event) => {
   if (event.key !== "Enter") return;
-  if (event.target?.id !== "agent-filter") return;
-  event.preventDefault();
-  const query = state.filters.agents.toLowerCase();
-  const first = state.agents.find((agent) => agentMatches(agent, query));
-  if (first) navigate({ type: "agent", key: first.key });
+  if (event.target?.id === "prompt-input") {
+    if (event.shiftKey || event.isComposing) return;
+
+    const form = event.target.closest("#composer");
+    const submitButton = form?.querySelector("button[type='submit']");
+    if (!form || !submitButton || submitButton.disabled) return;
+
+    event.preventDefault();
+    if (typeof form.requestSubmit === "function") {
+      form.requestSubmit(submitButton);
+    } else {
+      submitButton.click();
+    }
+    return;
+  }
+
+  if (event.target?.id === "agent-filter") {
+    event.preventDefault();
+    const query = state.filters.agents.toLowerCase();
+    const first = state.agents.find((agent) => agentMatches(agent, query));
+    if (first) navigate({ type: "agent", key: first.key });
+  }
 });
 
 els.view.addEventListener("input", (event) => {
@@ -4176,7 +4193,7 @@ els.view.addEventListener("submit", (event) => {
   if (event.target.id === "composer") {
     const form = event.target;
     const button = event.submitter;
-    const key = button?.dataset.agentKey;
+    const key = button?.dataset.agentKey || form.dataset.agentKey;
     const promptValue = document.getElementById("prompt-input")?.value.trim() || "";
     const pendingAttachments = pendingAttachmentsFor(key);
     const prompt = promptValue || (pendingAttachments.length ? "Please review the attached files." : "");

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1150,6 +1150,16 @@ module RemoteServerTest
            "expected Agent detail composer action to switch by running state")
     assert(js[:body].include?('class="danger" type="button" data-agent-action="stop" data-agent-key="${escapeAttr(agent.key)}">Stop agent'),
            "expected running agents to replace Send prompt with Stop agent")
+    assert(js[:body].include?('enterkeyhint="send"'),
+           "expected Agent composer textarea to hint send-capable keyboards")
+    assert(js[:body].include?('event.target?.id === "prompt-input"'),
+           "expected Agent composer textarea to handle Enter submissions")
+    assert(js[:body].include?("event.shiftKey || event.isComposing"),
+           "expected Agent composer Enter handling to preserve newlines and IME input")
+    assert(js[:body].include?("form.requestSubmit(submitButton)"),
+           "expected Agent composer Enter handling to submit through the form")
+    assert(js[:body].include?("button?.dataset.agentKey || form.dataset.agentKey"),
+           "expected keyboard prompt submits to resolve the agent key from the form")
     assert(js[:body].include?("iconSvg(\"squareSlash\")"), "expected Insert Skill to render a square slash SVG icon")
     assert(js[:body].include?("iconSvg(\"robot\")"), "expected Agent marks to render a robot SVG icon")
     assert(js[:body].include?("iconSvg(\"search\")"), "expected search controls to render an SVG icon")


### PR DESCRIPTION
## Summary

- Keep the Remote UI agent prompt as a multiline textarea while making Enter submit the prompt.
- Preserve Shift+Enter for newlines and IME composition behavior.
- Add a form data fallback for keyboard-triggered submits and regression assertions for the Remote UI JavaScript.

https://github.com/user-attachments/assets/4b9be9dd-3571-47a3-bd44-8a91e6fc9ffc




## Why

The prompt composer already used form submit semantics, but the prompt field is a textarea. Native Enter inserts a newline in a textarea, so keyboard users could not submit the prompt with Enter from the composer.

## Validation

- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- Browser-engine verification against a throwaway `bin/tycho serve` instance with temp config/log roots: textarea rendered, Shift+Enter inserted a newline, Enter submitted and cleared the prompt.
