### PR TITLE
[codex] Improve Remote UI agent messaging and iPad header

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -229,17 +229,17 @@ browser/TUI smoke verification.
 
 - [x] Ability to start webserver (`tycho serve`)
 - [x] Tailscale auto-bind, MagicDNS URL display, HTTPS Serve detection, and compact terminal QR for phone setup
-- [x] Mobile Remote UI shell at `/` with `Now`, `Agents`, `Search`, `Projects`, and `Setup` tabs
+- [x] Mobile Remote UI shell at `/` with simplified `Now`, `Agents`, and `Settings` tabs
 - [x] Footer navigation sticks to the viewport, hides on downward scroll, and reappears on upward scroll
 - [x] Read agent conversation (`GET /agents/{key}/conversation`)
 - [x] Submit prompt to agent (`POST /agents/{key}/messages`)
 - [x] Start / Stop an agent (`POST /agents/{key}/start`, `POST /agents/{key}/stop`)
 - [x] Creates / Edit an agent (`POST /agents`, `PATCH /agents/{key}`)
-- [x] Archive an agent (`DELETE /agents/{key}` or `POST /agents/{key}/archive`)
+- [x] Archive one agent (`DELETE /agents/{key}` or `POST /agents/{key}/archive`) or bulk archive idle agents (`POST /agents/archive`)
 - [x] Project list/detail endpoints and mobile project health/detail screens
 - [x] Guarded deploy/maintenance/live preflight and start endpoints
-- [x] Remote setup/readiness endpoint and Setup screen
-- [x] Client-side Remote UI search across agents and projects
+- [x] Remote setup/readiness endpoint and Settings screen
+- [x] Client-side Remote UI filtering across agents and projects
 - [x] Remote UI skill discovery for chat insertion
 - [x] Browser push subscription/test-notification foundation, with HTTPS MagicDNS support and HTTP MagicDNS warnings ([WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md))
 - [x] Automatic browser push notifications when agents require response or finish

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -125,7 +125,7 @@ The UI is plain server-served HTML/CSS/JavaScript, with no frontend build step o
 
 Home-screen launches are treated as normal browser sessions, but mobile browsers can be more aggressive about reusing an old app shell. The root UI references `/ui.css` and `/ui.js` with a content digest query string, and `POST /server/restart` is the explicit cache-reset path: the restart response sends cache-reset headers, the browser clears Cache Storage when available, and the UI reloads itself with a restart query string after the replacement server is healthy.
 
-The top-level mobile tabs are `Now`, `Agents`, `Search`, `Projects`, and `Setup`. Detail routes use hash navigation such as `#agent/{key}`, `#project/{key}`, and `#project/{key}/action/{action}`. The footer nav is fixed on top-level routes, hides while scrolling down, shows again while scrolling up, and is hidden on detail subpages.
+The top-level mobile tabs are `Now`, `Agents`, and `Settings`. Agents is the canonical project-and-agent workspace: it filters agents and project metadata, keeps zero-agent projects reachable for first-agent creation, and links to project detail routes. Legacy `#search`, `#projects`, and `#setup` hashes are redirected to the closest surviving tab. Detail routes use hash navigation such as `#agent/{key}`, `#project/{key}`, and `#project/{key}/action/{action}`. The footer nav is fixed on top-level routes, hides while scrolling down, shows again while scrolling up, and is hidden on detail subpages.
 
 Browser push notification work is tracked in [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md). Push can use a Tailscale MagicDNS domain when it is served over HTTPS, preferably with Tailscale Serve or Tailscale Funnel. Plain HTTP MagicDNS URLs show a soft warning, but the UI still lets the user try enabling notifications when the browser exposes the required push APIs.
 
@@ -161,7 +161,7 @@ http://100.x.y.z:7373/
 
 Authentication is optional for localhost. If `TYCHO_REMOTE_TOKEN` is unset or blank, requests are accepted without auth.
 
-When `tycho serve` binds to a non-loopback host without a token, startup logs print a warning. The Setup screen also marks public Remote UI URLs as `token recommended`.
+When `tycho serve` binds to a non-loopback host without a token, startup logs print a warning. The Settings screen also marks public Remote UI URLs as `token recommended`.
 
 Set `TYCHO_REMOTE_TOKEN` before using a Tailscale MagicDNS URL or another non-local interface:
 
@@ -255,6 +255,7 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | `GET` | `/agents/{key}` | Read one managed agent. |
 | `PATCH` / `PUT` | `/agents/{key}` | Edit one idle managed agent. |
 | `DELETE` | `/agents/{key}` | Archive one idle managed agent. |
+| `POST` | `/agents/archive` | Archive multiple idle managed agents from a `keys` array, returning archived, skipped, and failed keys. |
 | `GET` | `/agents/{key}/conversation` | Read the rendered conversation blocks for one agent. |
 | `PUT` | `/agents/{key}/reading` | Mark one agent as read after the user opens its conversation. |
 | `POST` | `/agents/{key}/messages` | Append a user prompt to one agent. |
@@ -278,7 +279,7 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | `GET` | `/attachments/{id}` | Read normalized attachment metadata and inline preview content when available. |
 | `GET` | `/attachments/{id}/blob` | Stream the attachment file bytes for image and binary previews. |
 | `GET` | `/setup` | Read Remote UI readiness, auth, Tailscale, config, log, and refresh metadata. |
-| `GET` | `/search` | Return agent and project payloads for client-side search. |
+| `GET` | `/search` | Return agent and project payloads for compatibility with older client-side search flows. |
 | `GET` | `/`, `/ui`, `/ui.css`, `/ui.js` | Serve the Remote UI. `/ui` remains a compatibility alias. |
 | `GET` | `/favicon.svg`, `/favicon.ico` | Serve the Remote UI favicon. |
 
