### PR TITLE
[codex] Add grouped web push badge support

### DIFF
--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -127,9 +127,9 @@ Home-screen launches are treated as normal browser sessions, but mobile browsers
 
 The top-level mobile tabs are `Now`, `Agents`, and `Settings`. Agents is the canonical project-and-agent workspace: it filters agents and project metadata, keeps zero-agent projects reachable for first-agent creation, and links to project detail routes. Legacy `#search`, `#projects`, and `#setup` hashes are redirected to the closest surviving tab. Detail routes use hash navigation such as `#agent/{key}`, `#project/{key}`, and `#project/{key}/action/{action}`. The footer nav is fixed on top-level routes, hides while scrolling down, shows again while scrolling up, and is hidden on detail subpages.
 
-Browser push notification work is tracked in [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md). Push can use a Tailscale MagicDNS domain when it is served over HTTPS, preferably with Tailscale Serve or Tailscale Funnel. Plain HTTP MagicDNS URLs show a soft warning, but the UI still lets the user try enabling notifications when the browser exposes the required push APIs.
+Browser push notification work is tracked in [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md), and the current grouping, silent-notification, and PWA badge behavior is summarized in [WEB_PUSH_BEHAVIOR.md](./WEB_PUSH_BEHAVIOR.md). Push can use a Tailscale MagicDNS domain when it is served over HTTPS, preferably with Tailscale Serve or Tailscale Funnel. Plain HTTP MagicDNS URLs show a soft warning, but the UI still lets the user try enabling notifications when the browser exposes the required push APIs.
 
-The Remote server polls managed-agent state while it is running and sends one push notification when an agent requires response or finishes. Agent notification clicks open `/#agent/{key}`.
+The Remote server polls managed-agent state while it is running and sends one push notification when an agent requires response or finishes. Agent notifications share the `hq:agents` browser notification tag so repeated agent updates replace the previous Tycho agent notification instead of piling up; input-required notifications renotify audibly, while routine finish notifications are marked silent. Agent payloads also carry the current unread-agent count so browsers with the Badging API can show the count on the installed PWA app icon. Agent notification clicks open `/#agent/{key}`.
 
 Use `.env.sample` as the template for local runtime environment values such as `TYCHO_WEB_PUSH_VAPID_SUBJECT`. Real `.env` files are gitignored, and `tycho serve` loads `.env` automatically on startup. Values already set in the process environment take precedence over `.env`; public runtime overrides use the `TYCHO_*` prefix.
 
@@ -644,7 +644,7 @@ Disables one browser push subscription by endpoint:
 
 ### `POST /push/test`
 
