### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.1.1 - 2026-05-24
+
+- Add release maintainer runbook.
+- Add README hero image.
+- Make Remote UI prompt submission use Enter while preserving Shift+Enter
+  newlines and IME composition.
+
 ## 0.1.0 - 2026-05-23
 
 - Add MIT license and public contribution/security/code-of-conduct documentation.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -62,9 +62,9 @@ Key references:
 ## Current Focus
 
 **Public release hardening**: Tycho is public, and the immediate focus is the
-`v0.1.0` Homebrew release contract: public tag, release notes, user-scoped
-runtime paths, Homebrew install verification, and first-user documentation.
-Agent UX and continuity remain active maintenance areas.
+`v0.1.x` Homebrew release contract: release notes, user-scoped runtime paths,
+Homebrew install verification, first-user documentation, and repeatable release
+operations. Agent UX and continuity remain active maintenance areas.
 
 ## Roadmap
 
@@ -134,7 +134,9 @@ Agent UX and continuity remain active maintenance areas.
 - [x] Add Remote UI warning for unauthenticated non-loopback binds
 - [x] Run gitleaks history secret scan with documented false-positive allowlist
 - [x] Publish from a clean public repository instead of exposing private history
-- [ ] Publish `v0.1.0` GitHub release and public Homebrew tap formula
+- [x] Publish `v0.1.0` GitHub release
+- [x] Add release maintainer runbook
+- [x] Publish public Homebrew tap formula
 
 ## Features Candidates
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,142 @@
+# Releasing Tycho
+
+This is the maintainer runbook for cutting Tycho releases. Keep releases small,
+tagged from `main`, and backed by a passing `bin/test` run.
+
+## Version Policy
+
+- Patch releases (`0.1.x`) are for bug fixes, documentation fixes, and small
+  UX improvements that do not change the public config or command contract.
+- Minor releases (`0.x.0`) are for new user-facing commands, config keys,
+  packaging behavior, or Remote UI/TUI workflows.
+- Major releases are reserved for breaking changes after Tycho reaches `1.0`.
+
+## Preconditions
+
+Before preparing a release:
+
+1. Confirm all intended changes are merged into `main`.
+2. Sync `main` locally with `git pull --ff-only`.
+3. Confirm the working tree is clean with `git status -sb`.
+4. Review changes since the previous tag:
+
+   ```sh
+   git log --oneline <previous-tag>..main
+   ```
+
+5. Decide the next version and check that the tag does not already exist:
+
+   ```sh
+   git tag --list v<next-version>
+   ```
+
+## Release-Prep PR
+
+Prepare releases through a small pull request. The release-prep PR should:
+
+1. Bump `lib/hq/version.rb`.
+2. Move relevant `CHANGELOG.md` entries from `Unreleased` into a dated version
+   section.
+3. Update durable project status or roadmap notes when a release milestone
+   changes.
+4. Run:
+
+   ```sh
+   bin/test
+   ```
+
+Use an imperative commit message such as:
+
+```sh
+Prepare v0.1.1 release
+```
+
+Merge the release-prep PR before tagging.
+
+## Publish GitHub Release
+
+After the release-prep PR is merged:
+
+1. Sync `main`:
+
+   ```sh
+   git switch main
+   git pull --ff-only
+   ```
+
+2. Create and push an annotated tag:
+
+   ```sh
+   git tag -a v<next-version> -m "Tycho v<next-version>"
+   git push origin v<next-version>
+   ```
+
+3. Create the GitHub release:
+
+   ```sh
+   gh release create v<next-version> --title "Tycho v<next-version>" --notes-file /path/to/notes.md
+   ```
+
+Release notes should summarize user-visible changes, compatibility notes, and
+validation.
+
+## Homebrew Tap
+
+Tycho's public tap is `firewalker06/homebrew-tycho`.
+
+After the GitHub release exists:
+
+1. Download the release tarball and calculate its SHA-256:
+
+   ```sh
+   curl -L -o tycho-v<next-version>.tar.gz \
+     https://github.com/firewalker06/tycho/archive/refs/tags/v<next-version>.tar.gz
+   shasum -a 256 tycho-v<next-version>.tar.gz
+   ```
+
+2. Update `Formula/tycho.rb` in the tap:
+
+   ```ruby
+   url "https://github.com/firewalker06/tycho/archive/refs/tags/v<next-version>.tar.gz"
+   sha256 "..."
+   ```
+
+3. Verify the formula locally when Homebrew is available:
+
+   ```sh
+   brew install --build-from-source --verbose ./Formula/tycho.rb
+   brew test tycho
+   ```
+
+4. Push or merge the tap update.
+
+## Post-Release Verification
+
+After publishing:
+
+1. Confirm the GitHub release page exists.
+2. Confirm the Homebrew formula points at the new tag and SHA.
+3. Run a source checkout smoke test:
+
+   ```sh
+   bin/tycho --help
+   bin/tycho app list
+   bin/tycho schedule list
+   ```
+
+4. If the Homebrew tap was updated, run:
+
+   ```sh
+   brew update
+   brew install firewalker06/tycho/tycho
+   tycho --help
+   ```
+
+## Corrections
+
+If a release is wrong but harmless, cut a new patch release. Do not move an
+existing public tag unless the release is private and no one could have fetched
+it.
+
+If a release is broken enough to hide, mark the GitHub release as a prerelease
+or delete the release page, then cut a corrected patch version from `main`.

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
## Summary

- Add `docs/RELEASING.md` as the maintainer release runbook.
- Bump Tycho to `0.1.1`.
- Add `v0.1.1` changelog notes and refresh release status.

## Validation

- `bin/test`
