### PR TITLE
[codex] Improve remote summary view

### DIFF
--- a/config/schemas/agent_result.json
+++ b/config/schemas/agent_result.json
@@ -7,7 +7,8 @@
       "enum": ["success", "partial", "failed", "blocked", "input_required"]
     },
     "summary": {
-      "type": "string"
+      "type": "string",
+      "description": "Concise operator-facing Markdown summary of this run. State the outcome, important changes or findings, blockers, and concrete next steps. Keep it focused enough for the Remote UI Summary page: usually 1-3 short paragraphs or bullets."
     },
     "inquiry": {
       "type": ["object", "null"],

--- a/config/schemas/agent_result.json
+++ b/config/schemas/agent_result.json
@@ -8,7 +8,7 @@
     },
     "summary": {
       "type": "string",
-      "description": "Concise operator-facing Markdown summary of this run. State the outcome, important changes or findings, blockers, and concrete next steps. Keep it focused enough for the Remote UI Summary page: usually 1-3 short paragraphs or bullets."
+      "description": "Concise operator-facing Markdown summary of this run. State the outcome, important changes or findings, blockers, and concrete next steps. Keep it focused enough for the Remote UI Summary page: usually 1-3 short paragraphs or bullets. After summarized, do a secondary check to not miss important details."
     },
     "inquiry": {
       "type": ["object", "null"],

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -69,7 +69,9 @@ module HQ
       end
     end
 
-    FINAL_OUTPUT_CHECKLIST = "Before final structured output, check whether this run created or referenced a PR, " \
+    FINAL_OUTPUT_CHECKLIST = "For `summary`, write a concise operator-facing Markdown summary of the outcome, " \
+                             "key changes or findings, blockers, and next steps in 1-3 short paragraphs or bullets. " \
+                             "Before final structured output, check whether this run created or referenced a PR, " \
                              "plan, review, report, markdown file, image, or other durable artifact. " \
                              "If yes, include it in `attachments`: use `type: file` with `path` for local files, " \
                              "or `type: link` with an http(s) `url` for web links."

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -876,7 +876,7 @@ module HQ
 
     def conversation(key)
       target = find_agent!(key)
-      blocks = AgentChatLog.new(target).chat_blocks
+      blocks = AgentChatLog.new(target).chat_blocks.reject { |block| block.kind == :run_summary }
       return conversation_messages(target) if blocks.empty?
 
       blocks.map do |block|

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1454,7 +1454,7 @@ button.restart-server-button {
 }
 
 .message-markdown-fallback,
-.summary-markdown-fallback {
+.agent-summary-fallback {
   margin: 0;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -1804,6 +1804,10 @@ button.restart-server-button {
   min-width: 0;
 }
 
+.agent-summary-viewer {
+  align-self: start;
+}
+
 .agent-attachment-body {
   display: grid;
   min-width: 0;
@@ -1837,6 +1841,11 @@ button.restart-server-button {
   font-size: 13px;
   line-height: 1.5;
   white-space: pre-wrap;
+}
+
+.agent-summary-markdown-viewer,
+.agent-summary-fallback {
+  max-width: 72ch;
 }
 
 .attachment-image-viewer {
@@ -2154,11 +2163,6 @@ button.restart-server-button {
     padding: 6px 10px calc(10px + env(safe-area-inset-bottom, 0px));
   }
 
-  .agent-dock:has(.inquiry-form) .agent-summary-panel {
-    max-height: min(18dvh, 130px);
-    padding: 7px 8px;
-  }
-
   .agent-dock:has(.inquiry-form) .inquiry-form {
     min-height: 0;
     max-height: min(50dvh, 430px);
@@ -2174,54 +2178,6 @@ button.restart-server-button {
     padding-top: 4px;
     background: color-mix(in srgb, var(--panel) 97%, transparent);
   }
-}
-
-.agent-summary-panel {
-  max-height: min(22dvh, 160px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 9px 10px;
-  background: var(--panel-soft);
-}
-
-.agent-summary-panel > p,
-.agent-summary-panel .summary-markdown-fallback {
-  margin: 0;
-  overflow-wrap: anywhere;
-  color: var(--text);
-  font-size: 13px;
-  line-height: 1.4;
-  white-space: pre-wrap;
-}
-
-.summary-markdown-viewer {
-  min-width: 0;
-  max-width: 100%;
-  font-size: 13px;
-  line-height: 1.45;
-}
-
-.summary-markdown-viewer h1,
-.summary-markdown-viewer h2,
-.summary-markdown-viewer h3,
-.summary-markdown-viewer h4,
-.summary-markdown-viewer h5,
-.summary-markdown-viewer h6 {
-  margin: 0 0 7px;
-  font-size: 13px;
-  line-height: 1.25;
-}
-
-.summary-markdown-viewer p,
-.summary-markdown-viewer ul,
-.summary-markdown-viewer ol,
-.summary-markdown-viewer blockquote,
-.summary-markdown-viewer pre,
-.summary-markdown-viewer table,
-.summary-markdown-viewer hr {
-  margin-bottom: 8px;
 }
 
 .go-recent-fab {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -342,8 +342,6 @@ const state = {
   lastScrollY: 0,
   navHidden: false,
   scrollTicking: false,
-  openSummaryAfterAutoScroll: false,
-  preserveSummaryOnAutoScroll: false,
   renderedRouteKey: null,
   renderedViewHtml: "",
   agentSettingsOpen: false,
@@ -475,6 +473,9 @@ function parseRoute() {
   if (parts[0] === "agent" && parts[1] && parts[2] === "archive") {
     return { type: "agentArchive", key: parts[1] };
   }
+  if (parts[0] === "agent" && parts[1] && parts[2] === "summary") {
+    return { type: "agentSummary", key: parts[1] };
+  }
   if (parts[0] === "agent" && parts[1] && parts[2] === "attachment" && parts[3]) {
     return { type: "agentAttachment", key: parts[1], attachmentId: parts[3] };
   }
@@ -496,6 +497,7 @@ function parseRoute() {
 
 function routeHash(route) {
   if (route.type === "agent") return `#agent/${encodeURIComponent(route.key)}`;
+  if (route.type === "agentSummary") return `#agent/${encodeURIComponent(route.key)}/summary`;
   if (route.type === "agentForm" && route.mode === "edit") {
     return `#agent/${encodeURIComponent(route.key)}/edit`;
   }
@@ -550,13 +552,13 @@ function currentTopTab(route) {
   if (route.type === "tab") return route.tab;
   if (route.type === "project" || route.type === "guard") return "agents";
   if (route.type === "agentForm") return "agents";
-  if (route.type === "agent" || route.type === "agentAttachment" || route.type === "agentArchive" || route.type === "attachment") return "agents";
+  if (route.type === "agent" || route.type === "agentSummary" || route.type === "agentAttachment" || route.type === "agentArchive" || route.type === "attachment") return "agents";
   if (route.type === "hiddenSettings") return "settings";
   return "now";
 }
 
 function agentShellRoute(route) {
-  return route.type === "agent" || route.type === "agentAttachment";
+  return route.type === "agent" || route.type === "agentSummary" || route.type === "agentAttachment";
 }
 
 function pollDelay() {
@@ -564,7 +566,7 @@ function pollDelay() {
   if (document.hidden) return intervals.hiddenMs;
   if (state.failureCount > 0) return Math.min(3_000 * (2 ** state.failureCount), 20_000);
   const route = parseRoute();
-  const routeAgent = route.type === "agent" || route.type === "agentAttachment" ? findAgent(route.key) : null;
+  const routeAgent = agentShellRoute(route) ? findAgent(route.key) : null;
   if (routeAgent?.running) return intervals.runningAgentMs;
   if (state.agents.some((agent) => agent.running)) return intervals.activeAgentMs;
   return intervals.idleMs;
@@ -601,9 +603,8 @@ async function refresh(options = {}) {
       apiGet("/schedules"),
     ]);
     const nextAgents = agentsData.agents || [];
-    if (shouldOpenSummaryForSucceededAgent(state.agents, nextAgents)) {
-      state.openSummaryAfterAutoScroll = true;
-    }
+    const routeBeforeRefresh = parseRoute();
+    const shouldOpenSucceededSummary = shouldOpenSummaryForSucceededAgent(state.agents, nextAgents, routeBeforeRefresh);
     state.agents = nextAgents;
     syncBulkArchiveSelection();
     state.projects = projectsData.projects || [];
@@ -615,6 +616,11 @@ async function refresh(options = {}) {
     els.authPanel.classList.add("hidden");
     await ensureRouteData(options);
     setConnection(refreshedText());
+    const currentRoute = parseRoute();
+    if (shouldOpenSucceededSummary && currentRoute.type === "agent" && currentRoute.key === routeBeforeRefresh.key) {
+      navigate({ type: "agentSummary", key: currentRoute.key });
+      return;
+    }
     render();
   } catch (error) {
     state.failureCount += 1;
@@ -632,7 +638,7 @@ async function refresh(options = {}) {
 
 async function ensureRouteData(options = {}) {
   const route = parseRoute();
-  if (route.type === "agent" || route.type === "agentAttachment") {
+  if (agentShellRoute(route)) {
     const agent = findAgent(route.key);
     if (agent) {
       await Promise.all([
@@ -791,10 +797,10 @@ function render() {
   els.view.classList.toggle("no-nav", subpage || onboarding);
   els.view.classList.toggle("onboarding-content", onboarding);
   els.view.classList.toggle("detail-page", subpage && !onboarding);
-  els.view.classList.toggle("agent-detail", !onboarding && (route.type === "agent" || route.type === "agentAttachment"));
+  els.view.classList.toggle("agent-detail", !onboarding && agentShellRoute(route));
   els.header.classList.toggle("detail-header", subpage && !onboarding);
   els.header.classList.remove("header-hidden");
-  if (route.type !== "agent" && route.type !== "agentAttachment") setAgentSettings(null);
+  if (!agentShellRoute(route)) setAgentSettings(null);
   syncDetailHeaderLayout();
   if (onboarding) {
     setNavHidden(false);
@@ -809,15 +815,14 @@ function render() {
   setActiveNav(currentTopTab(route));
 
   if (route.type === "agent") {
-    if (state.renderedRouteKey !== routeStateKey(route)) state.openSummaryAfterAutoScroll = true;
     const shouldScrollConversation = shouldAutoScrollAgentConversation(route.key);
     renderAgent(route.key);
     if (shouldScrollConversation) queueAgentConversationBottomScroll();
+  } else if (route.type === "agentSummary") {
+    renderAgent(route.key, { summaryMode: true });
   } else if (route.type === "agentAttachment") {
-    state.openSummaryAfterAutoScroll = false;
     renderAgent(route.key, { attachmentId: route.attachmentId });
   } else if (route.type === "attachment") {
-    state.openSummaryAfterAutoScroll = false;
     const attachment = state.attachmentDetails[route.id] || attachmentById(route.id);
     if (attachment?.agent_key && findAgent(attachment.agent_key)) {
       els.view.classList.add("agent-detail");
@@ -826,28 +831,20 @@ function render() {
       renderAttachmentViewer(route.id);
     }
   } else if (route.type === "project") {
-    state.openSummaryAfterAutoScroll = false;
     renderProject(route.key);
   } else if (route.type === "agentForm") {
-    state.openSummaryAfterAutoScroll = false;
     renderAgentForm(route);
   } else if (route.type === "agentArchive") {
-    state.openSummaryAfterAutoScroll = false;
     renderAgentArchive(route.key);
   } else if (route.type === "guard") {
-    state.openSummaryAfterAutoScroll = false;
     renderGuardedAction(route.key, route.action);
   } else if (route.type === "hiddenSettings") {
-    state.openSummaryAfterAutoScroll = false;
     renderHiddenSettings();
   } else if (route.tab === "agents") {
-    state.openSummaryAfterAutoScroll = false;
     renderAgents();
   } else if (route.tab === "settings") {
-    state.openSummaryAfterAutoScroll = false;
     renderSetup();
   } else {
-    state.openSummaryAfterAutoScroll = false;
     renderNow();
   }
 }
@@ -874,6 +871,7 @@ function replaceView(html) {
 
 function routeStateKey(route) {
   if (route.type === "agent") return `agent:${route.key}`;
+  if (route.type === "agentSummary") return `agent-summary:${route.key}`;
   if (route.type === "agentAttachment") return `agent-attachment:${route.key}:${route.attachmentId}`;
   if (route.type === "attachment") return `attachment:${route.id}`;
   if (route.type === "agentForm" && route.mode === "create") return `agent-form:create:${route.projectKey}`;
@@ -969,8 +967,6 @@ function syncPreservedOpenState(element, open) {
     document.querySelector("[data-toggle-attachments]")?.setAttribute("aria-expanded", open ? "true" : "false");
   } else if (element.matches("[data-skill-flyout]")) {
     document.querySelector("[data-toggle-skills]")?.setAttribute("aria-expanded", open ? "true" : "false");
-  } else if (element.matches("[data-agent-summary]")) {
-    document.querySelector("[data-toggle-summary]")?.setAttribute("aria-expanded", open ? "true" : "false");
   }
 }
 
@@ -1134,7 +1130,7 @@ function markdownHeadingSlug(text) {
 
 function handleMarkdownAnchorClick(anchor, event) {
   const route = parseRoute();
-  if (!["agent", "agentAttachment", "attachment"].includes(route.type)) return false;
+  if (!["agent", "agentSummary", "agentAttachment", "attachment"].includes(route.type)) return false;
 
   const href = String(anchor.getAttribute("href") || "");
   if (!href.startsWith("#") || href === "#") return false;
@@ -1696,24 +1692,43 @@ function renderAgent(key, options = {}) {
   const blocks = state.conversations[key]?.blocks || [];
   const skills = skillsForAgent(agent);
   const attachmentId = options.attachmentId || "";
+  const summaryMode = options.summaryMode === true;
+  const focusedMode = Boolean(attachmentId) || summaryMode;
+  const body = summaryMode
+    ? renderAgentSummaryView(agent)
+    : attachmentId
+      ? renderAgentAttachmentView(agent, attachmentId)
+      : renderAgentConversationView(agent, blocks);
   setHeader(agent.name || agent.key, agentHeaderLabel(agent), "A");
   setAgentSettings(agent);
   replaceView(`
-    ${attachmentId ? renderAgentAttachmentView(agent, attachmentId) : renderAgentConversationView(agent, blocks)}
+    ${body}
     <section class="agent-dock" data-agent-dock>
-      <section class="agent-summary-panel" data-agent-summary data-preserve-open data-preserve-scroll data-state-key="agent-summary" aria-label="Summary">
-        ${renderAgentSummaryContent(agent)}
-      </section>
-      ${agent.latest_inquiry ? renderInquiryForm(agent, { attachmentMode: Boolean(attachmentId) }) : renderAgentComposer(agent, skills, { attachmentMode: Boolean(attachmentId) })}
+      ${agent.latest_inquiry ? renderInquiryForm(agent, { attachmentMode: focusedMode }) : renderAgentComposer(agent, skills, { attachmentMode: focusedMode })}
     </section>
   `);
-  if (!attachmentId) scheduleAgentReading(agent);
+  if (!focusedMode) scheduleAgentReading(agent);
+}
+
+function renderAgentSummaryView(agent) {
+  const meta = [statusLabel(agent), timeShort(agent.finished_at || agent.updated_at || agent.created_at)].filter(Boolean).join(" / ");
+  return `
+    <section class="agent-attachment-shell agent-summary-shell" data-agent-summary-page>
+      <section class="attachment-viewer agent-attachment-viewer agent-summary-viewer" aria-label="Summary">
+        <div class="agent-attachment-body">
+          <div class="section-label"><strong>Summary</strong><span>${escapeHtml(meta || agent.name || agent.key)}</span></div>
+          ${renderAgentSummaryContent(agent)}
+        </div>
+      </section>
+    </section>
+    ${renderAgentFloatingActions(agent, { summary: false })}
+  `;
 }
 
 function renderAgentSummaryContent(agent) {
   return renderMarkdown(agentSummaryText(agent), {
-    viewerClassName: "markdown-viewer summary-markdown-viewer",
-    fallbackClassName: "summary-markdown-fallback",
+    viewerClassName: "markdown-viewer agent-summary-markdown-viewer",
+    fallbackClassName: "attachment-text-viewer agent-summary-fallback",
     emptyText: "No run summary yet.",
   });
 }
@@ -1724,7 +1739,7 @@ function renderAgentConversationView(agent, blocks) {
       ${blocks.length ? renderConversationBlocks(blocks) : emptyState("No conversation yet", "Send a prompt to start or continue the agent.")}
     </div>
     <div data-conversation-recent aria-hidden="true"></div>
-    ${renderAgentFloatingActions({ recent: true })}
+    ${renderAgentFloatingActions(agent, { recent: true })}
   `;
 }
 
@@ -1757,7 +1772,7 @@ function renderAgentAttachmentView(agent, attachmentId) {
 
   return `
     ${body}
-    ${renderAgentFloatingActions()}
+    ${renderAgentFloatingActions(agent)}
   `;
 }
 
@@ -1811,21 +1826,24 @@ function renderAttachmentNavigationItem(agent, attachment, currentAttachmentId, 
   `;
 }
 
-function renderAgentFloatingActions(options = {}) {
+function renderAgentFloatingActions(agent, options = {}) {
+  const summary = options.summary === false ? "" : renderAgentSummaryToggle(agent);
   const recent = options.recent
     ? `<button class="agent-floating-pill go-recent-fab hidden" type="button" data-go-recent>Go to recent</button>`
     : "";
+  const actions = `${summary}${recent}`;
+  if (!actions) return "";
+
   return `
     <div class="agent-floating-actions" aria-label="Agent shortcuts">
-      ${renderAgentSummaryToggle()}
-      ${recent}
+      ${actions}
     </div>
   `;
 }
 
-function renderAgentSummaryToggle() {
+function renderAgentSummaryToggle(agent) {
   return `
-    <button class="agent-floating-pill summary-fab" type="button" data-toggle-summary aria-expanded="true">
+    <button class="agent-floating-pill summary-fab" type="button" data-open-agent-summary="${escapeAttr(agent.key)}">
       ${iconSvg("scanText")}
       <span>Summary</span>
     </button>
@@ -3230,7 +3248,7 @@ function loadExternalScript(src) {
 
 function renderMarkdownRoute() {
   const route = parseRoute();
-  if (route.type === "agent" || route.type === "agentAttachment") {
+  if (route.type === "agent" || route.type === "agentSummary" || route.type === "agentAttachment") {
     state.renderedViewHtml = "";
     render();
     return;
@@ -3523,7 +3541,7 @@ function toggleUnreadPanel() {
   if (state.unreadPanelOpen) {
     state.agentSettingsOpen = false;
     const route = parseRoute();
-    const currentAgent = route.type === "agent" || route.type === "agentAttachment" ? findAgent(route.key) : null;
+    const currentAgent = agentShellRoute(route) ? findAgent(route.key) : null;
     setAgentSettings(currentAgent);
   }
   syncUnreadAlert();
@@ -3637,7 +3655,7 @@ function setAgentProjectButton(agent) {
 
 function toggleAgentSettings() {
   const route = parseRoute();
-  const agent = route.type === "agent" || route.type === "agentAttachment" ? findAgent(route.key) : null;
+  const agent = agentShellRoute(route) ? findAgent(route.key) : null;
   if (!agent) return;
 
   state.agentSettingsOpen = !state.agentSettingsOpen;
@@ -3722,7 +3740,6 @@ function handleScrollDirection() {
   const route = parseRoute();
   const currentY = Math.max(0, window.scrollY);
   const delta = currentY - state.lastScrollY;
-  if (Math.abs(delta) > 0 && !state.preserveSummaryOnAutoScroll) closeAgentSummary();
   if (route.type !== "tab") {
     state.lastScrollY = window.scrollY;
     setNavHidden(false);
@@ -4186,8 +4203,7 @@ function agentSucceeded(agent) {
   return agent?.status === "succeeded" || agent?.status === "success" || agent?.last_result === "success";
 }
 
-function shouldOpenSummaryForSucceededAgent(previousAgents, nextAgents) {
-  const route = parseRoute();
+function shouldOpenSummaryForSucceededAgent(previousAgents, nextAgents, route = parseRoute()) {
   if (route.type !== "agent") return false;
 
   const previous = previousAgents.find((agent) => agent.key === route.key);
@@ -4218,7 +4234,6 @@ function shouldAutoScrollAgentConversation(agentKey) {
   const previous = state.conversationTailMarkers[agentKey];
   if (marker !== null) state.conversationTailMarkers[agentKey] = marker;
 
-  if (state.openSummaryAfterAutoScroll) return true;
   return marker !== null && previous !== undefined && marker !== previous;
 }
 
@@ -4541,6 +4556,7 @@ els.nav.addEventListener("click", (event) => {
 els.back.addEventListener("click", () => {
   const route = parseRoute();
   if (route.type === "agent") navigate({ type: "tab", tab: "agents" });
+  else if (route.type === "agentSummary") navigate({ type: "agent", key: route.key });
   else if (route.type === "agentAttachment") navigate({ type: "agent", key: route.key });
   else if (route.type === "attachment") {
     const attachment = attachmentById(route.id) || state.attachmentDetails[route.id];
@@ -4619,12 +4635,11 @@ els.view.addEventListener("click", (event) => {
     closeSkillFlyout();
   }
 
-  const summaryToggle = event.target.closest("[data-toggle-summary]");
-  if (summaryToggle) {
-    toggleAgentSummary();
+  const summaryButton = event.target.closest("[data-open-agent-summary]");
+  if (summaryButton) {
+    navigate({ type: "agentSummary", key: summaryButton.dataset.openAgentSummary });
     return;
   }
-  if (!event.target.closest("[data-agent-summary]")) closeAgentSummary();
 
   const markdownAnchor = event.target.closest(".markdown-viewer a[href^=\"#\"]");
   if (markdownAnchor && handleMarkdownAnchorClick(markdownAnchor, event)) return;
@@ -4835,9 +4850,6 @@ document.addEventListener("click", (event) => {
 document.addEventListener("click", (event) => {
   if (!agentShellRoute(parseRoute())) return;
 
-  if (!event.target.closest("[data-agent-summary]") && !event.target.closest("[data-toggle-summary]")) {
-    closeAgentSummary();
-  }
   if (!event.target.closest("[data-attachment-flyout]") && !event.target.closest("[data-toggle-attachments]")) {
     closeAttachmentFlyout();
   }
@@ -5305,27 +5317,6 @@ function setAttachmentFlyoutOpen(open) {
   button.setAttribute("aria-expanded", open ? "true" : "false");
 }
 
-function toggleAgentSummary() {
-  const summary = document.querySelector("[data-agent-summary]");
-  if (!summary) return;
-
-  setAgentSummaryOpen(summary.classList.contains("hidden"));
-}
-
-function closeAgentSummary() {
-  setAgentSummaryOpen(false);
-}
-
-function setAgentSummaryOpen(open) {
-  const summary = document.querySelector("[data-agent-summary]");
-  const button = document.querySelector("[data-toggle-summary]");
-  if (!summary || !button) return;
-
-  summary.classList.toggle("hidden", !open);
-  button.setAttribute("aria-expanded", open ? "true" : "false");
-  window.requestAnimationFrame(syncAgentDockLayout);
-}
-
 function scrollConversationToRecent() {
   if (!document.querySelector("[data-conversation-recent]")) return;
 
@@ -5345,22 +5336,13 @@ function scrollAgentConversationToBottom() {
   if (!document.querySelector("[data-conversation-recent]")) return;
 
   const root = document.scrollingElement || document.documentElement;
-  const openSummary = state.openSummaryAfterAutoScroll;
-  state.preserveSummaryOnAutoScroll = true;
   root.scrollTo({ top: root.scrollHeight, behavior: "auto" });
   state.lastScrollY = Math.max(0, window.scrollY);
   window.requestAnimationFrame(() => {
-    if (openSummary) {
-      setAgentSummaryOpen(true);
-      state.openSummaryAfterAutoScroll = false;
-      syncAgentDockLayout();
-      root.scrollTo({ top: root.scrollHeight, behavior: "auto" });
-    }
     state.lastScrollY = Math.max(0, window.scrollY);
     window.requestAnimationFrame(() => {
       state.lastScrollY = Math.max(0, window.scrollY);
       window.setTimeout(() => {
-        state.preserveSummaryOnAutoScroll = false;
         updateGoRecentVisibility();
       }, 0);
     });
@@ -5380,11 +5362,6 @@ window.addEventListener("scroll", onScroll, { passive: true });
 
 window.addEventListener("focusin", () => {
   showNav();
-  if (agentShellRoute(parseRoute()) &&
-      !document.activeElement?.closest?.("[data-agent-summary]") &&
-      !document.activeElement?.closest?.("[data-toggle-summary]")) {
-    closeAgentSummary();
-  }
   if (agentShellRoute(parseRoute()) &&
       !document.activeElement?.closest?.("[data-attachment-flyout]") &&
       !document.activeElement?.closest?.("[data-toggle-attachments]")) {

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -16,6 +16,7 @@ module ManagedAgentTest
     assert_fallback_summary_uses_assistant_message_not_tool_json
     assert_structured_output_summary_beats_later_agent_message
     assert_final_output_checklist_is_ephemeral_execution_context
+    assert_agent_result_schema_describes_summary
     assert_initial_user_message_attachments_seed_memory
     assert_start_records_missing_harness_without_spawning
     assert_agent_runner_warns_when_command_cannot_execute
@@ -376,6 +377,8 @@ module ManagedAgentTest
   def assert_final_output_checklist_is_ephemeral_execution_context
     Dir.mktmpdir("hq-managed-agent-checklist-test") do |dir|
       checklist = HQ::ManagedAgent::FINAL_OUTPUT_CHECKLIST
+      assert(checklist.include?("For `summary`, write a concise operator-facing Markdown summary"),
+             "final output guidance should explain the summary field")
       log_path = File.join(dir, "checklist.raw.log")
 
       agent = HQ::ManagedAgent.new(
@@ -436,6 +439,15 @@ module ManagedAgentTest
       assert(resumed_user_event["content"] == "Attach the PR",
              "native resume memory should keep the user message unchanged")
     end
+  end
+
+  def assert_agent_result_schema_describes_summary
+    schema_path = File.expand_path("../config/schemas/agent_result.json", __dir__)
+    schema = JSON.parse(File.read(schema_path))
+    description = schema.dig("properties", "summary", "description").to_s
+
+    assert(description.include?("Remote UI Summary page"),
+           "agent result schema should describe how to write the summary field")
   end
 
   def assert_initial_user_message_attachments_seed_memory

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -20,7 +20,7 @@ module RemoteServerTest
     assert_remote_agent_payload_includes_attachments
     assert_remote_prompt_accepts_uploaded_attachments
     assert_remote_prompt_start_accepts_dash_prefixed_message
-    assert_remote_agent_conversation_keeps_run_summary
+    assert_remote_agent_conversation_hides_run_summary
     assert_remote_project_payloads_include_status_and_detail
     assert_remote_hidden_settings_filter_projects_and_agents
     assert_remote_schedule_routes
@@ -644,7 +644,7 @@ module RemoteServerTest
     end
   end
 
-  def assert_remote_agent_conversation_keeps_run_summary
+  def assert_remote_agent_conversation_hides_run_summary
     Dir.mktmpdir("hq-remote-test") do |dir|
       old_agents_file = replace_constant(HQ, :AGENTS_FILE, File.join(dir, "managed_agents.json"))
       old_logs_dir = replace_constant(HQ, :AGENT_LOGS_DIR, File.join(dir, "agents"))
@@ -665,16 +665,27 @@ module RemoteServerTest
         "agent" => "codex"
       )
       agent = HQ::AgentStore.new(registry.projects).load.find { |item| item.key == created[:key] }
-      HQ::AgentMemory.new(agent).append_run_summary!(
+      memory = HQ::AgentMemory.new(agent)
+      memory.append_assistant_message!(
+        "The normal assistant response should stay in the conversation.",
+        created_at: Time.now - 1
+      )
+      memory.append_run_summary!(
         summary: "A detailed run summary that should stay readable in the conversation.",
         status: "succeeded",
         created_at: Time.now
       )
 
-      summary = service.conversation(created[:key]).find { |block| block[:kind] == "run_summary" }
-      assert(summary, "expected Remote UI conversation payload to include the run summary")
-      assert(summary[:content].include?("A detailed run summary"),
-             "expected the full run summary to remain readable in the conversation")
+      conversation = service.conversation(created[:key])
+      summary = conversation.find { |block| block[:kind] == "run_summary" }
+      assistant = conversation.find { |block| block[:role] == "assistant" }
+      memory_summary = memory.events.find { |event| event["type"] == "run_summary" }
+
+      assert(summary.nil?, "expected Remote UI conversation payload to hide run summary blocks")
+      assert(assistant&.dig(:content)&.include?("normal assistant response"),
+             "expected normal assistant messages to remain visible in the conversation")
+      assert(memory_summary&.dig("content")&.include?("A detailed run summary"),
+             "expected run summaries to remain persisted for the Summary page")
     ensure
       replace_constant(HQ, :AGENTS_FILE, old_agents_file) if old_agents_file
       replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
@@ -1235,9 +1246,9 @@ module RemoteServerTest
            "expected Agent settings to hide edit/archive actions behind the settings panel")
     assert(css[:body].include?(".agent-form"), "expected Remote UI to style agent lifecycle forms")
     assert(css[:body].include?(".inline-icon-button"), "expected Remote UI action buttons to support SVG icons")
-    assert(css[:body].include?(".agent-summary-panel"), "expected Agent summary to render above the composer")
-    assert(css[:body].include?("max-height: min(22dvh, 160px)"),
-           "expected Agent summary to be constrained and scrollable")
+    assert(css[:body].include?(".agent-summary-viewer"), "expected Agent summary to render as a focused page")
+    assert(css[:body].include?("max-width: 72ch"),
+           "expected Agent summary text to keep a readable measure")
     assert(css[:body].include?(".inquiry-form"), "expected Remote UI to style structured inquiry forms")
     assert(css[:body].include?(".inquiry-banner"), "expected Remote UI inquiry forms to show a decision banner")
     assert(css[:body].include?(".inquiry-mark"), "expected Remote UI inquiry forms to style the inquiry icon")
@@ -1265,7 +1276,7 @@ module RemoteServerTest
     assert(css[:body].include?(".row-title .relative-time.recent"),
            "expected Remote UI to color recent list timestamps")
     assert(css[:body].include?("max-height: min(72dvh, 620px)"),
-           "expected mobile inquiry docks to leave room for the summary")
+           "expected mobile inquiry docks to stay within a compact viewport")
     assert(css[:body].include?("max-height: min(24dvh, 220px)"),
            "expected mobile inquiry fields to scroll in a compact viewport")
     assert(css[:body].include?("-webkit-line-clamp: 3"),
@@ -1289,13 +1300,13 @@ module RemoteServerTest
     assert(css[:body].include?(".message.user .message-content {\n  text-align: left;"),
            "expected user chat message text to stay readable with left alignment")
     assert(css[:body].include?(".message-content.markdown-message-content"),
-           "expected assistant and summary chat messages to render markdown with message-scoped layout")
+           "expected assistant and legacy summary chat messages to render markdown with message-scoped layout")
     assert(css[:body].include?(".message-content {\n  min-width: 0;"),
            "expected chat message content to allow markdown blocks to shrink inside the viewport")
     assert(css[:body].include?(".message-markdown-viewer"),
-           "expected assistant and summary chat markdown to have compact message styling")
-    assert(css[:body].include?(".summary-markdown-viewer"),
-           "expected Agent summary markdown to have compact dock styling")
+           "expected assistant and legacy summary chat markdown to have compact message styling")
+    assert(css[:body].include?(".agent-summary-markdown-viewer"),
+           "expected Agent summary markdown to use focused page styling")
     assert(css[:body].include?("font-weight: 700"),
            "expected chat labels to render bold")
     assert(css[:body].include?(".message-group"),
@@ -1571,22 +1582,25 @@ module RemoteServerTest
     assert(js[:body].include?('state.refreshing ? iconSvg("hourglass") : iconSvg(state.headerSubtitleIcon)'),
            "expected refresh to swap the subtitle icon without shifting the text")
     assert(js[:body].include?("function statusIcon"), "expected readiness marks to use SVG status icons")
-    assert(js[:body].include?("data-agent-summary"), "expected Agent detail to expose a docked Summary panel")
-    assert(js[:body].include?("data-preserve-scroll"),
-           "expected Agent summary scroll position to survive polling renders")
-    assert(js[:body].include?("function toggleAgentSummary"), "expected Summary to be toggleable")
+    assert(js[:body].include?("data-agent-summary-page"), "expected Agent detail to expose a focused Summary page")
+    assert(js[:body].include?("data-open-agent-summary"),
+           "expected Agent summary shortcut to navigate to the focused Summary page")
+    assert(js[:body].include?("function renderAgentSummaryView"),
+           "expected Agent summary to render as its own view")
+    assert(!js[:body].include?("function toggleAgentSummary"),
+           "expected Summary to use route navigation instead of a dock toggle")
     assert(js[:body].include?("function renderAgentSummaryToggle"),
            "expected Summary toggle markup to be shared across agent views")
     assert(js[:body].include?("function renderAgentFloatingActions"),
            "expected Agent detail floating actions to be reusable")
-    assert(js[:body].include?("function closeAgentSummary"), "expected Summary to close from outside interactions")
+    assert(!js[:body].include?("function closeAgentSummary"), "expected Summary page to avoid outside-click panel handling")
     assert(!js[:body].include?("Current activity"), "expected Current activity copy to move into Summary naming")
     assert(js[:body].include?("data-preserve-open"), "expected floating controls to preserve open state")
     assert(js[:body].include?("openElements"), "expected polling snapshots to preserve floating control state")
     assert(js[:body].include?("renderedViewHtml"),
            "expected polling renders to skip unchanged Remote UI view HTML")
     assert(js[:body].include?("scrollContainers"),
-           "expected polling snapshots to preserve summary scroll position")
+           "expected polling snapshots to preserve scroll positions for restored controls")
     assert(js[:body].include?("function syncPreservedOpenState"),
            "expected restored floating controls to update related button state")
     assert(js[:body].include?("const discovered = state.skills"),
@@ -1610,16 +1624,16 @@ module RemoteServerTest
            "expected Agent detail to scroll conversations to the recent sentinel")
     assert(js[:body].include?("function scrollAgentConversationToBottom"),
            "expected Agent detail to auto-scroll to the bottom after agent-page renders")
-    assert(js[:body].include?("preserveSummaryOnAutoScroll"),
-           "expected automatic conversation scrolling to keep Summary open")
-    assert(js[:body].include?("&& !state.preserveSummaryOnAutoScroll"),
-           "expected manual scrolling to keep closing Summary")
-    assert(js[:body].include?("openSummaryAfterAutoScroll"),
-           "expected first-open Agent detail scrolling to reopen Summary after landing at the bottom")
+    assert(!js[:body].include?("preserveSummaryOnAutoScroll"),
+           "expected Summary page routing to avoid preserving a docked Summary panel")
+    assert(!js[:body].include?("openSummaryAfterAutoScroll"),
+           "expected Agent detail scrolling to avoid reopening a docked Summary panel")
     assert(js[:body].include?("function shouldOpenSummaryForSucceededAgent"),
-           "expected Agent detail to open Summary when the active agent succeeds")
+           "expected Agent detail to open the Summary page when the active agent succeeds")
     assert(js[:body].include?("!agentSucceeded(previous) && agentSucceeded(next)"),
            "expected Summary to open only on a success transition")
+    assert(js[:body].include?('navigate({ type: "agentSummary", key: currentRoute.key });'),
+           "expected successful agent transitions to navigate to the Summary page")
     assert(js[:body].include?("conversationTailMarkers"),
            "expected Agent detail to remember the latest conversation tail marker")
     assert(js[:body].include?("function markAgentReading"),
@@ -1714,9 +1728,9 @@ module RemoteServerTest
            "expected Remote UI to render attachment detail routes")
     assert(js[:body].include?("function renderAgentAttachmentView"),
            "expected Agent detail to render attachment views without losing the composer")
-    assert(js[:body].include?("${renderAgentFloatingActions()}"),
-           "expected Agent detail attachment view to expose the Summary toggle")
-    assert(js[:body].include?("renderAgentFloatingActions({ recent: true })"),
+    assert(js[:body].include?("${renderAgentFloatingActions(agent)}"),
+           "expected Agent detail attachment view to expose the Summary page shortcut")
+    assert(js[:body].include?("renderAgentFloatingActions(agent, { recent: true })"),
            "expected Agent conversation view to keep the Go to recent shortcut")
     assert(js[:body].include?("function renderAttachmentNavigationDrawer"),
            "expected Agent detail attachment view to render a navigation drawer")
@@ -1728,6 +1742,10 @@ module RemoteServerTest
            "expected Attachment viewer markup to be reusable inside Agent detail")
     assert(js[:body].include?('return { type: "agentAttachment", key: parts[1], attachmentId: parts[3] };'),
            "expected Remote UI to support in-agent attachment routes")
+    assert(js[:body].include?('return { type: "agentSummary", key: parts[1] };'),
+           "expected Remote UI to support in-agent Summary routes")
+    assert(js[:body].include?('if (route.type === "agentSummary") return `#agent/${encodeURIComponent(route.key)}/summary`;'),
+           "expected Remote UI to generate in-agent Summary route hashes")
     assert(js[:body].include?('routeHash({ type: "agentAttachment", key: agentKey, attachmentId: id })'),
            "expected document attachments to open inside the owning Agent detail")
     assert(js[:body].include?("function formDraftRouteKey"),
@@ -1757,17 +1775,17 @@ module RemoteServerTest
     assert(js[:body].include?("function renderMarkdown"),
            "expected markdown attachments to render as markdown")
     assert(js[:body].include?("function markdownMessageBlock"),
-           "expected assistant messages and run summaries to opt into markdown rendering")
+           "expected assistant messages and legacy run summaries to opt into markdown rendering")
     assert(js[:body].include?('block?.kind === "run_summary"'),
-           "expected run summary messages to render as markdown")
+           "expected legacy run summary blocks to render as markdown if present")
     assert(js[:body].include?('block.role === "assistant"'),
            "expected assistant messages to render as markdown")
     assert(js[:body].include?("function renderAgentSummaryContent"),
            "expected Agent summary text to render as markdown")
     assert(js[:body].include?('viewerClassName: "markdown-viewer message-markdown-viewer"'),
            "expected chat markdown to use message-scoped markdown styling")
-    assert(js[:body].include?('viewerClassName: "markdown-viewer summary-markdown-viewer"'),
-           "expected Agent summary markdown to use dock-scoped markdown styling")
+    assert(js[:body].include?('viewerClassName: "markdown-viewer agent-summary-markdown-viewer"'),
+           "expected Agent summary markdown to use focused page styling")
     assert(js[:body].include?("function renderMarkdownRoute"),
            "expected markdown parser load completion to re-render active markdown routes")
     assert(!js[:body].include?("CODE_LANGUAGE_BY_EXTENSION"),
@@ -1803,7 +1821,7 @@ module RemoteServerTest
     assert(js[:body].include?("primaryConversationBlock"),
            "expected Agent detail to keep user and assistant messages visible")
     assert(js[:body].include?('block?.kind === "run_summary"'),
-           "expected Agent detail to keep run summaries visible in the conversation")
+           "expected Agent detail to keep legacy run summary rendering compatible")
     assert(js[:body].include?("<details class=\"message-group\""),
            "expected Agent detail internal groups to be collapsed by default")
     assert(js[:body].include?("iconSvg(\"squareUserRound\")"),


### PR DESCRIPTION
## Summary

- Adds concise structured-output guidance for agent summaries and describes the `summary` schema field.
- Moves the Remote UI Summary from a docked panel to a focused `#agent/:key/summary` page styled like attachment views.
- Keeps run summaries persisted for the Summary page while filtering `run_summary` blocks out of the Remote UI conversation payload, so the main conversation remains chronological and avoids duplicate summary cards.

## Impact

The Remote UI now treats Summary as its own reading surface. The conversation view keeps normal user and assistant messages visible, while legacy `run_summary` rendering remains compatible if such blocks appear from older payloads.

## Validation

- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby -c lib/hq/remote_server.rb`
- `node --check lib/hq/remote_ui/assets/app.js`
- Isolated headless Chrome smoke test for hiding run summary text from the conversation
- `bin/test`
- `git diff --check`
