### PR TITLE
[codex] Fix Claude structured output schema

### DIFF
--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -693,7 +693,7 @@ module HQ
       command << "--dangerously-skip-permissions" if @sandbox_mode == "danger-full-access"
       command.concat(["--print", "--output-format", "stream-json", "--verbose"])
       command.concat(claude_session_arguments)
-      schema = compact_agent_result_schema
+      schema = compact_claude_result_schema
       command.concat(["--json-schema", schema]) if schema
       command << prompt_for_execution
       { command: command, env: env }
@@ -1441,10 +1441,11 @@ module HQ
     def normalize_structured_result_payload(parsed)
       return nil unless parsed.is_a?(Hash)
 
-      return parsed if parsed["status"].is_a?(String) && parsed["summary"].is_a?(String)
+      canonical = canonical_structured_result_payload(parsed)
+      return canonical if canonical
 
-      structured = parsed["structured_output"]
-      return structured if structured.is_a?(Hash) && structured["status"].is_a?(String) && structured["summary"].is_a?(String)
+      structured = canonical_structured_result_payload(parsed["structured_output"])
+      return structured if structured
 
       assistant_structured = structured_output_from_assistant_event(parsed)
       return assistant_structured if assistant_structured
@@ -1487,10 +1488,33 @@ module HQ
         next unless item["name"].to_s.downcase == "structuredoutput"
 
         input = item["input"]
-        return input if input.is_a?(Hash) && input["status"].is_a?(String) && input["summary"].is_a?(String)
+        canonical = canonical_structured_result_payload(input)
+        return canonical if canonical
       end
 
       nil
+    end
+
+    def canonical_structured_result_payload(input)
+      return nil unless input.is_a?(Hash) && input["status"].is_a?(String) && input["summary"].is_a?(String)
+
+      result = input.dup
+      if result.key?("inquiry_json") && !result.key?("inquiry")
+        result["inquiry"] = structured_json_field(result["inquiry_json"], Hash)
+      end
+      if result.key?("attachments_json") && !result.key?("attachments")
+        result["attachments"] = structured_json_field(result["attachments_json"], Array)
+      end
+      result.delete("inquiry_json")
+      result.delete("attachments_json")
+      result
+    end
+
+    def structured_json_field(value, expected_class)
+      parsed = parse_json_string(value)
+      return nil if parsed.nil?
+
+      parsed.is_a?(expected_class) ? parsed : nil
     end
 
     def parse_json_string(value)
@@ -1509,12 +1533,33 @@ module HQ
       ExecutableResolver.command_for_tool("claude")
     end
 
-    def compact_agent_result_schema
+    def compact_claude_result_schema
       return nil unless File.exist?(AGENT_RESULT_SCHEMA)
 
-      JSON.generate(JSON.parse(File.read(AGENT_RESULT_SCHEMA)))
+      JSON.generate(claude_result_schema(JSON.parse(File.read(AGENT_RESULT_SCHEMA))))
     rescue StandardError
       nil
+    end
+
+    def claude_result_schema(canonical_schema)
+      properties = canonical_schema.fetch("properties", {})
+      {
+        "type" => "object",
+        "additionalProperties" => false,
+        "properties" => {
+          "status" => properties.fetch("status", { "type" => "string" }),
+          "summary" => properties.fetch("summary", { "type" => "string" }),
+          "inquiry_json" => {
+            "type" => "string",
+            "description" => "JSON-encoded inquiry object, or the literal string null when no inquiry is needed."
+          },
+          "attachments_json" => {
+            "type" => "string",
+            "description" => "JSON-encoded attachments array, or the literal string null when no attachments are needed."
+          }
+        },
+        "required" => ["status", "summary", "inquiry_json", "attachments_json"]
+      }
     end
 
     def current_run_log_lines

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -15,6 +15,7 @@ module ManagedAgentTest
     assert_start_reconciles_session_after_restart
     assert_fallback_summary_uses_assistant_message_not_tool_json
     assert_structured_output_summary_beats_later_agent_message
+    assert_claude_scalar_json_structured_output_normalizes
     assert_final_output_checklist_is_ephemeral_execution_context
     assert_agent_result_schema_describes_summary
     assert_initial_user_message_attachments_seed_memory
@@ -371,6 +372,92 @@ module ManagedAgentTest
              "structured output summary should beat later agent message, got #{summary.inspect}")
       assert(agent.structured_result&.dig("summary") == "Structured summary wins.",
              "expected StructuredOutput tool payload to populate structured_result")
