### PR TITLE
[codex] Add clipboard paste uploads

### DIFF
--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -12,6 +12,26 @@ const PROMPT_ATTACHMENT_LIMITS = {
   maxBytes: 10 * 1024 * 1024,
   accept: "image/*,video/*,audio/*,.txt,.md,.markdown,.pdf,.rtf,.doc,.docx,.json,.jsonl,.csv,.tsv,.log",
 };
+const CLIPBOARD_ATTACHMENT_EXTENSIONS = {
+  "application/json": ".json",
+  "application/pdf": ".pdf",
+  "application/rtf": ".rtf",
+  "audio/mp4": ".m4a",
+  "audio/mpeg": ".mp3",
+  "audio/ogg": ".ogg",
+  "audio/wav": ".wav",
+  "image/gif": ".gif",
+  "image/heic": ".heic",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/svg+xml": ".svg",
+  "image/webp": ".webp",
+  "text/markdown": ".md",
+  "text/plain": ".txt",
+  "video/mp4": ".mp4",
+  "video/quicktime": ".mov",
+  "video/webm": ".webm",
+};
 const FORM_DRAFT_STORAGE_PREFIX = "hq.remote.formDraft.";
 const FORM_DRAFT_TEXT_INPUT_TYPES = new Set(["text", "search", "email", "url", "tel", "password", "number"]);
 const MARKDOWN_SCRIPT_URLS = {
@@ -2773,6 +2793,73 @@ function handlePromptAttachmentFiles(agentKey, files) {
   if (rejected.length) setConnection(`Attachment skipped: ${rejected[0]}`);
 }
 
+function handleClipboardAttachmentPaste(event) {
+  const agentKey = clipboardAttachmentAgentKey(event);
+  if (!agentKey) return;
+
+  const files = clipboardAttachmentFiles(event);
+  if (!files.length) return;
+
+  const beforeCount = pendingAttachmentsFor(agentKey).length;
+  handlePromptAttachmentFiles(agentKey, files);
+  if (pendingAttachmentsFor(agentKey).length > beforeCount) event.preventDefault();
+}
+
+function clipboardAttachmentAgentKey(event) {
+  const route = parseRoute();
+  if (!agentShellRoute(route)) return "";
+
+  const agent = findAgent(route.key);
+  if (!agent || agentIsRunning(agent)) return "";
+  if (typeof event.target?.closest !== "function") return "";
+  if (!event.target.closest("#composer, #inquiry-form")) return "";
+
+  return agent.key;
+}
+
+function clipboardAttachmentFiles(event) {
+  const data = event.clipboardData;
+  if (!data) return [];
+
+  const directFiles = Array.from(data.files || []);
+  if (directFiles.length) return directFiles.map((file, index) => normalizeClipboardAttachmentFile(file, index));
+
+  return Array.from(data.items || []).filter((item) => item.kind === "file").map((item, index) => {
+    const file = item.getAsFile?.();
+    return file ? normalizeClipboardAttachmentFile(file, index) : null;
+  }).filter(Boolean);
+}
+
+function normalizeClipboardAttachmentFile(file, index) {
+  if (!file || file.name) return file;
+
+  const filename = clipboardAttachmentFilename(file, index);
+  try {
+    return new File([file], filename, { type: file.type || "", lastModified: Date.now() });
+  } catch (_error) {
+    return file;
+  }
+}
+
+function clipboardAttachmentFilename(file, index) {
+  const extension = CLIPBOARD_ATTACHMENT_EXTENSIONS[String(file?.type || "").toLowerCase()] || ".bin";
+  const suffix = index > 0 ? `-${index + 1}` : "";
+  return `clipboard-${clipboardAttachmentTimestamp()}${suffix}${extension}`;
+}
+
+function clipboardAttachmentTimestamp(date = new Date()) {
+  const pad = (value) => String(value).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    "-",
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+  ].join("");
+}
+
 function normalizePromptAttachmentFile(file) {
   if (file.size > PROMPT_ATTACHMENT_LIMITS.maxBytes) {
     return { error: `larger than ${formatBytes(PROMPT_ATTACHMENT_LIMITS.maxBytes)}` };
@@ -4657,6 +4744,10 @@ els.view.addEventListener("keydown", (event) => {
     if (firstAgent) navigate({ type: "agent", key: firstAgent.key });
     else if (firstGroup?.projectKey && findProject(firstGroup.projectKey)) navigate({ type: "project", key: firstGroup.projectKey });
   }
+});
+
+els.view.addEventListener("paste", (event) => {
+  handleClipboardAttachmentPaste(event);
 });
 
 els.view.addEventListener("input", (event) => {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1603,6 +1603,16 @@ module RemoteServerTest
            "expected Agent detail to render pending prompt attachments before sending")
     assert(js[:body].include?("function pendingAttachmentPayloads"),
            "expected Remote UI to serialize prompt attachments into API payloads")
+    assert(js[:body].include?('els.view.addEventListener("paste"'),
+           "expected Agent detail composer to listen for pasted attachment files")
+    assert(js[:body].include?("function handleClipboardAttachmentPaste"),
+           "expected Remote UI to route pasted clipboard files into pending attachments")
+    assert(js[:body].include?("function clipboardAttachmentFiles"),
+           "expected Remote UI to extract files from clipboard data")
+    assert(js[:body].include?("function clipboardAttachmentFilename"),
+           "expected Remote UI to synthesize filenames for nameless clipboard blobs")
+    assert(js[:body].include?("new File([file], filename"),
+           "expected Remote UI to wrap nameless clipboard blobs with safe filenames")
     assert(js[:body].include?("data-add-prompt-attachment"),
            "expected Agent detail composer to expose a file picker trigger")
     assert(js[:body].include?("data-prompt-attachment-input"),


### PR DESCRIPTION
## Summary
- Add Remote UI paste handling for clipboard-provided files/images in the agent composer and inquiry form.
- Synthesize safe filenames for nameless clipboard blobs before routing them through the existing pending attachment pipeline.
- Add Remote UI asset regression assertions for the clipboard attachment path.

## Impact
Users can paste copied screenshots/images, and browser-exposed copied files, directly into the Remote UI composer instead of opening the file picker. Text-only paste continues to behave normally.

## Validation
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- `node --check lib/hq/remote_ui/assets/app.js`
- Temporary Remote UI browser verification with Playwright + system Chrome: pasted PNG became a pending attachment, sent with the prompt, cleared from the composer, and rendered in the chat attachment row.