### PR TITLE
[codex] Fix Remote readiness executable resolution

### DIFF
--- a/lib/hq/domain/executable_resolver.rb
+++ b/lib/hq/domain/executable_resolver.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "constants"
+
+module HQ
+  module ExecutableResolver
+    Resolution = Struct.new(:name, :command, :path, :source, keyword_init: true) do
+      def available?
+        !path.to_s.empty?
+      end
+    end
+
+    ENV_NAMES = {
+      "claude" => "CLAUDE_BIN",
+      "codex" => "CODEX_BIN",
+      "mise" => "MISE_BIN",
+      "tailscale" => "TAILSCALE_BIN"
+    }.freeze
+
+    module_function
+
+    def resolve_tool(name)
+      tool_name = name.to_s
+      resolve(tool_name, env_name: ENV_NAMES[tool_name], fallback_paths: fallback_paths_for(tool_name))
+    end
+
+    def command_for_tool(name)
+      resolve_tool(name).command
+    end
+
+    def resolve(command, env_name: nil, fallback_paths: [])
+      name = command.to_s.strip
+      configured = env_name ? HQ.env_present(env_name, "").to_s.strip : ""
+      unless configured.empty?
+        return Resolution.new(name: name, command: configured, path: executable_path(configured), source: "env")
+      end
+
+      Array(fallback_paths).each do |candidate|
+        path = executable_path(candidate.to_s)
+        return Resolution.new(name: name, command: path, path: path, source: "fallback") if path
+      end
+
+      path = executable_path(name)
+      Resolution.new(name: name, command: path || name, path: path, source: path ? "path" : "missing")
+    end
+
+    def executable_path(command)
+      value = command.to_s.strip
+      return nil if value.empty?
+      return value if value.include?(File::SEPARATOR) && File.file?(value) && File.executable?(value)
+
+      ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |dir|
+        path = File.join(dir, value)
+        return path if File.file?(path) && File.executable?(path)
+      end
+      nil
+    end
+
+    def fallback_paths_for(name)
+      case name.to_s
+      when "claude", "codex", "mise"
+        [
+          File.join(Dir.home, ".local", "bin", name.to_s),
+          "/opt/homebrew/bin/#{name}",
+          "/usr/local/bin/#{name}"
+        ]
+      else
+        []
+      end
+    end
+  end
+end

--- a/lib/hq/domain/kamal_action.rb
+++ b/lib/hq/domain/kamal_action.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "constants"
+require_relative "executable_resolver"
 require_relative "log_paths"
 require_relative "process_liveness"
 
@@ -113,18 +114,32 @@ module HQ
       }[action.to_sym]
     end
 