@@ -545,6 +546,37 @@ Response:
 }
 ```
 
+### `POST /agents/archive`
+
+Archives multiple idle agents from a `keys` array. Running agents are skipped and missing keys are reported without blocking idle agents in the same request.
+
+```bash
+curl -X POST http://127.0.0.1:7373/agents/archive \
+  -H "Content-Type: application/json" \
+  -d '{"keys":["web-charlie-agent-8","web-delta-agent-3"]}'
+```
+
+Response:
+
+```json
+{
+  "archived": [
+    {
+      "agent_key": "web-charlie-agent-8",
+      "archive_path": "/Users/example/.tycho/logs/agents/archive/20260508-001431-web-charlie-agent-8"
+    }
+  ],
+  "skipped": [
+    {
+      "agent_key": "web-delta-agent-3",
+      "reason": "running"
+    }
+  ],
+  "failed": [],
+  "archive_count": 1
+}
+```
+
 ### `POST /agents/{key}/clone`
 
 Creates a fresh managed agent from an existing one with a new key, empty logs, no runs, and no native session id. Form fields such as `name`, `template_key`, `agent`, `workspace`, `prompt`, and `sandbox_mode` may be supplied to edit the clone before it is saved. Set `archive_source: true` to archive the source agent after the clone is created.
@@ -571,7 +603,7 @@ Response:
 
 ### `GET /push/config`
 
-Returns browser push readiness for the Remote UI Setup screen. The public VAPID key is safe for the browser; the private key remains server-side.
+Returns browser push readiness for the Remote UI Settings screen. The public VAPID key is safe for the browser; the private key remains server-side.
 
 ```json
 {

--- a/docs/REMOTE_UI_IMPLEMENTATION_HANDOFF.md
+++ b/docs/REMOTE_UI_IMPLEMENTATION_HANDOFF.md
@@ -23,19 +23,18 @@ Current implementation files:
 - JavaScript: `lib/hq/remote_ui/assets/app.js`
 - Static asset helper: `lib/hq/remote_ui.rb`
 
-The old phase checklist has been retired because the shell, top-level screens, main detail routes, project payloads, setup/readiness payloads, skill discovery, client-side search, guarded project actions, audit fixes, and mobile nav polish are now implemented.
+The old phase checklist has been retired because the shell, simplified top-level screens, main detail routes, project payloads, setup/readiness payloads, skill discovery, client-side filtering, guarded project actions, audit fixes, and mobile nav polish are now implemented.
 
 ## Implemented
 
-- Five top-level destinations: `Now`, `Agents`, `Search`, `Projects`, `Setup`.
+- Three top-level destinations: `Now`, `Agents`, `Settings`.
 - Fixed bottom nav on top-level screens; it hides on downward scroll and reappears on upward scroll, focus, route changes, or near page top.
 - Bottom nav is hidden on subpages with a back button.
 - Deep links show loading states instead of transient not-found screens while initial data loads.
 - Now screen shows attention count, paused/blocked agents, running agents, and search affordance.
-- Agents screen filters and groups managed agents by project.
-- Search screen searches agents and projects client-side, prioritizing unread agents on empty query.
-- Projects screen lists health, latency, group, and maintenance/action state.
-- Setup screen shows URL, Tailscale/MagicDNS state, auth state, harness readiness, schema/config readiness, logs/storage, refresh intervals, and safety defaults.
+- Agents screen filters and groups managed agents by project, matches project metadata, keeps zero-agent projects reachable, and supports bulk archiving idle agents.
+- Project detail routes remain reachable from Agents project headers.
+- Settings screen shows URL, Tailscale/MagicDNS state, auth state, harness readiness, schema/config readiness, logs/storage, refresh intervals, and safety defaults.
 - Agent detail supports conversation viewing, current activity, run metadata, skill insertion, prompt submission, start run, and stop confirmation.
 - Project detail shows health, revision, deploy details, versions/templates, recent agent summary, and guarded project actions.
 - Guarded deploy/maintenance/live action screens show consequences and preflight checks before starting a detached Kamal action.
@@ -84,7 +83,7 @@ Manual smoke:
 
 - Start `bin/tycho serve`.
 - Open `/` at mobile width.
-- Check `Now`, `Agents`, `Search`, `Projects`, and `Setup`.
+- Check `Now`, `Agents`, and `Settings`.
 - Confirm the footer nav hides while scrolling down and shows while scrolling up.
 - Deep-link to an agent and project detail route.
 - Open a guarded project action preflight.

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -188,6 +188,7 @@ module HQ
       return accepted(service.start_schedule_daemon(body)) if method == "POST" && parts == ["schedules", "daemon", "start"]
       return accepted(service.stop_schedule_daemon) if method == "POST" && parts == ["schedules", "daemon", "stop"]
       return accepted(service.restart_schedule_daemon(body)) if method == "POST" && parts == ["schedules", "daemon", "restart"]
+      return ok(service.archive_agents(body)) if method == "POST" && parts == ["agents", "archive"]
       return ok(projects: service.projects) if method == "GET" && parts == ["projects"]
       return ok(hidden: service.hidden_settings) if method == "GET" && parts == ["settings", "hidden"]
       return ok(hidden: service.update_hidden_setting(body)) if %w[PATCH PUT].include?(method) && parts == ["settings", "hidden"]
@@ -998,6 +999,45 @@ module HQ
         archived: true,
         agent_key: target.key,
         archive_path: archive_path
+      }
+    end
+
+    def archive_agents(attrs)
+      payload = attrs || {}
+      keys = Array(payload["keys"]).map { |key| key.to_s.strip }.reject(&:empty?).uniq
+      raise Error.new("Missing agent keys") if keys.empty?
+
+      current = load_all_agents
+      agents_by_key = current.to_h { |agent| [agent.key, agent] }
+      archived = []
+      skipped = []
+      failed = []
+
+      keys.each do |key|
+        target = agents_by_key[key]
+        unless target
+          failed << { agent_key: key, error: "Agent not found" }
+          next
+        end
+
+        if target.running?
+          skipped << { agent_key: key, reason: "running" }
+          next
+        end
+
+        archived << { agent_key: target.key, archive_path: target.archive_logs! }
+      rescue StandardError => e
+        failed << { agent_key: key, error: e.message }
+      end
+
+      archived_keys = archived.map { |item| item.fetch(:agent_key) }
+      save_agents(current.reject { |agent| archived_keys.include?(agent.key) }) if archived_keys.any?
+
+      {
+        archived: archived,
+        skipped: skipped,
+        failed: failed,
+        archive_count: archived.length
       }
     end
 

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -21,7 +21,7 @@
 }
 
 html.ipad-standalone {
-  --ipad-header-control-space: 36px;
+  --ipad-header-control-space: 60px;
 }
 
 * {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -21,13 +21,7 @@
 }
 
 html.ipad-standalone {
-  --ipad-header-control-space: 72px;
-}
-
-@media (min-width: 820px) {
-  html.ipad-standalone {
-    --ipad-header-control-space: max(0px, calc(482px - 50vw));
-  }
+  --ipad-header-control-space: 36px;
 }
 
 * {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -467,6 +467,15 @@ h3 {
   flex-wrap: wrap;
 }
 
+.top-actions .search-box {
+  flex: 1 1 auto;
+}
+
+.top-actions > button {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
 .compact-actions button {
   padding: 7px 9px;
 }
@@ -969,6 +978,8 @@ select {
 }
 
 .search-box input {
+  flex: 1 1 auto;
+  min-width: 0;
   border: 0;
   background: transparent;
   padding: 2px 0;

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -566,7 +566,7 @@ select {
   left: 50%;
   z-index: 4;
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 4px;
   width: 100%;
   max-width: 820px;
@@ -1046,6 +1046,57 @@ select {
 
 .archive-actions button {
   flex: 1 1 140px;
+}
+
+.bulk-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 10px;
+}
+
+.bulk-action-bar > div:first-child {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.bulk-action-bar strong,
+.bulk-action-bar span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulk-action-bar span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.selectable-agent-row {
+  cursor: pointer;
+}
+
+.selectable-agent-row.selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.selectable-agent-row.disabled {
+  cursor: not-allowed;
+  opacity: 0.66;
+}
+
+.agent-select-box {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--accent);
 }
 
 .unread-dot {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -21,7 +21,7 @@
 }
 
 html.ipad-standalone {
-  --ipad-header-control-space: 84px;
+  --ipad-header-control-space: 72px;
 }
 
 * {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -21,7 +21,7 @@
 }
 
 html.ipad-standalone {
-  --ipad-header-control-space: 112px;
+  --ipad-header-control-space: 84px;
 }
 
 * {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -16,6 +16,13 @@
   --yellow: #f1fa8c;
   --accent-contrast: #282a36;
   --shadow: 0 14px 32px rgba(0, 0, 0, 0.32);
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+  --ipad-header-control-space: 0px;
+}
+
+html.ipad-standalone {
+  --ipad-header-control-space: 112px;
 }
 
 * {
@@ -120,13 +127,15 @@ h3 {
   width: 100%;
   max-width: 820px;
   min-height: 100vh;
+  min-height: 100dvh;
   margin: 0 auto;
+  padding-top: var(--safe-area-top);
 }
 
 .app-header {
   --header-offset-y: 0;
   position: sticky;
-  top: 0;
+  top: var(--safe-area-top);
   z-index: 7;
   border-bottom: 1px solid var(--border);
   background: color-mix(in srgb, var(--panel) 95%, transparent);
@@ -150,7 +159,7 @@ h3 {
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 10px 12px 10px calc(12px + var(--safe-area-left) + var(--ipad-header-control-space));
 }
 
 .header-row > #back-button {
@@ -306,15 +315,28 @@ h3 {
   font-size: 13px;
 }
 
-.subtitle-refresh {
-  display: inline-flex;
+.subtitle-status {
+  display: inline-grid;
+  grid-template-columns: 14px minmax(0, 1fr);
   align-items: center;
   gap: 6px;
+  max-width: 100%;
+}
+
+.subtitle-status .ui-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+}
+
+.subtitle-status-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .subtitle-refresh .ui-icon {
-  width: 14px;
-  height: 14px;
   color: var(--accent);
   animation: poll-refresh-hourglass 1s infinite;
 }
@@ -1155,7 +1177,9 @@ button.restart-server-button {
 .message {
   display: grid;
   gap: 5px;
+  min-width: 0;
   width: calc(100% - 28px);
+  max-width: 100%;
   margin-right: 28px;
   padding: 10px 12px;
 }
@@ -1265,8 +1289,56 @@ button.restart-server-button {
 }
 
 .message-content {
+  min-width: 0;
+  max-width: 100%;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+}
+
+.message-content.markdown-message-content {
+  text-align: left;
+  white-space: normal;
+}
+
+.message-markdown-viewer {
+  min-width: 0;
+  max-width: 100%;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.message-markdown-viewer h1,
+.message-markdown-viewer h2 {
+  margin: 0 0 9px;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.message-markdown-viewer h3,
+.message-markdown-viewer h4,
+.message-markdown-viewer h5,
+.message-markdown-viewer h6 {
+  margin: 14px 0 7px;
+  font-size: 14px;
+}
+
+.message-markdown-viewer p,
+.message-markdown-viewer ul,
+.message-markdown-viewer ol,
+.message-markdown-viewer blockquote,
+.message-markdown-viewer pre,
+.message-markdown-viewer table,
+.message-markdown-viewer hr {
+  margin-bottom: 10px;
+}
+
+.message-markdown-fallback,
+.summary-markdown-fallback {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  color: var(--text);
+  font: inherit;
 }
 
 .parsed-json-message {
@@ -1725,6 +1797,7 @@ button.restart-server-button {
   font-size: 14px;
   line-height: 1.65;
   overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .markdown-viewer > :first-child {
@@ -1808,15 +1881,19 @@ button.restart-server-button {
 }
 
 .markdown-viewer code {
+  max-width: 100%;
   border-radius: 4px;
   background: color-mix(in srgb, var(--panel-soft) 72%, var(--bg));
   padding: 2px 5px;
   color: var(--yellow);
   font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   font-size: 0.92em;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .markdown-viewer pre {
+  min-width: 0;
   max-width: 100%;
   overflow-x: auto;
   border: 1px solid color-mix(in srgb, var(--border) 78%, var(--panel-soft));
@@ -1829,15 +1906,19 @@ button.restart-server-button {
 }
 
 .markdown-viewer pre code {
+  max-width: none;
   border-radius: 0;
   background: transparent;
   padding: 0;
   color: inherit;
   font-size: inherit;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 .markdown-viewer table {
   display: block;
+  min-width: 0;
   width: 100%;
   max-width: 100%;
   overflow-x: auto;
@@ -1984,13 +2065,42 @@ button.restart-server-button {
   background: var(--panel-soft);
 }
 
-.agent-summary-panel p {
+.agent-summary-panel > p,
+.agent-summary-panel .summary-markdown-fallback {
   margin: 0;
   overflow-wrap: anywhere;
   color: var(--text);
   font-size: 13px;
   line-height: 1.4;
   white-space: pre-wrap;
+}
+
+.summary-markdown-viewer {
+  min-width: 0;
+  max-width: 100%;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.summary-markdown-viewer h1,
+.summary-markdown-viewer h2,
+.summary-markdown-viewer h3,
+.summary-markdown-viewer h4,
+.summary-markdown-viewer h5,
+.summary-markdown-viewer h6 {
+  margin: 0 0 7px;
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.summary-markdown-viewer p,
+.summary-markdown-viewer ul,
+.summary-markdown-viewer ol,
+.summary-markdown-viewer blockquote,
+.summary-markdown-viewer pre,
+.summary-markdown-viewer table,
+.summary-markdown-viewer hr {
+  margin-bottom: 8px;
 }
 
 .go-recent-fab {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -17,7 +17,6 @@
   --accent-contrast: #282a36;
   --shadow: 0 14px 32px rgba(0, 0, 0, 0.32);
   --safe-area-top: env(safe-area-inset-top, 0px);
-  --safe-area-left: env(safe-area-inset-left, 0px);
   --ipad-header-control-space: 0px;
 }
 
@@ -159,7 +158,7 @@ h3 {
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
-  padding: 10px 12px 10px calc(12px + var(--safe-area-left) + var(--ipad-header-control-space));
+  padding: 10px 12px 10px calc(12px + var(--ipad-header-control-space));
 }
 
 .header-row > #back-button {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -24,6 +24,12 @@ html.ipad-standalone {
   --ipad-header-control-space: 72px;
 }
 
+@media (min-width: 820px) {
+  html.ipad-standalone {
+    --ipad-header-control-space: max(0px, calc(482px - 50vw));
+  }
+}
+
 * {
   box-sizing: border-box;
 }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1,4 +1,4 @@
-const TOP_TABS = ["now", "agents", "search", "projects", "setup"];
+const TOP_TABS = ["now", "agents", "settings"];
 const PROJECT_ACTIONS = ["deploy", "maintenance", "live"];
 const BUILTIN_AGENT_HARNESSES = ["codex", "claude"];
 const DEFAULT_REFRESH_INTERVALS = {
@@ -300,10 +300,10 @@ const state = {
   skills: {},
   preflights: {},
   filters: {
-    search: "",
     agents: "",
-    projects: "",
   },
+  bulkArchiveMode: false,
+  bulkArchiveSelection: new Set(),
   failureCount: 0,
   timer: null,
   lastUpdatedAt: null,
@@ -448,7 +448,9 @@ function parseRoute() {
     return { type: "guard", key: parts[1], action: parts[3] };
   }
   if (parts[0] === "project" && parts[1]) return { type: "project", key: parts[1] };
-  if (parts[0] === "setup" && parts[1] === "hidden") return { type: "hiddenSettings" };
+  if ((parts[0] === "settings" || parts[0] === "setup") && parts[1] === "hidden") return { type: "hiddenSettings" };
+  if (parts[0] === "setup") return { type: "tab", tab: "settings" };
+  if (parts[0] === "search" || parts[0] === "projects") return { type: "tab", tab: "agents" };
   if (TOP_TABS.includes(parts[0])) return { type: "tab", tab: parts[0] };
   return { type: "tab", tab: "now" };
 }
@@ -473,7 +475,7 @@ function routeHash(route) {
   if (route.type === "guard") {
     return `#project/${encodeURIComponent(route.key)}/action/${encodeURIComponent(route.action)}`;
   }
-  if (route.type === "hiddenSettings") return "#setup/hidden";
+  if (route.type === "hiddenSettings") return "#settings/hidden";
   return `#${route.tab}`;
 }
 
@@ -507,10 +509,10 @@ function scrollPageToTop() {
 
 function currentTopTab(route) {
   if (route.type === "tab") return route.tab;
-  if (route.type === "project" || route.type === "guard") return "projects";
-  if (route.type === "agentForm") return route.mode === "create" ? "projects" : "agents";
+  if (route.type === "project" || route.type === "guard") return "agents";
+  if (route.type === "agentForm") return "agents";
   if (route.type === "agent" || route.type === "agentAttachment" || route.type === "agentArchive" || route.type === "attachment") return "agents";
-  if (route.type === "hiddenSettings") return "setup";
+  if (route.type === "hiddenSettings") return "settings";
   return "now";
 }
 
@@ -564,6 +566,7 @@ async function refresh(options = {}) {
       state.openSummaryAfterAutoScroll = true;
     }
     state.agents = nextAgents;
+    syncBulkArchiveSelection();
     state.projects = projectsData.projects || [];
     state.setup = setupData.setup || null;
     state.schedules = schedulesData.schedules || [];
@@ -790,13 +793,7 @@ function render() {
   } else if (route.tab === "agents") {
     state.openSummaryAfterAutoScroll = false;
     renderAgents();
-  } else if (route.tab === "search") {
-    state.openSummaryAfterAutoScroll = false;
-    renderSearch();
-  } else if (route.tab === "projects") {
-    state.openSummaryAfterAutoScroll = false;
-    renderProjects();
-  } else if (route.tab === "setup") {
+  } else if (route.tab === "settings") {
     state.openSummaryAfterAutoScroll = false;
     renderSetup();
   } else {
@@ -835,7 +832,7 @@ function routeStateKey(route) {
   if (route.type === "agentArchive") return `agent-archive:${route.key}`;
   if (route.type === "project") return `project:${route.key}`;
   if (route.type === "guard") return `guard:${route.key}:${route.action}`;
-  if (route.type === "hiddenSettings") return "setup:hidden";
+  if (route.type === "hiddenSettings") return "settings:hidden";
   return `tab:${route.tab}`;
 }
 
@@ -1314,60 +1311,46 @@ function renderScheduleDaemonActions(daemon, schedules) {
 }
 
 function renderAgents() {
-  const query = state.filters.agents.toLowerCase();
-  const filtered = state.agents.filter((agent) => agentMatches(agent, query));
-  const groups = sortedAgentGroups(filtered);
+  const query = state.filters.agents.trim().toLowerCase();
+  const groups = agentProjectGroups(query);
   const unread = state.agents.filter((agent) => agent.unread).length;
-  setHeader("Agents", `${state.agents.length} managed / ${unread} unread`, "A");
+  setHeader("Agents", `${state.agents.length} managed / ${state.projects.length} projects / ${unread} unread`, "A");
 
   replaceView(`
     <div class="top-actions">
       <label class="search-box" for="agent-filter">
         <span class="nav-mark" aria-hidden="true">${iconSvg("search")}</span>
-        <input id="agent-filter" type="search" value="${escapeAttr(state.filters.agents)}" placeholder="Filter agents" aria-label="Filter agents" data-filter="agents">
+        <input id="agent-filter" type="search" value="${escapeAttr(state.filters.agents)}" placeholder="Filter agents and projects" aria-label="Filter agents and projects" data-filter="agents">
       </label>
-      <button type="button" data-open-tab="projects" aria-label="Choose a project to create an agent">Projects</button>
+      <button class="inline-icon-button" type="button" data-toggle-bulk-archive ${state.agents.length ? "" : "disabled"}>${iconSvg(state.bulkArchiveMode ? "x" : "archive")}<span>${state.bulkArchiveMode ? "Cancel" : "Select"}</span></button>
     </div>
-    ${filtered.length ? groups.map((group) => renderAgentGroup(group.projectKey, group.agents)).join("") : emptyState("No agents", "Open a project detail to add the first managed agent.")}
+    ${renderBulkArchiveBar()}
+    ${groups.length ? groups.map((group) => renderAgentGroup(group.projectKey, group.agents)).join("") : renderAgentsEmpty(query)}
   `);
+  focusFilterInput("agents", "agent-filter");
 }
 
-function renderSearch() {
-  const query = state.filters.search.trim().toLowerCase();
-  const results = searchResults(query);
-  setHeader("Search HQ", query ? `${results.length} results` : "Unread agents first", "search");
+function renderBulkArchiveBar() {
+  if (!state.bulkArchiveMode) return "";
 
-  replaceView(`
-    <label class="search-box" for="search-input">
-      <span class="nav-mark" aria-hidden="true">${iconSvg("search")}</span>
-      <input id="search-input" type="search" value="${escapeAttr(state.filters.search)}" placeholder="Search agents and projects" aria-label="Search agents and projects" data-filter="search">
-    </label>
-    <div class="section-label"><strong>${query ? "Results" : "Suggested"}</strong><span>${query ? "direct navigation" : "unread first"}</span></div>
-    <div class="result-list">
-      ${results.length ? results.map(renderSearchResult).join("") : emptyRow("No matches", "Try an agent name, project key, status, branch, or summary.")}
-    </div>
-  `);
-  focusSearchInput();
+  const selected = selectedBulkArchiveKeys();
+  return `
+    <section class="bulk-action-bar" aria-label="Bulk archive">
+      <div>
+        <strong>${selected.length} selected</strong>
+        <span>${archiveableAgents().length} archiveable agents</span>
+      </div>
+      <div class="button-row">
+        <button type="button" data-clear-bulk-archive ${selected.length ? "" : "disabled"}>Clear</button>
+        <button class="danger inline-icon-button" type="button" data-run-bulk-archive ${selected.length ? "" : "disabled"}>${iconSvg("archive")}<span>Archive selected</span></button>
+      </div>
+    </section>
+  `;
 }
 
-function renderProjects() {
-  const query = state.filters.projects.toLowerCase();
-  const filtered = sortedProjects(state.projects).filter((project) => projectMatches(project, query));
-  const maintenanceCount = state.projects.filter((project) => project.maintenance).length;
-  setHeader("Projects", `${state.projects.length} active / ${maintenanceCount} maintenance`, "folders");
-
-  replaceView(`
-    <label class="search-box" for="project-filter">
-      <span class="nav-mark" aria-hidden="true">${iconSvg("search")}</span>
-      <input id="project-filter" type="search" value="${escapeAttr(state.filters.projects)}" placeholder="Search projects" aria-label="Search projects" data-filter="projects">
-    </label>
-    ${filtered.length ? `<div class="list">${filtered.map(renderProjectRow).join("")}</div>` : emptyState("No projects configured", "Project setup still happens in the TUI because it needs local filesystem access.")}
-  `);
-  focusFilterInput("projects", "project-filter");
-}
-
-function focusSearchInput() {
-  focusFilterInput("search", "search-input");
+function renderAgentsEmpty(query) {
+  if (query) return emptyState("No matches", "Try an agent name, project name, status, branch, or summary.");
+  return emptyState("No projects configured", "Project setup still happens in the TUI because it needs local filesystem access.");
 }
 
 function focusFilterInput(tab, inputId) {
@@ -1387,9 +1370,9 @@ function focusFilterInput(tab, inputId) {
 
 function renderSetup() {
   const setup = state.setup;
-  setHeader("Setup", connectionText(), "S");
+  setHeader("Settings", connectionText(), "S");
   if (!setup) {
-    replaceView(emptyState("Setup unavailable", "Refresh to load Remote UI readiness."));
+    replaceView(emptyState("Settings unavailable", "Refresh to load Remote UI readiness."));
     return;
   }
 
@@ -2096,7 +2079,7 @@ function renderProject(key) {
     }
 
     setHeader("Project not found", "It may have been removed from config.", "folder");
-    replaceView(emptyState("Project not found", "Return to the Projects tab and choose an active project."));
+    replaceView(emptyState("Project not found", "Return to the Agents tab and choose an active project."));
     return;
   }
 
@@ -2170,7 +2153,7 @@ function renderGuardedAction(projectKey, action) {
   }
 
   if (!project) {
-    replaceView(emptyState("Project not found", "Return to the Projects tab and choose an active project."));
+    replaceView(emptyState("Project not found", "Return to the Agents tab and choose an active project."));
     return;
   }
 
@@ -2260,19 +2243,26 @@ function renderAgentSection(title, subtitle, agents, emptyText) {
 function renderAgentGroup(projectKey, agents) {
   const project = findProject(projectKey);
   const projectName = project?.name || projectKey;
-  const projectHref = routeHash({ type: "project", key: projectKey });
+  const projectMeta = project ? `${agents.length} agents / ${project.health_status || project.status || "configured"}` : `${agents.length} agents`;
   return `
     <section class="agent-group">
       <div class="group-title">
         <div class="agent-group-project">
-          <a href="${escapeAttr(projectHref)}" data-open-project="${escapeAttr(projectKey)}">${escapeHtml(projectName)}</a>
-          <span>${agents.length} agents</span>
+          ${renderAgentGroupProjectTitle(projectKey, projectName, !!project)}
+          <span>${escapeHtml(projectMeta)}</span>
         </div>
-        <button class="inline-icon-button agent-group-create" type="button" data-create-agent="${escapeAttr(projectKey)}" aria-label="Create agent for ${escapeAttr(projectName)}">${iconSvg("plus")}<span>Agent</span></button>
+        ${project ? `<button class="inline-icon-button agent-group-create" type="button" data-create-agent="${escapeAttr(projectKey)}" aria-label="Create agent for ${escapeAttr(projectName)}">${iconSvg("plus")}<span>Agent</span></button>` : ""}
       </div>
-      ${agents.map(renderAgentRow).join("")}
+      ${agents.length ? agents.map(renderAgentRow).join("") : renderProjectAgentEmpty()}
     </section>
   `;
+}
+
+function renderAgentGroupProjectTitle(projectKey, projectName, linked) {
+  if (!linked) return `<strong>${escapeHtml(projectName)}</strong>`;
+
+  const projectHref = routeHash({ type: "project", key: projectKey });
+  return `<a href="${escapeAttr(projectHref)}" data-open-project="${escapeAttr(projectKey)}">${escapeHtml(projectName)}</a>`;
 }
 
 function renderAgentCard(agent) {
@@ -2290,6 +2280,8 @@ function renderAgentCard(agent) {
 }
 
 function renderAgentRow(agent) {
+  if (state.bulkArchiveMode) return renderSelectableAgentRow(agent);
+
   return `
     <button class="agent-row" type="button" data-open-agent="${escapeAttr(agent.key)}">
       <span class="status-mark ${statusClass(agent)}" aria-hidden="true">${iconSvg("robot")}</span>
@@ -2302,44 +2294,18 @@ function renderAgentRow(agent) {
   `;
 }
 
-function renderProjectRow(project) {
+function renderSelectableAgentRow(agent) {
+  const selected = state.bulkArchiveSelection.has(agent.key);
+  const disabled = !agentArchiveable(agent);
   return `
-    <button class="project-row" type="button" data-open-project="${escapeAttr(project.key)}">
-      <span class="status-mark ${projectStatusClass(project)}" aria-hidden="true">${iconSvg("folder")}</span>
+    <label class="agent-row selectable-agent-row ${selected ? "selected" : ""} ${disabled ? "disabled" : ""}">
+      <input class="agent-select-box" type="checkbox" data-select-agent="${escapeAttr(agent.key)}" ${selected ? "checked" : ""} ${disabled ? "disabled" : ""}>
       <div class="row-title">
-        <strong>${escapeHtml(project.name || project.key)}</strong>
-        <span>${escapeHtml(`${project.status || "configured"} / ${latencyText(project)} / ${project.group || "ungrouped"}`)}</span>
+        <strong>${escapeHtml(agent.name || agent.key)}</strong>
+        <span>${agentListSubtextHtml(agent)}</span>
       </div>
-      <span class="pill ${projectStatusClass(project)}">${escapeHtml(project.maintenance ? "Maintenance" : project.health_status || "Open")}</span>
-    </button>
-  `;
-}
-
-function renderSearchResult(result) {
-  if (result.type === "agent") {
-    const agent = result.item;
-    return `
-      <button class="result-row" type="button" data-open-agent="${escapeAttr(agent.key)}">
-        <span class="type-mark ${statusClass(agent)}" aria-hidden="true">${iconSvg("robot")}</span>
-        <div class="row-title">
-          <strong>${escapeHtml(agent.name || agent.key)}</strong>
-          <span>${agentSearchSubtextHtml(agent)}</span>
-        </div>
-        ${agent.unread ? `<span class="pill need">Unread</span>` : `<span class="pill ${statusClass(agent)}">Agent</span>`}
-      </button>
-    `;
-  }
-
-  const project = result.item;
-  return `
-    <button class="result-row" type="button" data-open-project="${escapeAttr(project.key)}">
-      <span class="type-mark ${projectStatusClass(project)}" aria-hidden="true">${iconSvg("folder")}</span>
-      <div class="row-title">
-        <strong>${escapeHtml(project.name || project.key)}</strong>
-        <span>${escapeHtml(projectSearchSubtext(project))}</span>
-      </div>
-      <span class="pill ${projectStatusClass(project)}">Project</span>
-    </button>
+      <span class="pill ${disabled ? "detail" : statusClass(agent)}">${escapeHtml(disabled ? "Running" : (agent.last_result || "archiveable"))}</span>
+    </label>
   `;
 }
 
@@ -3105,20 +3071,6 @@ function kv(label, value) {
   return `<div class="kv"><span>${escapeHtml(label)}</span><strong class="wrap-anywhere">${escapeHtml(display)}</strong></div>`;
 }
 
-function searchResults(query) {
-  const agentResults = state.agents
-    .filter((agent) => !query || agentMatches(agent, query))
-    .map((agent) => ({ type: "agent", item: agent }));
-  const projectResults = state.projects
-    .filter((project) => !query || projectMatches(project, query))
-    .map((project) => ({ type: "project", item: project }));
-
-  if (query) return [...agentResults, ...projectResults].slice(0, 40);
-
-  return [...agentResults.sort((a, b) => agentPriority(b.item) - agentPriority(a.item)), ...projectResults]
-    .slice(0, 40);
-}
-
 function unreadAgents() {
   return state.agents
     .filter((agent) => agent.unread)
@@ -3139,19 +3091,30 @@ function agentActivityTimestamp(agent) {
   return Date.parse(agent.updated_at || agent.finished_at || agent.started_at || agent.created_at || "") || 0;
 }
 
-function sortedProjects(projects) {
-  return [...projects].sort(compareProjectsByName);
+function agentProjectGroups(query) {
+  const agentsByProject = groupBy(state.agents, (agent) => agent.project_key || "unassigned");
+  const projectKeys = new Set([
+    ...state.projects.map((project) => project.key),
+    ...Object.keys(agentsByProject),
+  ]);
+
+  return [...projectKeys]
+    .sort(compareAgentProjectKeys)
+    .map((projectKey) => agentProjectGroup(projectKey, agentsByProject[projectKey] || [], query))
+    .filter(Boolean);
 }
 
-function sortedAgentGroups(agents) {
-  const groups = groupBy(agents, (agent) => agent.project_key || "unassigned");
+function agentProjectGroup(projectKey, agents, query) {
+  const project = findProject(projectKey);
+  const projectMatch = project ? projectMatches(project, query) : String(projectKey || "").toLowerCase().includes(query);
+  const filteredAgents = agents
+    .filter((agent) => !query || projectMatch || agentMatches(agent, query))
+    .sort(compareAgentsByName);
 
-  return Object.keys(groups)
-    .sort(compareAgentProjectKeys)
-    .map((projectKey) => ({
-      projectKey,
-      agents: [...groups[projectKey]].sort(compareAgentsByName),
-    }));
+  if (query && !projectMatch && filteredAgents.length === 0) return null;
+  if (!query && !project && filteredAgents.length === 0) return null;
+
+  return { projectKey, agents: filteredAgents };
 }
 
 function agentsForProject(projectKey) {
@@ -3160,13 +3123,25 @@ function agentsForProject(projectKey) {
     .sort(compareAgentsByName);
 }
 
-function compareProjectsByName(a, b) {
-  const name = String(a.name || a.key || "");
-  const otherName = String(b.name || b.key || "");
-  const byName = compareDisplayText(name, otherName);
-  if (byName !== 0) return byName;
+function agentArchiveable(agent) {
+  return !!agent && !agent.running && agent.status !== "running";
+}
 
-  return compareDisplayText(a.key, b.key);
+function archiveableAgents() {
+  return state.agents.filter(agentArchiveable);
+}
+
+function selectedBulkArchiveKeys() {
+  syncBulkArchiveSelection();
+  return [...state.bulkArchiveSelection];
+}
+
+function syncBulkArchiveSelection() {
+  const activeKeys = new Set(state.agents.map((agent) => agent.key));
+  state.bulkArchiveSelection.forEach((key) => {
+    const agent = state.agents.find((item) => item.key === key);
+    if (!activeKeys.has(key) || !agentArchiveable(agent)) state.bulkArchiveSelection.delete(key);
+  });
 }
 
 function compareAgentProjectKeys(a, b) {
@@ -4015,21 +3990,6 @@ function agentListSubtextHtml(agent) {
   return [relativeTimeHtml(agentUpdatedAt(agent)), escapeHtml(agentMeta(agent))].filter(Boolean).join(" / ");
 }
 
-function agentSearchSubtextHtml(agent) {
-  return [
-    relativeTimeHtml(agentUpdatedAt(agent)),
-    escapeHtml(agentMeta(agent)),
-    escapeHtml(statusLabel(agent)),
-  ].filter(Boolean).join(" / ");
-}
-
-function projectSearchSubtext(project) {
-  return [
-    project.status || "configured",
-    project.branch || project.group || "ungrouped",
-  ].filter(Boolean).join(" / ");
-}
-
 function actionText(actionState) {
   if (!actionState) return "No active or recent action";
   return [actionState.label, actionState.status, timeShort(actionState.started_at)].filter(Boolean).join(" / ");
@@ -4328,8 +4288,8 @@ els.back.addEventListener("click", () => {
   else if (route.type === "agentForm" && route.mode === "clone") navigate({ type: "agentArchive", key: route.key });
   else if (route.type === "agentForm" && route.mode === "create") navigate({ type: "project", key: route.projectKey });
   else if (route.type === "agentArchive") navigate({ type: "agent", key: route.key });
-  else if (route.type === "project" || route.type === "guard") navigate({ type: "tab", tab: "projects" });
-  else if (route.type === "hiddenSettings") navigate({ type: "tab", tab: "setup" });
+  else if (route.type === "project" || route.type === "guard") navigate({ type: "tab", tab: "agents" });
+  else if (route.type === "hiddenSettings") navigate({ type: "tab", tab: "settings" });
   else navigate({ type: "tab", tab: "now" });
 });
 
@@ -4410,6 +4370,22 @@ els.view.addEventListener("click", (event) => {
   if (firstWaiting) {
     const agent = state.agents.find((item) => item.awaiting_input);
     if (agent) navigate({ type: "agent", key: agent.key });
+    return;
+  }
+
+  if (event.target.closest("[data-toggle-bulk-archive]")) {
+    toggleBulkArchiveMode();
+    return;
+  }
+
+  if (event.target.closest("[data-clear-bulk-archive]")) {
+    state.bulkArchiveSelection.clear();
+    render();
+    return;
+  }
+
+  if (event.target.closest("[data-run-bulk-archive]")) {
+    archiveSelectedAgents();
     return;
   }
 
@@ -4616,8 +4592,10 @@ els.view.addEventListener("keydown", (event) => {
   if (event.target?.id === "agent-filter") {
     event.preventDefault();
     const query = state.filters.agents.toLowerCase();
-    const first = state.agents.find((agent) => agentMatches(agent, query));
-    if (first) navigate({ type: "agent", key: first.key });
+    const firstGroup = agentProjectGroups(query)[0];
+    const firstAgent = firstGroup?.agents[0];
+    if (firstAgent) navigate({ type: "agent", key: firstAgent.key });
+    else if (firstGroup?.projectKey && findProject(firstGroup.projectKey)) navigate({ type: "project", key: firstGroup.projectKey });
   }
 });
 
@@ -4659,6 +4637,15 @@ els.view.addEventListener("focusout", (event) => {
 els.view.addEventListener("change", (event) => {
   if (event.target.closest("#inquiry-form")) {
     syncViewControls();
+  }
+
+  const agentSelection = event.target.closest("[data-select-agent]");
+  if (agentSelection) {
+    const key = agentSelection.dataset.selectAgent;
+    if (agentSelection.checked) state.bulkArchiveSelection.add(key);
+    else state.bulkArchiveSelection.delete(key);
+    render();
+    return;
   }
 
   const attachmentInput = event.target.closest("[data-prompt-attachment-input]");
@@ -4766,6 +4753,33 @@ function runAgentAction(agentAction) {
       removeAgent(key);
       navigate({ type: "tab", tab: "agents" });
     }
+  });
+}
+
+function toggleBulkArchiveMode() {
+  state.bulkArchiveMode = !state.bulkArchiveMode;
+  if (!state.bulkArchiveMode) state.bulkArchiveSelection.clear();
+  render();
+}
+
+function archiveSelectedAgents() {
+  const keys = selectedBulkArchiveKeys();
+  if (keys.length === 0) return;
+
+  const noun = keys.length === 1 ? "agent" : "agents";
+  if (!window.confirm(`Archive ${keys.length} selected ${noun}? Running agents are not included.`)) return;
+
+  mutate(async () => {
+    const result = await apiPost("/agents/archive", { keys });
+    const archivedKeys = (result.archived || []).map((item) => item.agent_key).filter(Boolean);
+    archivedKeys.forEach(removeAgent);
+    state.bulkArchiveSelection.clear();
+    state.bulkArchiveMode = false;
+
+    const skipped = result.skipped?.length || 0;
+    const failed = result.failed?.length || 0;
+    const detail = [skipped ? `${skipped} skipped` : null, failed ? `${failed} failed` : null].filter(Boolean).join(" / ");
+    setConnection(detail ? `Archived ${archivedKeys.length} / ${detail}` : `Archived ${archivedKeys.length} ${noun}`);
   });
 }
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -309,6 +309,7 @@ const state = {
   lastUpdatedAt: null,
   connection: "Connecting",
   headerSubtitle: "Connecting",
+  headerSubtitleIcon: "folder",
   refreshing: false,
   loadingConversation: false,
   lastScrollY: 0,
@@ -344,6 +345,16 @@ const els = {
   view: document.getElementById("view"),
   nav: document.getElementById("bottom-nav"),
 };
+
+syncPlatformClasses();
+
+function syncPlatformClasses() {
+  const standalone = window.navigator.standalone === true ||
+    window.matchMedia?.("(display-mode: standalone)")?.matches;
+  const platform = window.navigator.platform || "";
+  const iPadLike = platform === "iPad" || (platform === "MacIntel" && window.navigator.maxTouchPoints > 1);
+  document.documentElement.classList.toggle("ipad-standalone", Boolean(standalone && iPadLike));
+}
 
 function token() {
   return localStorage.getItem("hq.remote.token") || "";
@@ -1084,7 +1095,7 @@ function markdownHeadingSlug(text) {
 
 function handleMarkdownAnchorClick(anchor, event) {
   const route = parseRoute();
-  if (route.type !== "attachment" && route.type !== "agentAttachment") return false;
+  if (!["agent", "agentAttachment", "attachment"].includes(route.type)) return false;
 
   const href = String(anchor.getAttribute("href") || "");
   if (!href.startsWith("#") || href === "#") return false;
@@ -1621,12 +1632,20 @@ function renderAgent(key, options = {}) {
     ${attachmentId ? renderAgentAttachmentView(agent, attachmentId) : renderAgentConversationView(agent, blocks)}
     <section class="agent-dock" data-agent-dock>
       <section class="agent-summary-panel" data-agent-summary data-preserve-open data-preserve-scroll data-state-key="agent-summary" aria-label="Summary">
-        <p>${escapeHtml(agentSummaryText(agent))}</p>
+        ${renderAgentSummaryContent(agent)}
       </section>
       ${agent.latest_inquiry ? renderInquiryForm(agent, { attachmentMode: Boolean(attachmentId) }) : renderAgentComposer(agent, skills, { attachmentMode: Boolean(attachmentId) })}
     </section>
   `);
   if (!attachmentId) scheduleAgentReading(agent);
+}
+
+function renderAgentSummaryContent(agent) {
+  return renderMarkdown(agentSummaryText(agent), {
+    viewerClassName: "markdown-viewer summary-markdown-viewer",
+    fallbackClassName: "summary-markdown-fallback",
+    emptyText: "No run summary yet.",
+  });
 }
 
 function renderAgentConversationView(agent, blocks) {
@@ -2412,10 +2431,27 @@ function inquiryResponseBlock(block) {
 
 function renderMessageContent(block) {
   const content = String(block.content || "");
+  if (markdownMessageBlock(block)) {
+    return `
+      <div class="message-content markdown-message-content">
+        ${renderMarkdown(content, {
+          viewerClassName: "markdown-viewer message-markdown-viewer",
+          fallbackClassName: "message-markdown-fallback",
+          emptyText: "",
+        })}
+      </div>
+    `;
+  }
+
   const formatted = block.role === "user" ? formatJsonObjectMessage(content) : "";
   if (formatted) return `<div class="message-content parsed-json-message">${formatted}</div>`;
 
   return `<div class="message-content">${escapeHtml(content)}</div>`;
+}
+
+function markdownMessageBlock(block) {
+  if (block?.kind === "run_summary") return true;
+  return block?.kind === "message" && block.role === "assistant";
 }
 
 function formatJsonObjectMessage(content) {
@@ -2954,12 +2990,12 @@ function openAttachmentLinkOnce(id, href) {
   window.setTimeout(() => window.open(href, "_blank", "noopener"), 0);
 }
 
-function renderMarkdown(text) {
+function renderMarkdown(text, options = {}) {
   const source = String(text || "");
-  if (markdownParserReady()) return renderParsedMarkdown(source);
+  if (markdownParserReady()) return renderParsedMarkdown(source, options);
 
   ensureMarkdownParserLoaded();
-  return renderPlainTextMarkdown(source);
+  return renderPlainTextMarkdown(source, options);
 }
 
 function markdownParserReady() {
@@ -2976,7 +3012,7 @@ function ensureMarkdownParserLoaded() {
     loadExternalScript(MARKDOWN_SCRIPT_URLS.marked),
   ]).then(() => {
     if (!markdownParserReady()) throw new Error("Markdown parser globals unavailable");
-    renderMarkdownAttachmentRoute();
+    renderMarkdownRoute();
     return true;
   }).catch((error) => {
     markdownParser.failed = true;
@@ -3012,8 +3048,14 @@ function loadExternalScript(src) {
   });
 }
 
-function renderMarkdownAttachmentRoute() {
+function renderMarkdownRoute() {
   const route = parseRoute();
+  if (route.type === "agent" || route.type === "agentAttachment") {
+    state.renderedViewHtml = "";
+    render();
+    return;
+  }
+
   if (route.type !== "attachment" && route.type !== "agentAttachment") return;
 
   const attachmentId = route.type === "agentAttachment" ? route.attachmentId : route.id;
@@ -3026,18 +3068,24 @@ function renderMarkdownAttachmentRoute() {
   render();
 }
 
-function renderParsedMarkdown(text) {
+function renderParsedMarkdown(text, options = {}) {
   const unsafe = window.marked.parse(text, { gfm: true });
   const safe = window.DOMPurify.sanitize(unsafe, {
     USE_PROFILES: { html: true },
     FORBID_TAGS: ["embed", "iframe", "img", "object", "script", "style"],
     FORBID_ATTR: ["style", "srcset"],
   });
-  return `<div class="markdown-viewer">${safe}</div>`;
+  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${safe}</div>`;
 }
 
-function renderPlainTextMarkdown(text) {
-  return `<pre class="attachment-text-viewer">${escapeHtml(text || "No content")}</pre>`;
+function renderPlainTextMarkdown(text, options = {}) {
+  const className = String(options.fallbackClassName || "attachment-text-viewer").trim() || "attachment-text-viewer";
+  const emptyText = Object.prototype.hasOwnProperty.call(options, "emptyText") ? options.emptyText : "No content";
+  return `<pre class="${escapeAttr(className)}">${escapeHtml(text || emptyText)}</pre>`;
+}
+
+function markdownViewerClassName(options = {}) {
+  return String(options.viewerClassName || "markdown-viewer").trim() || "markdown-viewer";
 }
 
 function messageIcon(block) {
@@ -3205,11 +3253,16 @@ function projectMatches(project, query) {
   ].some((value) => String(value || "").toLowerCase().includes(query));
 }
 
-function setHeader(title, subtitle) {
+function setHeader(title, subtitle, subtitleIcon = "folder") {
   els.title.textContent = title;
+  setHeaderSubtitleIcon(subtitleIcon);
   setHeaderSubtitle(subtitle);
   syncUnreadAlert();
   syncDetailHeaderLayout();
+}
+
+function setHeaderSubtitleIcon(icon) {
+  state.headerSubtitleIcon = headerSubtitleIconName(icon);
 }
 
 function setHeaderSubtitle(text) {
@@ -3219,12 +3272,19 @@ function setHeaderSubtitle(text) {
 
 function renderHeaderSubtitle() {
   const value = state.headerSubtitle;
-  if (state.refreshing) {
-    els.subtitle.innerHTML = `<span class="subtitle-refresh">${iconSvg("hourglass")}<span>${escapeHtml(value)}</span></span>`;
-    return;
-  }
+  const icon = state.refreshing ? iconSvg("hourglass") : iconSvg(state.headerSubtitleIcon);
+  const className = state.refreshing ? "subtitle-status subtitle-refresh" : "subtitle-status";
+  els.subtitle.innerHTML = `<span class="${className}"><span class="subtitle-icon" aria-hidden="true">${icon}</span><span class="subtitle-status-text">${escapeHtml(value)}</span></span>`;
+}
 
-  els.subtitle.textContent = value;
+function headerSubtitleIconName(icon) {
+  const requested = String(icon || "").trim();
+  const aliases = {
+    A: "folder",
+    HQ: "activity",
+  };
+  const name = aliases[requested] || requested || "folder";
+  return ICONS[name] ? name : "folder";
 }
 
 function syncUnreadAlert() {

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" data-asset-version="<%= HQ::RemoteUI.asset_version %>">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#282a36">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -94,32 +94,14 @@
           </span>
           <span>Agents</span>
         </button>
-        <button type="button" data-tab="search">
-          <span class="nav-mark" aria-hidden="true">
-            <svg class="ui-icon" viewBox="0 0 24 24">
-              <circle cx="11" cy="11" r="8"></circle>
-              <path d="m21 21-4.3-4.3"></path>
-            </svg>
-          </span>
-          <span>Search</span>
-        </button>
-        <button type="button" data-tab="projects">
-          <span class="nav-mark" aria-hidden="true">
-            <svg class="ui-icon" viewBox="0 0 24 24">
-              <path d="M20 17a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3.9a2 2 0 0 1-1.69-.9l-.81-1.2A2 2 0 0 0 11.93 4H8a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2Z"></path>
-              <path d="M2 8v11a2 2 0 0 0 2 2h14"></path>
-            </svg>
-          </span>
-          <span>Projects</span>
-        </button>
-        <button type="button" data-tab="setup">
+        <button type="button" data-tab="settings">
           <span class="nav-mark" aria-hidden="true">
             <svg class="ui-icon" viewBox="0 0 24 24">
               <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
               <circle cx="12" cy="12" r="3"></circle>
             </svg>
           </span>
-          <span>Setup</span>
+          <span>Settings</span>
         </button>
       </nav>
     </div>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1158,13 +1158,11 @@ module RemoteServerTest
     assert(css[:body].include?("color-scheme: dark"), "expected Remote UI CSS to use the Dracula dark scheme")
     assert(css[:body].include?("--safe-area-top: env(safe-area-inset-top, 0px);"),
            "expected Remote UI to reserve iOS top safe-area space")
-    assert(css[:body].include?("--safe-area-left: env(safe-area-inset-left, 0px);"),
-           "expected Remote UI to account for horizontal iOS safe-area space")
     assert(css[:body].include?("--ipad-header-control-space: 0px;"),
            "expected Remote UI to default iPad standalone control spacing off")
     assert(css[:body].include?("html.ipad-standalone"),
            "expected Remote UI to reserve space for iPad standalone window controls")
-    assert(css[:body].include?("padding: 10px 12px 10px calc(12px + var(--safe-area-left) + var(--ipad-header-control-space));"),
+    assert(css[:body].include?("padding: 10px 12px 10px calc(12px + var(--ipad-header-control-space));"),
            "expected header rows to keep content clear of iPad left-side controls")
     assert(css[:body].include?("top: var(--safe-area-top);"),
            "expected sticky and fixed headers to sit below iOS status controls")

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1162,7 +1162,7 @@ module RemoteServerTest
            "expected Remote UI to default iPad standalone control spacing off")
     assert(css[:body].include?("html.ipad-standalone"),
            "expected Remote UI to reserve space for iPad standalone window controls")
-    assert(css[:body].include?("--ipad-header-control-space: 36px;"),
+    assert(css[:body].include?("--ipad-header-control-space: 60px;"),
            "expected Remote UI to reserve compact iPad standalone window control spacing")
     assert(css[:body].include?("padding: 10px 12px 10px calc(12px + var(--ipad-header-control-space));"),
            "expected header rows to keep content clear of iPad left-side controls")

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1107,6 +1107,8 @@ module RemoteServerTest
     assert(legacy_response[:content_type].include?("text/html"), "expected /ui compatibility route to return HTML")
     assert(response[:body].include?('name="theme-color" content="#282a36"'),
            "expected root shell to expose a PWA theme color")
+    assert(response[:body].include?('content="width=device-width, initial-scale=1, viewport-fit=cover"'),
+           "expected root shell viewport to expose iOS safe-area insets")
     assert(response[:body].match?(%r{href="/manifest\.webmanifest\?v=[0-9a-f]{12}"}),
            "expected root shell to link a versioned web app manifest")
     assert(response[:body].match?(%r{href="/favicon\.png\?v=[0-9a-f]{12}"}),
@@ -1154,6 +1156,20 @@ module RemoteServerTest
       assert(css[:body].include?(color), "expected Remote UI CSS to include Dracula color #{color}")
     end
     assert(css[:body].include?("color-scheme: dark"), "expected Remote UI CSS to use the Dracula dark scheme")
+    assert(css[:body].include?("--safe-area-top: env(safe-area-inset-top, 0px);"),
+           "expected Remote UI to reserve iOS top safe-area space")
+    assert(css[:body].include?("--safe-area-left: env(safe-area-inset-left, 0px);"),
+           "expected Remote UI to account for horizontal iOS safe-area space")
+    assert(css[:body].include?("--ipad-header-control-space: 0px;"),
+           "expected Remote UI to default iPad standalone control spacing off")
+    assert(css[:body].include?("html.ipad-standalone"),
+           "expected Remote UI to reserve space for iPad standalone window controls")
+    assert(css[:body].include?("padding: 10px 12px 10px calc(12px + var(--safe-area-left) + var(--ipad-header-control-space));"),
+           "expected header rows to keep content clear of iPad left-side controls")
+    assert(css[:body].include?("top: var(--safe-area-top);"),
+           "expected sticky and fixed headers to sit below iOS status controls")
+    assert(css[:body].include?("padding-top: var(--safe-area-top);"),
+           "expected the app shell to start below the iOS safe area")
     assert(css[:body].include?(".agent-dock"), "expected Agent detail to have a bottom dock")
     assert(css[:body].include?("position: fixed"), "expected Agent detail dock to stay pinned to the viewport")
     assert(css[:body].include?(".agent-floating-actions"),
@@ -1203,6 +1219,10 @@ module RemoteServerTest
            "expected refresh indicators to use the hourglass animation")
     assert(css[:body].include?("transform: rotate(.5turn)"),
            "expected refresh hourglass animation to rotate by half a turn")
+    assert(css[:body].include?(".subtitle-status"),
+           "expected header subtitles to reserve a persistent icon slot")
+    assert(css[:body].include?("grid-template-columns: 14px minmax(0, 1fr)"),
+           "expected header subtitle text to keep its position during refresh")
     assert(css[:body].include?("margin-left: 28px"),
            "expected user chat messages to be offset from the left")
     assert(css[:body].include?("margin-right: 28px"),
@@ -1213,6 +1233,14 @@ module RemoteServerTest
            "expected user chat message content to have dedicated alignment")
     assert(css[:body].include?(".message.user .message-content {\n  text-align: left;"),
            "expected user chat message text to stay readable with left alignment")
+    assert(css[:body].include?(".message-content.markdown-message-content"),
+           "expected assistant and summary chat messages to render markdown with message-scoped layout")
+    assert(css[:body].include?(".message-content {\n  min-width: 0;"),
+           "expected chat message content to allow markdown blocks to shrink inside the viewport")
+    assert(css[:body].include?(".message-markdown-viewer"),
+           "expected assistant and summary chat markdown to have compact message styling")
+    assert(css[:body].include?(".summary-markdown-viewer"),
+           "expected Agent summary markdown to have compact dock styling")
     assert(css[:body].include?("font-weight: 700"),
            "expected chat labels to render bold")
     assert(css[:body].include?(".message-group"),
@@ -1248,6 +1276,8 @@ module RemoteServerTest
            "expected rendered markdown links to have readable underline spacing")
     assert(css[:body].include?("white-space: pre"),
            "expected rendered markdown code blocks to preserve whitespace")
+    assert(css[:body].include?("overflow-wrap: anywhere"),
+           "expected rendered markdown inline code to avoid horizontal page overflow")
     assert(css[:body].include?(".skill-flyout"), "expected skills to use a floating picker")
     assert(css[:body].include?("min-height: min(180px, 42dvh)"),
            "expected the skill picker to show multiple skills before scrolling")
@@ -1445,6 +1475,12 @@ module RemoteServerTest
     assert(js[:body].include?("function brandLogoHtml"), "expected HQ header mark to render the Remote UI logo")
     assert(js[:body].include?("function unreadAgents"),
            "expected the Remote UI to compute unread agents for the logo popup")
+    assert(js[:body].include?("function syncPlatformClasses"),
+           "expected the Remote UI to detect platform display mode classes")
+    assert(js[:body].include?("navigator.standalone === true"),
+           "expected iPad standalone detection to cover Apple home-screen apps")
+    assert(js[:body].include?("ipad-standalone"),
+           "expected iPad standalone detection to toggle the header spacing class")
     assert(js[:body].include?("function toggleUnreadPanel"),
            "expected the Remote UI logo to toggle an unread agents popup")
     assert(js[:body].include?("function renderUnreadAgentsPanel"),
@@ -1461,6 +1497,12 @@ module RemoteServerTest
            "expected the Remote UI header mark to stay on the brand logo with unread state")
     assert(!js[:body].include?("function markHtml"),
            "expected page-specific icons to stay out of the header brand mark")
+    assert(js[:body].include?("headerSubtitleIcon"),
+           "expected header subtitle icon state to stay separate from the brand mark")
+    assert(js[:body].include?("function headerSubtitleIconName"),
+           "expected header subtitle icons to normalize legacy header mark aliases")
+    assert(js[:body].include?('state.refreshing ? iconSvg("hourglass") : iconSvg(state.headerSubtitleIcon)'),
+           "expected refresh to swap the subtitle icon without shifting the text")
     assert(js[:body].include?("function statusIcon"), "expected readiness marks to use SVG status icons")
     assert(js[:body].include?("data-agent-summary"), "expected Agent detail to expose a docked Summary panel")
     assert(js[:body].include?("data-preserve-scroll"),
@@ -1629,6 +1671,20 @@ module RemoteServerTest
            "expected Remote UI to support #attachment/:id routes")
     assert(js[:body].include?("function renderMarkdown"),
            "expected markdown attachments to render as markdown")
+    assert(js[:body].include?("function markdownMessageBlock"),
+           "expected assistant messages and run summaries to opt into markdown rendering")
+    assert(js[:body].include?('block?.kind === "run_summary"'),
+           "expected run summary messages to render as markdown")
+    assert(js[:body].include?('block.role === "assistant"'),
+           "expected assistant messages to render as markdown")
+    assert(js[:body].include?("function renderAgentSummaryContent"),
+           "expected Agent summary text to render as markdown")
+    assert(js[:body].include?('viewerClassName: "markdown-viewer message-markdown-viewer"'),
+           "expected chat markdown to use message-scoped markdown styling")
+    assert(js[:body].include?('viewerClassName: "markdown-viewer summary-markdown-viewer"'),
+           "expected Agent summary markdown to use dock-scoped markdown styling")
+    assert(js[:body].include?("function renderMarkdownRoute"),
+           "expected markdown parser load completion to re-render active markdown routes")
     assert(!js[:body].include?("CODE_LANGUAGE_BY_EXTENSION"),
            "expected syntax metadata inference to remain out of the attachment viewer")
     assert(js[:body].include?("https://cdn.jsdelivr.net/npm/marked@"),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1162,8 +1162,8 @@ module RemoteServerTest
            "expected Remote UI to default iPad standalone control spacing off")
     assert(css[:body].include?("html.ipad-standalone"),
            "expected Remote UI to reserve space for iPad standalone window controls")
-    assert(css[:body].include?("calc(482px - 50vw)"),
-           "expected iPad standalone header spacing to shrink as the centered shell clears the control")
+    assert(css[:body].include?("--ipad-header-control-space: 36px;"),
+           "expected Remote UI to reserve compact iPad standalone window control spacing")
     assert(css[:body].include?("padding: 10px 12px 10px calc(12px + var(--ipad-header-control-space));"),
            "expected header rows to keep content clear of iPad left-side controls")
     assert(css[:body].include?("top: var(--safe-area-top);"),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -13,6 +13,7 @@ module RemoteServerTest
 
   def run!
     assert_remote_agent_lifecycle
+    assert_remote_agent_bulk_archive
     assert_remote_agent_clone_archives_source_with_editable_name
     assert_remote_agent_payload_has_revision
     assert_remote_inquiry_payload_has_stable_id_and_guarded_answer
@@ -80,6 +81,79 @@ module RemoteServerTest
       replace_constant(HQ, :AGENTS_FILE, old_agents_file) if old_agents_file
       replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
       replace_constant(HQ, :AGENT_ARCHIVE_DIR, old_archive_dir) if old_archive_dir
+    end
+  end
+
+  def assert_remote_agent_bulk_archive
+    running_pid = nil
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      FileUtils.mkdir_p(workspace)
+      registry = registry_for(dir, workspace)
+      service = HQ::RemoteService.new(registry: registry)
+      server = HQ::RemoteServer.new
+
+      archive_one = service.create_agent(
+        "project_key" => "web",
+        "template_key" => "custom",
+        "name" => "Archive One",
+        "prompt" => "Archive this.",
+        "agent" => "codex"
+      )
+      archive_two = service.create_agent(
+        "project_key" => "web",
+        "template_key" => "custom",
+        "name" => "Archive Two",
+        "prompt" => "Archive this too.",
+        "agent" => "codex"
+      )
+      running = service.create_agent(
+        "project_key" => "web",
+        "template_key" => "custom",
+        "name" => "Running Agent",
+        "prompt" => "Keep running.",
+        "agent" => "codex"
+      )
+      [archive_one, archive_two, running].each { |agent| File.write(agent[:log_path], "#{agent[:name]}\n") }
+
+      running_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 30", pgroup: true, out: File::NULL, err: File::NULL)
+      stored = JSON.parse(File.read(HQ::AGENTS_FILE))
+      stored.each do |agent|
+        next unless agent["key"] == running[:key]
+
+        agent["pid"] = running_pid
+        agent["started_at"] = Time.now.iso8601
+      end
+      File.write(HQ::AGENTS_FILE, JSON.pretty_generate(stored))
+
+      response = server.send(
+        :route,
+        service,
+        "POST",
+        "/agents/archive",
+        { "keys" => [archive_one[:key], running[:key], "missing-agent", archive_two[:key], archive_one[:key]] },
+        nil
+      )
+
+      archived_keys = response.dig(:body, :archived).map { |item| item[:agent_key] }
+      assert(archived_keys == [archive_one[:key], archive_two[:key]], "expected bulk archive to archive unique idle agents")
+      assert(response.dig(:body, :skipped).map { |item| item[:agent_key] } == [running[:key]],
+             "expected bulk archive to skip running agents")
+      assert(response.dig(:body, :failed).map { |item| item[:agent_key] } == ["missing-agent"],
+             "expected bulk archive to report missing agents")
+      assert(service.agents.map { |agent| agent[:key] } == [running[:key]],
+             "expected only running agent to remain active")
+      assert(response.dig(:body, :archived).all? { |item| item[:archive_path].nil? || Dir.exist?(item[:archive_path]) },
+             "expected archived agents to report archive destinations when logs existed")
+    ensure
+      if running_pid
+        begin
+          Process.kill("TERM", -running_pid)
+          Process.wait(running_pid)
+        rescue Errno::ESRCH, Errno::ECHILD
+          nil
+        end
+      end
     end
   end
 
@@ -1052,6 +1126,10 @@ module RemoteServerTest
     assert(response[:body].match?(%r{src="/ui\.js\?v=[0-9a-f]{12}"}),
            "expected root JavaScript reference to be asset-versioned")
     assert(response[:body].include?("agent-settings-button"), "expected root shell to expose Agent settings")
+    assert(response[:body].include?('data-tab="settings"'), "expected root shell to expose Settings navigation")
+    assert(response[:body].include?("<span>Settings</span>"), "expected root shell to label setup navigation as Settings")
+    assert(!response[:body].include?('data-tab="search"'), "expected root shell to remove Search navigation")
+    assert(!response[:body].include?('data-tab="projects"'), "expected root shell to remove Projects navigation")
     assert(response[:body].include?("<svg class=\"ui-icon\""), "expected root shell controls to use SVG icons")
     %w[‹ ● ⌕ ▦ ⚙].each do |glyph|
       assert(!response[:body].include?(glyph), "expected root shell to avoid text icon glyph #{glyph.inspect}")
@@ -1200,9 +1278,15 @@ module RemoteServerTest
     assert(css[:body].include?(".agent-dock:has(.attachment-flyout:not(.hidden))"),
            "expected the attachment flyout to stack above the skill flyout")
     assert(css[:body].include?(".server-lifecycle-card"),
-           "expected Setup restart lifecycle card to have distinct styling")
+           "expected Settings restart lifecycle card to have distinct styling")
     assert(css[:body].include?(".restart-server-button"),
-           "expected Setup restart action to have distinct button styling")
+           "expected Settings restart action to have distinct button styling")
+    assert(css[:body].include?("grid-template-columns: repeat(3, minmax(0, 1fr));"),
+           "expected bottom navigation to use the simplified three-tab layout")
+    assert(css[:body].include?(".bulk-action-bar"),
+           "expected Agents tab to style bulk archive controls")
+    assert(css[:body].include?(".selectable-agent-row"),
+           "expected Agents tab to style selectable bulk archive rows")
     assert(css[:body].include?(".compact-actions"),
            "expected Hidden settings rows to support compact action buttons")
     assert(css[:body].include?(".schedule-card-body") && css[:body].include?("padding: 0;"),
@@ -1255,22 +1339,22 @@ module RemoteServerTest
     assert(js[:body].include?("normalizeInquiryInputType"),
            "expected Remote UI to normalize inquiry field input types")
     assert(js[:body].include?("function setAgentSettings"), "expected Agent metadata to move into header settings")
-    assert(js[:body].include?("Push notifications"), "expected Setup screen to expose push readiness")
+    assert(js[:body].include?("Push notifications"), "expected Settings screen to expose push readiness")
     assert(js[:body].include?("function renderHiddenSettings"),
-           "expected Setup screen to expose a dedicated Hidden settings page")
+           "expected Settings screen to expose a dedicated Hidden settings page")
     assert(js[:body].include?('apiGet("/settings/hidden")'),
            "expected Hidden settings page to load hidden configuration")
     assert(js[:body].include?('apiPatch("/settings/hidden"'),
            "expected Hidden settings page to update hidden configuration")
     assert(js[:body].include?("data-open-hidden-settings"),
-           "expected Setup screen to link to Hidden settings")
+           "expected Settings screen to link to Hidden settings")
     assert(js[:body].include?('"eyeOff"') && js[:body].include?('"slash"') && js[:body].include?('"eye"'),
            "expected Hidden settings to use hidden/inherit/visible icon toggle buttons")
-    assert(js[:body].include?("data-restart-server"), "expected Setup screen to expose Remote restart action")
+    assert(js[:body].include?("data-restart-server"), "expected Settings screen to expose Remote restart action")
     assert(js[:body].include?('class="danger inline-icon-button restart-server-button" type="button" data-restart-server'),
            "expected Remote restart action to use danger button styling")
     assert(js[:body].index("Refresh and preferences") < js[:body].index("data-restart-server"),
-           "expected Remote restart action to stay at the bottom of the Setup screen")
+           "expected Remote restart action to stay at the bottom of the Settings screen")
     assert(js[:body].include?("function restartRemoteServer"), "expected Remote UI to handle Remote restarts")
     assert(js[:body].include?('apiPost("/server/restart"'),
            "expected Remote UI restart action to call the restart endpoint")
@@ -1439,8 +1523,8 @@ module RemoteServerTest
            "expected Agent detail read state to use the reading endpoint")
     assert(js[:body].include?('if (agent.unread) return "unread";'),
            "expected unread agents to show unread as the visible status before final run status")
-    assert(js[:body].scan('<span class="pill need">Unread</span>').length >= 2,
-           "expected agent and search lists to render explicit Unread pills")
+    assert(js[:body].scan('<span class="pill need">Unread</span>').length >= 1,
+           "expected agent list surfaces to render explicit Unread pills")
     assert(js[:body].include?("function shouldAutoScrollAgentConversation"),
            "expected Agent detail to auto-scroll only when conversation content changes")
     assert(js[:body].include?("function renderConversationBlocks"),
@@ -1610,13 +1694,32 @@ module RemoteServerTest
            "expected Remote UI to scope in-document hash link handling to Markdown viewers")
     assert(js[:body].include?("history.replaceState(null, \"\", routeHash(route))"),
            "expected Markdown hash links to preserve the attachment route")
-    assert(js[:body].include?("function focusSearchInput"), "expected Search tab to focus the search input after render")
-    assert(js[:body].include?("sortedAgentGroups(filtered)"),
+    assert(js[:body].include?('const TOP_TABS = ["now", "agents", "settings"];'),
+           "expected Remote UI to simplify top-level tabs")
+    assert(js[:body].include?('if (parts[0] === "search" || parts[0] === "projects") return { type: "tab", tab: "agents" };'),
+           "expected legacy Search and Projects hashes to land on Agents")
+    assert(js[:body].include?('return "#settings/hidden";'),
+           "expected Hidden settings to use the Settings route")
+    assert(js[:body].include?('setHeader("Settings"'),
+           "expected Setup screen to be labeled Settings")
+    assert(js[:body].include?("function agentProjectGroups"),
            "expected Agents tab to render project groups in sorted order")
     assert(js[:body].include?("function compareAgentProjectKeys"),
            "expected Agents tab group sorting to compare project display names")
     assert(js[:body].include?("function compareAgentsByName"),
            "expected Agents tab to sort agents alphabetically within each project group")
+    assert(js[:body].include?("projectMatches(project, query)"),
+           "expected Agents tab filtering to match project fields")
+    assert(js[:body].include?("renderProjectAgentEmpty()"),
+           "expected Agents tab to keep zero-agent projects reachable")
+    assert(js[:body].include?("data-toggle-bulk-archive"),
+           "expected Agents tab to expose bulk archive selection mode")
+    assert(js[:body].include?("data-run-bulk-archive"),
+           "expected Agents tab to expose bulk archive submission")
+    assert(js[:body].include?('apiPost("/agents/archive", { keys })'),
+           "expected Remote UI to call the bulk archive endpoint")
+    assert(js[:body].include?("function agentArchiveable"),
+           "expected Remote UI to guard running agents from bulk archives")
     assert(js[:body].include?("function relativeTimeShort"),
            "expected Remote UI list metadata to use compact relative times")
     assert(js[:body].include?("function relativeTimeBucket"),
@@ -1625,26 +1728,18 @@ module RemoteServerTest
            "expected Remote UI list metadata to color only relative time tokens")
     assert(js[:body].include?("function agentListSubtextHtml"),
            "expected Agents tab rows to build dedicated list subtitles")
-    assert(js[:body].include?("function agentSearchSubtextHtml"),
-           "expected Search agent rows to put relative time first")
-    assert(js[:body].include?("function projectSearchSubtext"),
-           "expected Search project rows to build dedicated subtitles")
     assert(js[:body].include?('class="relative-time ${escapeAttr(bucket)}"'),
            "expected Remote UI agent subtitles to render colorable relative time spans")
-    assert(!js[:body].include?("Agent / ${agentMeta(agent)}"),
-           "expected Search agent rows to omit redundant Agent prefix")
-    assert(!js[:body].include?("Project / ${project.status"),
-           "expected Search project rows to omit redundant Project prefix")
+    assert(!js[:body].include?("function renderSearch"),
+           "expected Search tab rendering to be removed")
+    assert(!js[:body].include?("function renderProjects"),
+           "expected Projects tab rendering to be removed")
     assert(!js[:body].include?("${statusLabel(agent)} / ${agentMeta(agent)}"),
            "expected Agents tab rows to omit status from subtext")
     assert(!js[:body].include?("agent.project_key, agent.agent, agent.template_key"),
            "expected Remote UI list metadata to omit agent template keys")
     assert(!js[:body].include?('agent.template_key || "template"'),
            "expected Remote UI agent cards to omit agent template keys")
-    assert(js[:body].include?("sortedProjects(state.projects)"),
-           "expected Projects tab to render projects in sorted order")
-    assert(js[:body].include?("function compareProjectsByName"),
-           "expected Projects tab sorting to use a stable comparator")
     direct_view_writes = js[:body].scan(/els\.view\.innerHTML\s*=\s*(?!\s*html\b)/)
     assert(direct_view_writes.empty?, "expected page renderers to use replaceView so polling preserves form state")
     assert(!js[:body].include?("detail.open === detail.hasAttribute"),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1162,6 +1162,8 @@ module RemoteServerTest
            "expected Remote UI to default iPad standalone control spacing off")
     assert(css[:body].include?("html.ipad-standalone"),
            "expected Remote UI to reserve space for iPad standalone window controls")
+    assert(css[:body].include?("calc(482px - 50vw)"),
+           "expected iPad standalone header spacing to shrink as the centered shell clears the control")
     assert(css[:body].include?("padding: 10px 12px 10px calc(12px + var(--ipad-header-control-space));"),
            "expected header rows to keep content clear of iPad left-side controls")
     assert(css[:body].include?("top: var(--safe-area-top);"),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1313,6 +1313,12 @@ module RemoteServerTest
            "expected bottom navigation to use the simplified three-tab layout")
     assert(css[:body].include?(".bulk-action-bar"),
            "expected Agents tab to style bulk archive controls")
+    assert(css[:body].include?(".top-actions .search-box"),
+           "expected Agents tab search to flex inside the action row")
+    assert(css[:body].include?(".top-actions > button"),
+           "expected Agents tab actions to align independently from the search width")
+    assert(css[:body].include?("margin-left: auto;"),
+           "expected Agents tab action button to stay right aligned")
     assert(css[:body].include?(".selectable-agent-row"),
            "expected Agents tab to style selectable bulk archive rows")
     assert(css[:body].include?(".compact-actions"),


### PR DESCRIPTION
## Summary

- simplify the Remote UI agent workflow and update the related Remote UI docs/status notes
- render assistant messages and run summaries as scoped markdown while preserving chat layout constraints
- add iPad standalone header spacing, iOS safe-area handling, and a stable subtitle icon slot so refresh state does not shift header text

## Root Cause

The iPad obstruction was not the normal status-bar safe area. It was the floating standalone/window control drawn over the left edge of the app, which is not represented by `safe-area-inset-top`. The header now detects iPad-like standalone mode and reserves left-side space for that control. The subtitle shift came from only inserting the refresh icon while polling; the subtitle now keeps a persistent icon slot.

## Validation

- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- `git diff --check`
- local Chrome/CDP simulation of iPad standalone mode confirmed `ipad-standalone` applied, `--ipad-header-control-space: 112px`, header padding `124px`, and logo left edge at `x=133` on a 773px-wide viewport
