### PR TITLE
Prepend and dedupe attachments

### DIFF
--- a/lib/hq/domain/agent_memory.rb
+++ b/lib/hq/domain/agent_memory.rb
@@ -427,7 +427,7 @@ module HQ
       end
       return if records_to_append.empty?
 
-      records = dedupe_attachments(read_attachment_records + records_to_append)
+      records = dedupe_attachments(records_to_append + read_attachment_records)
       FileUtils.mkdir_p(File.dirname(attachments_path))
       File.write(attachments_path, "#{JSON.pretty_generate("attachments" => records)}\n")
     rescue StandardError
@@ -523,8 +523,7 @@ module HQ
 
       [
         normalized["type"],
-        normalized["type"] == "link" ? normalized["url"] : normalized["path"],
-        normalized["title"]
+        normalized["type"] == "link" ? normalized["url"] : normalized["path"]
       ].map(&:to_s)
     end
 

--- a/lib/hq/domain/attachment_normalizer.rb
+++ b/lib/hq/domain/attachment_normalizer.rb
@@ -272,16 +272,19 @@ module HQ
       end
 
       def dedupe(attachments)
-        by_key = {}
+        seen = {}
+        deduped = []
         attachments.each do |attachment|
           key = [
             attachment["type"],
-            attachment["type"] == "link" ? attachment["url"] : attachment["path"],
-            attachment["title"]
+            attachment["type"] == "link" ? attachment["url"] : attachment["path"]
           ]
-          by_key[key] = attachment
+          next if seen[key]
+
+          seen[key] = true
+          deduped << attachment
         end