+    def self.project_ready?(project_path)
+      !project_readiness_source(project_path).to_s.empty?
+    end
+
+    def self.project_readiness_source(project_path)
+      path = project_path.to_s
+      return nil if path.empty?
+
+      binstub = File.join(path, "bin", "kamal")
+      return "bin/kamal" if File.executable?(binstub)
+
+      lockfile = File.join(path, "Gemfile.lock")
+      return "Gemfile.lock" if File.file?(lockfile) && File.read(lockfile).match?(/^    kamal \(/)
+
+      gemfile = File.join(path, "Gemfile")
+      return "Gemfile" if File.file?(gemfile) && File.read(gemfile).match?(/gem ["']kamal["']/)
+
+      nil
+    rescue StandardError
+      nil
+    end
+
     private
 
     def mise_executable
-      configured = HQ.env_present("MISE_BIN", "").to_s.strip
-      return configured unless configured.empty?
-
-      candidates = [
-        File.join(Dir.home, ".local", "bin", "mise"),
-        "/opt/homebrew/bin/mise",
-        "/usr/local/bin/mise"
-      ]
-      candidates.find { |path| File.executable?(path) } || "mise"
+      ExecutableResolver.command_for_tool("mise")
     end
 
     def action_exit_success?

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -4,6 +4,7 @@ require_relative "constants"
 require_relative "log_paths"
 require_relative "attachment_normalizer"
 require_relative "agent_memory"
+require_relative "executable_resolver"
 require_relative "../harness_registry"
 require_relative "../parser"
 require_relative "agent_chat_log"
@@ -1501,27 +1502,11 @@ module HQ
     end
 
     def codex_executable
-      configured = HQ.env_present("CODEX_BIN", "").to_s.strip
-      return configured unless configured.empty?
-
-      candidates = [
-        File.join(Dir.home, ".local", "bin", "codex"),
-        "/opt/homebrew/bin/codex",
-        "/usr/local/bin/codex"
-      ]
-      candidates.find { |path| File.executable?(path) } || "codex"
+      ExecutableResolver.command_for_tool("codex")
     end
 
     def claude_executable
-      configured = HQ.env_present("CLAUDE_BIN", "").to_s.strip
-      return configured unless configured.empty?
-
-      candidates = [
-        File.join(Dir.home, ".local", "bin", "claude"),
-        "/opt/homebrew/bin/claude",
-        "/usr/local/bin/claude"
-      ]
-      candidates.find { |path| File.executable?(path) } || "claude"
+      ExecutableResolver.command_for_tool("claude")
     end
 
     def compact_agent_result_schema

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -15,6 +15,7 @@ require_relative "domain/attachment_normalizer"
 require_relative "domain/agent_attachment_store"
 require_relative "domain/agent_chat_log"
 require_relative "domain/agent_store"
+require_relative "domain/executable_resolver"
 require_relative "domain/kamal_action"
 require_relative "domain/push_notification_store"
 require_relative "domain/push_subscription_store"
@@ -1517,8 +1518,8 @@ module HQ
 
     def harness_readiness
       builtins = [
-        harness_payload("codex", ["codex"]),
-        harness_payload("claude", ["claude"])
+        resolver_payload("codex", ExecutableResolver.resolve_tool("codex")),
+        resolver_payload("claude", ExecutableResolver.resolve_tool("claude"))
       ]
       custom = HQ.custom_harnesses.values.sort_by(&:key).map { |config| custom_harness_payload(config) }
       builtins + custom
@@ -1526,37 +1527,79 @@ module HQ
 
     def tool_readiness
       [
-        harness_payload("mise", ["mise"]),
-        harness_payload("kamal", ["kamal"]),
-        harness_payload("tailscale", ["tailscale"])
+        resolver_payload("mise", ExecutableResolver.resolve_tool("mise")),
+        resolver_payload("kamal", ExecutableResolver.resolve("kamal")),
+        kamal_project_payload,
+        resolver_payload("tailscale", ExecutableResolver.resolve_tool("tailscale"))
       ]
     end
 
-    def harness_payload(name, commands)
-      missing = commands.reject { |command| executable_path(command) }
+    def resolver_payload(name, resolution)
       {
         name: name,
-        ready: missing.empty?,
-        detail: missing.empty? ? "available on PATH" : "missing #{missing.join(", ")}",
-        commands: commands
+        ready: resolution.available?,
+        detail: resolution.available? ? executable_detail(resolution) : "missing #{resolution.command}",
+        commands: [resolution.command],
+        path: resolution.path,
+        source: resolution.source
       }
     end
 
     def custom_harness_payload(config)
       command = readiness_command_for(config.command_parts)
-      available = command && executable_path(command)
+      resolution = command ? ExecutableResolver.resolve(command) : nil
+      available = resolution&.available?
       detail = if available
-                 "adapter #{config.adapter}; #{command} available on PATH"
+                 "adapter #{config.adapter}; #{command} #{executable_detail(resolution)}"
                else
                  "adapter #{config.adapter}; missing #{command || "execution command"}"
                end
       {
         name: config.key,
-        ready: available ? true : false,
+        ready: resolution&.available? ? true : false,
         detail: detail,
         commands: config.command_parts,
-        adapter: config.adapter
+        adapter: config.adapter,
+        path: resolution&.path,
+        source: resolution&.source
       }
+    end
+
+    def executable_detail(resolution)
+      case resolution.source
+      when "path"
+        "available on PATH: #{resolution.path}"
+      else
+        "available at #{resolution.path}"
+      end
+    end
+
+    def kamal_project_payload
+      app_projects = @projects.select(&:apps_enabled?)
+      ready_projects = app_projects.select { |project| KamalAction.project_ready?(project.path) }
+      ready = app_projects.empty? || ready_projects.length == app_projects.length
+      {
+        name: "kamal-projects",
+        ready: ready,
+        detail: kamal_project_detail(app_projects, ready_projects),
+        commands: ["bin/kamal", "bundle exec kamal"],
+        project_count: app_projects.length,
+        ready_project_count: ready_projects.length
+      }
+    end
+
+    def kamal_project_detail(app_projects, ready_projects)
+      return "no app projects configured" if app_projects.empty?
+
+      ready_count = ready_projects.length
+      total = app_projects.length
+      if ready_count == total
+        sources = ready_projects.map { |project| KamalAction.project_readiness_source(project.path) }.compact.uniq
+        return "#{ready_count}/#{total} app project(s) ready via #{sources.join(", ")}"
+      end
+      return "missing project bin/kamal or Kamal gem dependency for #{total} app project(s)" if ready_count.zero?
+
+      "#{ready_count}/#{total} app project(s) ready; #{total - ready_count} missing project Kamal"
     end
 
     def readiness_command_for(parts)
@@ -1565,15 +1608,6 @@ module HQ
       return values.first unless values.first == "env"
 
       values.drop(1).find { |value| !value.include?("=") }
-    end
-
-    def executable_path(command)
-      return command if command.include?(File::SEPARATOR) && File.file?(command) && File.executable?(command)
-
-      ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).find do |dir|
-        path = File.join(dir, command)
-        File.file?(path) && File.executable?(path)
-      end
     end
 
     def schema_readiness

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -25,6 +25,7 @@ module RemoteServerTest
     assert_remote_hidden_settings_filter_projects_and_agents
     assert_remote_schedule_routes
     assert_remote_setup_payload_includes_readiness
+    assert_remote_setup_uses_shared_executable_resolution
     assert_remote_welcome_onboarding_creates_project
     assert_remote_setup_warns_when_public_url_has_no_token
     assert_remote_server_restart_route_schedules_restart
@@ -885,11 +886,50 @@ module RemoteServerTest
       assert(setup.dig(:counts, :archived_projects) == 1, "expected archived project count")
       assert(setup[:harnesses].map { |item| item[:name] }.sort == %w[claude claude-wrapper codex],
              "expected harness readiness entries")
-      assert(setup[:tools].map { |item| item[:name] }.sort == %w[kamal mise tailscale],
+      assert(setup[:tools].map { |item| item[:name] }.sort == %w[kamal kamal-projects mise tailscale],
              "expected optional tool readiness entries")
       assert(setup.dig(:schema, :valid) == true, "expected valid result schema")
       assert(setup.dig(:config, :prompt_template_count) == 1, "expected prompt template count")
       assert(setup[:safety].any? { |line| line.include?("confirmation") }, "expected safety defaults")
+    end
+  end
+
+  def assert_remote_setup_uses_shared_executable_resolution
+    with_remote_temp_store do |dir|
+      home = File.join(dir, "home")
+      empty_path = File.join(dir, "empty-bin")
+      workspace = File.join(dir, "workspace")
+      %w[claude codex mise].each do |command|
+        write_test_executable(File.join(home, ".local", "bin", command))
+      end
+      FileUtils.mkdir_p(empty_path)
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace, apps: true)
+
+      with_env_values(
+        "HOME" => home,
+        "PATH" => empty_path,
+        "TYCHO_CLAUDE_BIN" => nil,
+        "TYCHO_CODEX_BIN" => nil,
+        "TYCHO_MISE_BIN" => nil
+      ) do
+        setup = HQ::RemoteService.new(registry: registry).setup
+        codex = setup[:harnesses].find { |item| item[:name] == "codex" }
+        claude = setup[:harnesses].find { |item| item[:name] == "claude" }
+        mise = setup[:tools].find { |item| item[:name] == "mise" }
+        global_kamal = setup[:tools].find { |item| item[:name] == "kamal" }
+        project_kamal = setup[:tools].find { |item| item[:name] == "kamal-projects" }
+
+        assert(codex[:ready] && codex[:path].end_with?("/.local/bin/codex"),
+               "expected Remote setup to find fallback Codex")
+        assert(claude[:ready] && claude[:path].end_with?("/.local/bin/claude"),
+               "expected Remote setup to find fallback Claude")
+        assert(mise[:ready] && mise[:path].end_with?("/.local/bin/mise"),
+               "expected Remote setup to find fallback mise")
+        assert(!global_kamal[:ready], "expected global Kamal to remain PATH-only")
+        assert(project_kamal[:ready], "expected project-level Kamal readiness")
+        assert(project_kamal[:detail].include?("1/1 app project"), "expected project Kamal count detail")
+      end
     end
   end
 
@@ -2176,6 +2216,29 @@ module RemoteServerTest
           kamal (2.6.1)
           rails (7.2.2)
     LOCK
+  end
+
+  def write_test_executable(path)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, "#!/bin/sh\nexit 0\n")
+    File.chmod(0o755, path)
+  end
+
+  def with_env_values(values)
+    old_values = {}
+    had_keys = {}
+    values.each_key do |key|
+      had_keys[key] = ENV.key?(key)
+      old_values[key] = ENV[key]
+    end
+    values.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+    yield
+  ensure
+    values.each_key do |key|
+      had_keys[key] ? ENV[key] = old_values[key] : ENV.delete(key)
+    end
   end
 
   def write_archived_config(dir)


### PR DESCRIPTION
## Summary

- Add a shared `HQ::ExecutableResolver` for Codex, Claude, mise, and generic executable lookup.
- Use the shared resolver in managed-agent execution, Kamal action mise resolution, and Remote `/setup` readiness.
- Split Remote Kamal readiness into global `kamal` availability and project-level `kamal-projects` readiness through `bin/kamal`, `Gemfile.lock`, or `Gemfile` detection.

Fixes #8.

## Verification

- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/managed_agent_test.rb`
- `bin/test`