+    end
+  end
+
+  def assert_claude_scalar_json_structured_output_normalizes
+    Dir.mktmpdir("hq-managed-agent-scalar-structured-test") do |dir|
+      log_path = File.join(dir, "scalar-structured.raw.log")
+      started_at = Time.parse("2026-05-12 10:15:00")
+      inquiry = {
+        "message" => "Deploy now?",
+        "fields" => [
+          {
+            "key" => "confirm",
+            "label" => "Confirm deploy",
+            "description" => "Approve the deployment.",
+            "input_type" => "boolean",
+            "required" => true,
+            "options" => nil
+          }
+        ]
+      }
+      attachments = [
+        {
+          "type" => "link",
+          "title" => "Issue 9",
+          "url" => "https://github.com/firewalker06/tycho/issues/9",
+          "description" => "StructuredOutput compatibility issue."
+        }
+      ]
+      File.open(log_path, "w") do |f|
+        f.puts "=== [#{started_at.strftime("%Y-%m-%d %H:%M:%S")}] start ==="
+        f.puts "workspace=#{dir}"
+        f.puts "prompt=Prefer scalar structured output"
+        f.puts JSON.generate(
+          "type" => "assistant",
+          "message" => {
+            "role" => "assistant",
+            "content" => [
+              {
+                "type" => "tool_use",
+                "name" => "StructuredOutput",
+                "input" => {
+                  "status" => "input_required",
+                  "summary" => "Need deploy approval.",
+                  "inquiry_json" => JSON.generate(inquiry),
+                  "attachments_json" => JSON.generate(attachments)
+                }
+              }
+            ]
+          }
+        )
+      end
+
+      agent = HQ::ManagedAgent.new(
+        key: "scalar-structured-demo",
+        name: "Scalar Structured Demo",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "Prefer scalar structured output",
+        agent: "claude",
+        started_at: started_at,
+        finished_at: started_at + 20,
+        last_exit_code: 0,
+        runs: [
+          HQ::ManagedAgent::AgentRun.new(
+            started_at: started_at,
+            finished_at: started_at + 20,
+            exit_code: 0,
+            status: "success",
+            log_path: log_path,
+            command: "claude test"
+          )
+        ],
+        log_path: log_path
+      )
+
+      summary = agent.build_summary!
+      structured = agent.structured_result
+      assert(summary == "Need deploy approval.", "expected scalar structured summary")
+      assert(structured["inquiry"]["message"] == "Deploy now?", "expected scalar inquiry JSON to normalize")
+      assert(structured["inquiry"]["fields"].first["input_type"] == "boolean",
+             "expected scalar inquiry fields to normalize")
+      assert(structured["attachments"].first["url"] == "https://github.com/firewalker06/tycho/issues/9",
+             "expected scalar attachments JSON to normalize")
+      assert(!structured.key?("inquiry_json"), "expected scalar inquiry field to be removed")
+      assert(!structured.key?("attachments_json"), "expected scalar attachments field to be removed")
     end
   end
 

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -2731,16 +2731,17 @@ module RenderingTest
     schema = command[command.index("--json-schema") + 1]
     assert(!schema.include?("\n"), "expected compact json schema without newlines")
     parsed = JSON.parse(schema)
-    attachment_items = parsed.dig("properties", "attachments", "items")
-    attachment_type = attachment_items.dig("properties", "type")
-    assert(attachment_type["enum"] == %w[file link],
-           "expected structured output schema to expose file/link attachment types")
-    assert(attachment_items["required"].include?("path"),
-           "expected attachment schema to include a nullable path")
-    assert(attachment_items["required"].include?("url"),
-           "expected attachment schema to include a nullable URL")
+    assert(parsed["properties"].key?("inquiry_json"), "expected Claude schema to expose scalar inquiry JSON")
+    assert(parsed["properties"].key?("attachments_json"), "expected Claude schema to expose scalar attachments JSON")
+    assert(parsed.dig("properties", "inquiry_json", "type") == "string",
+           "expected Claude inquiry output to stay scalar")
+    assert(parsed.dig("properties", "attachments_json", "type") == "string",
+           "expected Claude attachments output to stay scalar")
     assert(!schema.include?('"oneOf"'), "expected structured output schema to avoid unsupported oneOf")
-    assert(parsed["required"].include?("attachments"), "expected structured output schema to require attachments")
+    assert(parsed["required"] == %w[status summary inquiry_json attachments_json],
+           "expected Claude schema to require scalar output fields")
+    assert(!parsed["properties"].key?("inquiry"), "expected Claude schema to avoid object root fields")
+    assert(!parsed["properties"].key?("attachments"), "expected Claude schema to avoid array root fields")
   end
 
   def assert_agent_session_id_persists_and_renders


### PR DESCRIPTION
## Summary

- Generate a Claude-specific scalar-root structured output schema with `inquiry_json` and `attachments_json` string fields.
- Normalize those scalar JSON fields back into Tycho's canonical `inquiry` and `attachments` result shape.
- Keep legacy `StructuredOutput` payloads with object/array fields readable for existing logs.

Fixes #9.

## Verification

- `bundle exec ruby test/managed_agent_test.rb`
- `bundle exec ruby test/rendering_test.rb`
- `bin/test`