-Sends a test notification to an enabled subscription. Automatic agent-transition notifications are sent by the Remote server poll loop and de-duplicated in `~/.tycho/logs/push_notifications.json`.
+Sends a test notification to an enabled subscription. Automatic agent-transition notifications are sent by the Remote server poll loop, de-duplicated in `~/.tycho/logs/push_notifications.json`, grouped through a shared notification tag, and mirrored to the installed-app badge when the browser exposes the Badging API.
 
 ```json
 {

--- a/docs/WEB_PUSH_BEHAVIOR.md
+++ b/docs/WEB_PUSH_BEHAVIOR.md
@@ -1,0 +1,101 @@
+# Web Push Notification Behavior
+
+This note explains how Tycho Remote UI uses browser push notifications, notification grouping, silent delivery, and PWA app icon badges. It is meant as a learning map for future improvements, not as the original implementation plan.
+
+## Current Flow
+
+1. The Remote server polls managed agents through `AgentStore#load_with_poll_events`.
+2. When a running agent transitions to `awaiting-input`, `succeeded`, `failed`, `stopped`, or `blocked`, Tycho marks that agent unread and records a push event.
+3. `RemoteService#dispatch_agent_push_events` builds a compact JSON payload for the event.
+4. `WebPushNotifier#send_payload!` sends that payload to every enabled browser subscription with VAPID authentication.
+5. `/service-worker.js` receives the push event, updates the installed-app badge when a `badge_count` is present, and calls `registration.showNotification(title, options)`.
+6. When the Remote UI page is open, `syncUnreadAlert()` also mirrors the unread-agent count into the app badge so foreground state and background push state stay aligned.
+7. Notification clicks focus an existing Tycho Remote tab when possible, otherwise they open the payload URL, usually `/#agent/{key}`.
+
+## Grouping Model
+
+The Web Notifications API does not provide a portable native "group" primitive like some mobile notification frameworks do. The closest standard tool is the notification `tag` option:
+
+- A notification with the same `tag` as an existing notification replaces the older notification.
+- `renotify: true` asks the browser to alert the user again when replacement happens.
+- `renotify` only makes sense when a `tag` is present.
+
+Tycho uses this replacement model for agent pushes:
+
+```json
+{
+  "tag": "hq:agents",
+  "renotify": true,
+  "url": "/#agent/smoke-agent-1"
+}
+```
+
+All agent transition notifications share the `hq:agents` tag. That means repeated agent updates collapse into one visible Tycho agent notification instead of piling up. The newest notification wins, and when more than one unread agent exists Tycho appends the unread count to the notification body.
+
+This is intentionally coarse-grained. A future improvement could split tags by priority, for example `hq:agents:input-required` and `hq:agents:finished`, if replacing finished notifications with input-required notifications feels too aggressive.
+
+## Silent Notifications
+
+The Notification API `silent` option suppresses notification sounds and vibrations. It does not make a push invisible, and it does not guarantee that the browser will avoid showing a notification.
+
+Tycho uses this policy:
+
+- `awaiting-input`: `silent: false`, `renotify: true`, Web Push urgency `high`
+- finished states (`succeeded`, `failed`, `stopped`, `blocked`): `silent: true`, Web Push urgency `normal`
+
+This keeps "agent needs your answer" events attention-grabbing while making routine completions less disruptive. Browser behavior still varies by platform and user notification settings.
+
+Important limitation: do not rely on Web Push as a fully silent background transport for badge-only updates. Browsers can require a visible notification whenever a push event is received. Tycho treats background push as a visible notification path and uses the app badge as supplemental state.
+
+## PWA App Icon Badges
+
+There are two different "badge" concepts:
+
+- `showNotification({ badge: "/pwa-icon-192.png" })` is the small notification-shelf icon used by some platforms.
+- `navigator.setAppBadge(count)` / `navigator.clearAppBadge()` update the installed PWA app icon badge when supported.
+
+Tycho uses both:
+
+- The service worker keeps the notification `badge` image pointed at Tycho's PWA icon.
+- Agent push payloads include `badge_count`, derived from the current unread-agent count.
+- The service worker calls `setAppBadge(badge_count)` when it handles a push payload with `badge_count`.
+- The foreground Remote UI calls `setAppBadge(unread_count)` during normal rendering and `clearAppBadge()` when unread agents drop to zero.
+- Unsupported browsers are treated as no-ops.
+
+Example agent payload:
+
+```json
+{
+  "title": "Agent requires response",
+  "body": "Smoke Project reviewer: Needs deployment confirmation (2 unread agents)",
+  "tag": "hq:agents",
+  "renotify": true,
+  "silent": false,
+  "badge_count": 2,
+  "url": "/#agent/smoke-agent-1"
+}
+```
+
+## Files To Read
+
+- `lib/hq/remote_server.rb`: builds agent push payloads and unread badge counts.
+- `lib/hq/domain/web_push_notifier.rb`: sends encrypted Web Push payloads.
+- `lib/hq/remote_ui/assets/service-worker.js`: receives push events, displays notifications, and updates badges in the background.
+- `lib/hq/remote_ui/assets/app.js`: mirrors unread-agent state to the header logo badge and the installed PWA app badge.
+- `test/remote_server_test.rb`: regression coverage for push payload shape, service worker behavior, and Remote UI hooks.
+
+## Improvement Ideas
+
+- Add Settings toggles for notification mode: grouped, per-agent, silent completions, or all-silent.
+- Split group tags by severity so input-required notifications do not replace routine completion notifications.
+- Add notification actions such as "Open agent" and "Mark read" once action support is tested across target browsers.
+- Persist per-subscription preferences so a desktop browser and phone can use different notification policies.
+- Include schedule failures in the app badge count, or document why app badges are agent-only.
+- Add a "last push payload" debug view under Settings for diagnosing service worker behavior.
+- Explore a summary notification body that lists the top two unread agents instead of only the newest event.
+
+## References
+
+- [MDN: ServiceWorkerRegistration.showNotification()](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification)
+- [MDN: Badging API](https://developer.mozilla.org/en-US/docs/Web/API/Badging_API)
+- [Chrome for Developers: Badging for app icons](https://developer.chrome.com/docs/capabilities/web-apis/badging-api)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -1238,9 +1238,10 @@ module HQ
 
     def dispatch_agent_push_events(events, agents:)
       totals = { events: 0, sent: 0, failed: 0, attempted: 0 }
+      unread_count = agents.count(&:unread?)
       Array(events).each do |event|
         agent = agents.find { |candidate| candidate.key == event.agent_key }
-        payload = agent && agent_push_payload(agent)
+        payload = agent && agent_push_payload(agent, unread_count: unread_count)
         next unless payload
 
         notification_id = agent_push_notification_id(agent, payload.fetch(:event))
@@ -1266,7 +1267,7 @@ module HQ
       totals
     end
 
-    def agent_push_payload(agent)
+    def agent_push_payload(agent, unread_count:)
       status = agent.status
       if status == "awaiting-input"
         event = "input_required"
@@ -1278,12 +1279,19 @@ module HQ
         return nil
       end
 
+      group_count = [unread_count.to_i, 1].max
+      body = "#{agent.name}: #{truncate(agent.last_summary, 120)}"
+      body = "#{body} (#{group_count} unread agents)" if group_count > 1
+
       {
         event: event,
         payload: {
           title: title,
-          body: "#{agent.name}: #{truncate(agent.last_summary, 120)}",
-          tag: "hq:agent:#{agent.key}:#{event}",
+          body: body,
+          tag: "hq:agents",
+          renotify: event == "input_required",
+          silent: event != "input_required",
+          badge_count: group_count,
           url: "/#agent/#{agent.key}"
         }
       }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -349,6 +349,7 @@ const state = {
   agentSettingsOpen: false,
   unreadPanelOpen: false,
   readMarkTimer: null,
+  lastAppBadgeCount: null,
 };
 
 const markdownParser = {
@@ -720,7 +721,10 @@ async function markAgentReading(agent) {
   if (!agent?.unread) return;
 
   const data = await apiPut(`/agents/${encodeURIComponent(agent.key)}/reading`);
-  if (data.agent) upsertAgent(data.agent);
+  if (data.agent) {
+    upsertAgent(data.agent);
+    syncUnreadAlert();
+  }
 }
 
 async function ensureSkills(agent) {
@@ -3467,6 +3471,7 @@ function syncUnreadAlert() {
   const agents = unreadAgents();
   const count = agents.length;
   if (count === 0) state.unreadPanelOpen = false;
+  syncAppBadge(count);
 
   els.mark.innerHTML = brandLogoHtml(count);
   els.mark.classList.toggle("has-unread", count > 0);
@@ -3476,6 +3481,17 @@ function syncUnreadAlert() {
   els.mark.setAttribute("aria-expanded", state.unreadPanelOpen && count > 0 ? "true" : "false");
   els.mark.setAttribute("aria-disabled", count > 0 ? "false" : "true");
   renderUnreadAgentsPanel(agents);
+}
+
+function syncAppBadge(count) {
+  const nextCount = Math.max(0, Math.trunc(Number(count) || 0));
+  if (state.lastAppBadgeCount === nextCount) return;
+
+  state.lastAppBadgeCount = nextCount;
+  if (!("setAppBadge" in navigator) || !("clearAppBadge" in navigator)) return;
+
+  const promise = nextCount > 0 ? navigator.setAppBadge(nextCount) : navigator.clearAppBadge();
+  Promise.resolve(promise).catch(() => {});
 }
 
 function unreadLogoLabel(count) {

--- a/lib/hq/remote_ui/assets/service-worker.js
+++ b/lib/hq/remote_ui/assets/service-worker.js
@@ -20,6 +20,8 @@ self.addEventListener("push", (event) => {
   const options = {
     body: payload.body || "Tycho has an update.",
     tag: payload.tag || "hq-remote",
+    renotify: Boolean(payload.renotify && payload.tag),
+    silent: payload.silent === true,
     icon: "/pwa-icon-192.png",
     badge: "/pwa-icon-192.png",
     data: {
@@ -27,7 +29,12 @@ self.addEventListener("push", (event) => {
     },
   };
 
-  event.waitUntil(self.registration.showNotification(title, options));
+  const badgePromise = Object.prototype.hasOwnProperty.call(payload, "badge_count")
+    ? syncAppBadge(payload.badge_count)
+    : Promise.resolve();
+  event.waitUntil(
+    badgePromise.then(() => self.registration.showNotification(title, options))
+  );
 });
 
 self.addEventListener("notificationclick", (event) => {
@@ -46,3 +53,16 @@ self.addEventListener("notificationclick", (event) => {
     })
   );
 });
+
+function syncAppBadge(count) {
+  if (!("setAppBadge" in self.navigator) || !("clearAppBadge" in self.navigator)) {
+    return Promise.resolve();
+  }
+
+  const number = Number(count);
+  if (!Number.isFinite(number) || number <= 0) {
+    return self.navigator.clearAppBadge().catch(() => {});
+  }
+
+  return self.navigator.setAppBadge(Math.trunc(number)).catch(() => {});
+}

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1048,6 +1048,14 @@ module RemoteServerTest
              "expected finished notification")
       assert(notifier.payloads.all? { |payload| payload[:url].start_with?("/#agent/") },
              "expected notification click URLs to target agent detail")
+      assert(notifier.payloads.all? { |payload| payload[:tag] == "hq:agents" },
+             "expected agent notifications to share a group tag")
+      assert(notifier.payloads.any? { |payload| payload[:renotify] == true && payload[:silent] == false },
+             "expected input-required notifications to renotify audibly")
+      assert(notifier.payloads.any? { |payload| payload[:silent] == true },
+             "expected finished notifications to be silent")
+      assert(notifier.payloads.all? { |payload| payload[:badge_count] == 2 },
+             "expected agent notifications to carry the unread app badge count")
       agents = service.agents
       assert(agents.find { |agent| agent[:key] == "web-agent-1" }[:unread],
              "expected finalized input-required agent to be marked unread")
@@ -1188,6 +1196,14 @@ module RemoteServerTest
            "expected service worker push fallback body to use Tycho")
     assert(service_worker[:body].include?('icon: "/pwa-icon-192.png"'),
            "expected service worker notifications to use the PWA logo icon")
+    assert(service_worker[:body].include?("payload.silent === true"),
+           "expected service worker notifications to support silent pushes")
+    assert(service_worker[:body].include?("Boolean(payload.renotify && payload.tag)"),
+           "expected service worker notifications to support grouped renotify")
+    assert(service_worker[:body].include?("syncAppBadge(payload.badge_count)"),
+           "expected service worker pushes to sync the app badge count")
+    assert(service_worker[:body].include?("setAppBadge"),
+           "expected service worker to use the Badging API when available")
 
     css = server.send(:route_ui, "/ui.css")
     assert(css[:content_type].include?("text/css"), "expected /ui.css to return CSS")
@@ -1520,6 +1536,12 @@ module RemoteServerTest
     assert(js[:body].include?("function brandLogoHtml"), "expected HQ header mark to render the Remote UI logo")
     assert(js[:body].include?("function unreadAgents"),
            "expected the Remote UI to compute unread agents for the logo popup")
+    assert(js[:body].include?("function syncAppBadge"),
+           "expected the Remote UI to sync unread agents to the PWA app badge")
+    assert(js[:body].include?("navigator.setAppBadge"),
+           "expected the Remote UI to use the Badging API when available")
+    assert(js[:body].include?("navigator.clearAppBadge"),
+           "expected the Remote UI to clear the PWA app badge when unread agents clear")
     assert(js[:body].include?("function syncPlatformClasses"),
            "expected the Remote UI to detect platform display mode classes")
     assert(js[:body].include?("navigator.standalone === true"),


### PR DESCRIPTION
## Summary
- group agent push notifications under a shared `hq:agents` notification tag
- mark routine finished-agent notifications silent while keeping input-required events attention-grabbing
- sync unread-agent counts to the installed PWA app badge from both the service worker and foreground Remote UI
- add a standalone web push behavior guide and update Remote Server docs

## Verification
- `bin/test`
- `git diff --check`
- previous browser smoke check against isolated `bin/tycho serve` instance