-        by_key.values
+        deduped
       end
     end
   end

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -1091,8 +1091,7 @@ module HQ
 
       [
         normalized["type"],
-        normalized["type"] == "link" ? normalized["url"] : normalized["path"],
-        normalized["title"]
+        normalized["type"] == "link" ? normalized["url"] : normalized["path"]
       ].map(&:to_s)
     end
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2703,7 +2703,27 @@ function renderAttachment(attachment) {
 }
 
 function agentAttachments(agent) {
-  return Array.isArray(agent?.attachments) ? agent.attachments : [];
+  return dedupeAgentAttachments(Array.isArray(agent?.attachments) ? agent.attachments : []);
+}
+
+function dedupeAgentAttachments(attachments) {
+  const seen = new Set();
+  const deduped = [];
+  attachments.forEach((attachment) => {
+    const key = attachmentDedupeKey(attachment);
+    if (!key || seen.has(key)) return;
+
+    seen.add(key);
+    deduped.push(attachment);
+  });
+  return deduped;
+}
+
+function attachmentDedupeKey(attachment) {
+  const target = attachmentTarget(attachment);
+  if (!target) return "";
+
+  return `${attachmentKind(attachment)}\u001f${target}`;
 }
 
 function attachmentId(attachment) {
@@ -2816,22 +2836,34 @@ function handlePromptAttachmentFiles(agentKey, files) {
   const pending = pendingAttachmentsFor(agentKey);
   const accepted = [];
   const rejected = [];
+  const existingKeys = new Set(pending.map(pendingAttachmentDedupeKey));
+  const acceptedKeys = new Set();
 
   Array.from(files || []).forEach((file) => {
-    if (pending.length + accepted.length >= PROMPT_ATTACHMENT_LIMITS.maxFiles) {
-      rejected.push(`${file.name}: limit ${PROMPT_ATTACHMENT_LIMITS.maxFiles}`);
-      return;
-    }
     const normalized = normalizePromptAttachmentFile(file);
     if (normalized.error) {
       rejected.push(`${file.name}: ${normalized.error}`);
+      return;
+    }
+
+    const key = pendingAttachmentDedupeKey(normalized);
+    if (existingKeys.has(key) || acceptedKeys.has(key)) {
+      rejected.push(`${normalized.filename}: duplicate`);
+      revokePendingAttachment(normalized);
+      return;
+    }
+
+    if (pending.length + accepted.length >= PROMPT_ATTACHMENT_LIMITS.maxFiles) {
+      rejected.push(`${normalized.filename}: limit ${PROMPT_ATTACHMENT_LIMITS.maxFiles}`);
+      revokePendingAttachment(normalized);
     } else {
+      acceptedKeys.add(key);
       accepted.push(normalized);
     }
   });
 
   if (accepted.length) {
-    state.pendingPromptAttachments[agentKey] = pending.concat(accepted);
+    state.pendingPromptAttachments[agentKey] = accepted.concat(pending);
     state.renderedViewHtml = "";
     render();
     window.requestAnimationFrame(syncAgentDockLayout);
@@ -2921,6 +2953,17 @@ function normalizePromptAttachmentFile(file) {
     size: file.size,
     previewUrl: image ? URL.createObjectURL(file) : "",
   };
+}
+
+function pendingAttachmentDedupeKey(attachment) {
+  const file = attachment?.file;
+  return [
+    attachment?.type || "file",
+    String(attachment?.filename || "").trim().toLowerCase(),
+    String(attachment?.mimeType || "").trim().toLowerCase(),
+    String(attachment?.size || ""),
+    String(file?.lastModified || "")
+  ].join("\u001f");
 }
 
 function promptAttachmentIsImage(file) {

--- a/test/attachment_normalization_test.rb
+++ b/test/attachment_normalization_test.rb
@@ -2,6 +2,7 @@
 
 require "tmpdir"
 require "fileutils"
+require "time"
 
 require_relative "../lib/hq/domain/managed_agent"
 
@@ -10,6 +11,8 @@ module AttachmentNormalizationTest
 
   def run!
     assert_file_and_link_attachments_are_normalized
+    assert_duplicate_attachment_targets_are_deduped
+    assert_new_attachment_records_are_prepended
     assert_legacy_kind_attachments_remain_supported
     assert_invalid_attachments_are_dropped
     puts "attachment_normalization_test: ok"
@@ -61,6 +64,106 @@ module AttachmentNormalizationTest
       assert(attachments[2]["path"] == File.join(dir, "tmp-export.jsonl"),
              "expected file:// targets to normalize to absolute paths")
       assert(!attachments[2].key?("url"), "expected file attachments not to keep file:// URLs")
+    end
+  end
+
+  def assert_duplicate_attachment_targets_are_deduped
+    Dir.mktmpdir("hq-attachment-normalization-test") do |dir|
+      FileUtils.mkdir_p(File.join(dir, "docs"))
+      notes_path = File.join(dir, "docs/project-notes.md")
+      File.write(notes_path, "# Project notes\n")
+      agent = HQ::ManagedAgent.new(
+        key: "attachment-dedup",
+        name: "Attachment Dedup",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "Test attachment deduplication",
+        agent: "claude",
+        log_path: File.join(dir, "agent.raw.log")
+      )
+
+      attachments = agent.send(
+        :normalize_attachments,
+        [
+          {
+            "type" => "file",
+            "title" => "Project notes",
+            "path" => "docs/project-notes.md"
+          },
+          {
+            "type" => "file",
+            "title" => "Renamed project notes",
+            "path" => notes_path
+          },
+          {
+            "type" => "link",
+            "title" => "Implementation PR",
+            "url" => "https://github.com/example/web/pull/123"
+          },
+          {
+            "type" => "link",
+            "title" => "Renamed implementation PR",
+            "url" => "https://github.com/example/web/pull/123"
+          }
+        ]
+      )
+
+      assert(attachments.map { |item| item["title"] } == ["Project notes", "Implementation PR"],
+             "expected identical file paths and URLs to dedupe regardless of title")
+    end
+  end
+
+  def assert_new_attachment_records_are_prepended
+    Dir.mktmpdir("hq-attachment-normalization-test") do |dir|
+      FileUtils.mkdir_p(File.join(dir, "docs"))
+      older_path = File.join(dir, "docs/older.md")
+      newer_path = File.join(dir, "docs/newer.md")
+      File.write(older_path, "# Older\n")
+      File.write(newer_path, "# Newer\n")
+      agent = HQ::ManagedAgent.new(
+        key: "attachment-prepend",
+        name: "Attachment Prepend",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "Test attachment ordering",
+        agent: "claude",
+        log_path: File.join(dir, "agent.raw.log")
+      )
+      memory = agent.send(:memory_store)
+
+      memory.append_attachment!(
+        {
+          "type" => "file",
+          "title" => "Older notes",
+          "path" => older_path
+        },
+        created_at: Time.parse("2026-05-01 10:00:00")
+      )
+      memory.append_attachment!(
+        {
+          "type" => "file",
+          "title" => "Newer notes",
+          "path" => newer_path
+        },
+        created_at: Time.parse("2026-05-01 11:00:00")
+      )
+
+      assert(agent.attachments.map { |item| item["title"] } == ["Newer notes", "Older notes"],
+             "expected newly added attachment records to appear first")
+
+      memory.append_attachment!(
+        {
+          "type" => "file",
+          "title" => "Renamed older notes",
+          "path" => older_path
+        },
+        created_at: Time.parse("2026-05-01 12:00:00")
+      )
+
+      assert(agent.attachments.map { |item| item["title"] } == ["Renamed older notes", "Newer notes"],
+             "expected duplicate targets to be replaced at the front")
     end
   end
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -381,7 +381,14 @@ module RemoteServerTest
 
       payload = service.agent(created[:key])
       attachments = payload[:attachments]
-      assert(attachments.map { |item| item["type"] } == %w[link file file file file],
+      assert(attachments.map { |item| item["title"] } == [
+        "UI screenshot",
+        "File URI notes",
+        "Markdown notes",
+        "Release checklist",
+        "Implementation PR"
+      ], "expected Remote agent payload to expose newest attachments first")
+      assert(attachments.map { |item| item["type"] } == %w[file file file file link],
              "expected Remote agent payload to expose normalized file/link attachments")
       assert(attachments.all? { |item| item["id"].to_s.length == 20 },
              "expected Remote agent payload to expose stable attachment IDs")
@@ -1611,6 +1618,10 @@ module RemoteServerTest
            "expected Agent detail to group internal conversation blocks before rendering")
     assert(js[:body].include?("function renderAgentAttachments"),
            "expected Agent detail to render saved attachments")
+    assert(js[:body].include?("function dedupeAgentAttachments"),
+           "expected Agent detail to dedupe saved attachments before rendering")
+    assert(js[:body].include?("function attachmentDedupeKey"),
+           "expected Agent detail to dedupe saved attachments by target")
     assert(js[:body].include?("function refreshAttachment"),
            "expected Attachment detail to support refreshing cached preview data")
     assert(js[:body].include?("function deleteAttachment"),
@@ -1635,6 +1646,10 @@ module RemoteServerTest
            "expected Agent detail to render pending prompt attachments before sending")
     assert(js[:body].include?("function pendingAttachmentPayloads"),
            "expected Remote UI to serialize prompt attachments into API payloads")
+    assert(js[:body].include?("function pendingAttachmentDedupeKey"),
+           "expected Remote UI pending attachments to dedupe repeated browser files")
+    assert(js[:body].include?("state.pendingPromptAttachments[agentKey] = accepted.concat(pending);"),
+           "expected Remote UI pending attachments to prepend newly added files")
     assert(js[:body].include?('els.view.addEventListener("paste"'),
            "expected Agent detail composer to listen for pasted attachment files")
     assert(js[:body].include?("function handleClipboardAttachmentPaste"),

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -1607,10 +1607,15 @@ module RenderingTest
       agent.send(:finalize_latest_run!)
 
       attachments = agent.attachments
-      assert(attachments.map { |item| item["type"] } == %w[link file file],
+      assert(attachments.map { |item| item["type"] } == %w[file file link],
              "expected attachment types to normalize for compact rendering, got #{attachments.inspect}")
-      assert(attachments.map { |item| item["kind"] } == %w[link document image],
+      assert(attachments.map { |item| item["kind"] } == %w[image document link],
              "expected attachment kinds to normalize for compact rendering, got #{attachments.inspect}")
+      assert(attachments.map { |item| item["title"] } == [
+        "Infographic for a plan",
+        "Plan for attachment feature",
+        "PR #1234: bugfixing some log"
+      ], "expected compact attachments to render newest first")
       assert(attachments.map { |item| item["title"] }.include?("PR #1234: bugfixing some log"),
              "expected PR attachment title to persist")
       assert(File.exist?(agent.attachments_path), "expected attachments to persist outside rebuildable memory")


### PR DESCRIPTION
## Summary
- Dedupe saved attachments by normalized URL/path target instead of title-sensitive identity.
- Store newly added attachment records first so flyouts show the latest attachments at the top.
- Prepend pending Remote UI uploads and skip repeated browser files before sending.

## Verification
- `bin/test`
- `node --check lib/hq/remote_ui/assets/app.js`
- `git diff --check`
- Isolated headless Chrome check for Remote UI attachment dedupe/prepend behavior.