### PR TITLE
[codex] Resume schedules after archived interactive agents

### DIFF
--- a/docs/SCHEDULED_RUNS.md
+++ b/docs/SCHEDULED_RUNS.md
@@ -253,7 +253,7 @@ Remote UI:
 
 Hooks:
 
-- Emit `schedule.due`, `schedule.started`, `schedule.skipped`, `schedule.failed`, `schedule.stopped`, `schedule.completed`, and `schedule.recovered`.
+- Emit `schedule.due`, `schedule.started`, `schedule.skipped`, `schedule.failed`, `schedule.stopped`, `schedule.completed`, `schedule.recovered`, `schedule.agent_archived`, and `schedule.resumed`.
 - Include `schedule_key`, `target_kind`, `target_key`, `project_key`, and timestamps.
 
 ### Implementation Order

--- a/lib/hq/app.rb
+++ b/lib/hq/app.rb
@@ -1154,6 +1154,7 @@ def selected_screen_items
       return [self, nil] if agent.running?
 
       agent.archive_logs!
+      reconcile_archived_schedule_agent(agent.key)
       @agents.delete(agent)
       save_agents!
       rebuild_agent_index!
@@ -1164,6 +1165,12 @@ def selected_screen_items
                        project_key: agent.project_key,
                        name: agent.name)
       [self, nil]
+    end
+
+    def reconcile_archived_schedule_agent(agent_key)
+      Scheduler.new(registry: @registry).reconcile_archived_agent!(agent_key)
+    rescue StandardError
+      false
     end
 
     def open_cloned_agent_chat(agent)
@@ -1254,7 +1261,10 @@ def selected_screen_items
       return [self, nil] unless archived_config
 
       destination = project.archive_logs!
-      @agents_by_project[project.key].each(&:archive_logs!)
+      @agents_by_project[project.key].each do |agent|
+        agent.archive_logs!
+        reconcile_archived_schedule_agent(agent.key)
+      end
       @agents.reject! { |agent| agent.project_key == project.key }
       save_agents!
       load_registry!

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -81,6 +81,24 @@ module HQ
       result
     end
 
+    def reconcile_archived_agent!(agent_key, now: Time.now)
+      key = agent_key.to_s
+      return false if key.empty?
+
+      schedules = schedule_registry.schedules
+      states = store.load
+      changed = false
+      schedules.each do |schedule|
+        state = store.state_for(states, schedule.key)
+        next unless state.last_target_key.to_s == key
+
+        reconcile_archived_agent_state!(schedule, state, key, now:)
+        changed = true
+      end
+      store.save(states) if changed
+      changed
+    end
+
     def tick(now: Time.now, dry_run: false)
       schedules = schedule_registry.schedules
       states = store.load
@@ -268,6 +286,28 @@ module HQ
       agents.reject! { |agent| agent.key == target.key }
       state.previous_target_key = target.key
       publish("schedule.agent_archived", schedule, state, agent_key: target.key, archive_path:)
+    end
+
+    def reconcile_archived_agent_state!(schedule, state, agent_key, now:)
+      interactive = state.last_status.to_s == "skipped" && state.last_error.to_s == "interactive"
+      state.previous_target_key = agent_key
+      state.last_target_key = nil
+      state.last_target_kind = nil
+      state.last_finished_at ||= now
+      if interactive
+        state.last_status = "resumed"
+        state.last_error = nil
+        state.next_due_at = now if runnable?(schedule, state)
+        publish("schedule.resumed", schedule, state,
+                agent_key: agent_key,
+                target_key: agent_key,
+                reason: "archived_interactive_agent")
+      else
+        publish("schedule.agent_archived", schedule, state,
+                agent_key: agent_key,
+                target_key: agent_key,
+                reason: "manual_archive")
+      end
     end
 
     def last_agent(state, agents)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -998,6 +998,7 @@ module HQ
       target.start! if truthy?(attrs["start"])
 
       archive_path = source.archive_logs! if archive_source
+      schedule_reconciled = reconcile_archived_schedule_agent(source.key) if archive_source
       next_agents = current.reject { |agent| agent.key == target.key || (archive_source && agent.key == source.key) }
       next_agents.unshift(target)
       save_agents(sort_agents(next_agents))
@@ -1011,7 +1012,8 @@ module HQ
         agent: agent_payload(target),
         source_agent_key: source.key,
         archived: archive_source,
-        archive_path: archive_path
+        archive_path: archive_path,
+        schedule_reconciled: schedule_reconciled
       }.compact
     end
 
@@ -1020,12 +1022,14 @@ module HQ
       raise Error.new("Agent is running", status: 409) if target.running?
 
       archive_path = target.archive_logs!
+      schedule_reconciled = reconcile_archived_schedule_agent(target.key)
       remaining = load_all_agents.reject { |agent| agent.key == target.key }
       save_agents(remaining)
       {
         archived: true,
         agent_key: target.key,
-        archive_path: archive_path
+        archive_path: archive_path,
+        schedule_reconciled: schedule_reconciled
       }
     end
 
@@ -1052,7 +1056,11 @@ module HQ
           next
         end
 
-        archived << { agent_key: target.key, archive_path: target.archive_logs! }
+        archived << {
+          agent_key: target.key,
+          archive_path: target.archive_logs!,
+          schedule_reconciled: reconcile_archived_schedule_agent(target.key)
+        }
       rescue StandardError => e
         failed << { agent_key: key, error: e.message }
       end
@@ -1066,6 +1074,12 @@ module HQ
         failed: failed,
         archive_count: archived.length
       }
+    end
+
+    def reconcile_archived_schedule_agent(agent_key)
+      scheduler.reconcile_archived_agent!(agent_key)
+    rescue StandardError
+      false
     end
 
     private

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -13,6 +13,7 @@ module RemoteServerTest
 
   def run!
     assert_remote_agent_lifecycle
+    assert_remote_archive_reconciles_scheduled_agent_state
     assert_remote_agent_bulk_archive
     assert_remote_agent_clone_archives_source_with_editable_name
     assert_remote_agent_payload_has_revision
@@ -83,6 +84,51 @@ module RemoteServerTest
       replace_constant(HQ, :AGENTS_FILE, old_agents_file) if old_agents_file
       replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
       replace_constant(HQ, :AGENT_ARCHIVE_DIR, old_archive_dir) if old_archive_dir
+    end
+  end
+
+  def assert_remote_archive_reconciles_scheduled_agent_state
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace, apps: false)
+      File.write(HQ::SCHEDULES_FILE, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              message: "Run maintenance."
+      YAML
+      service = HQ::RemoteService.new(registry: registry)
+      created = service.create_agent(
+        "project_key" => "web",
+        "template_key" => "custom",
+        "name" => "Scheduled Interactive Agent",
+        "prompt" => "Work remotely.",
+        "agent" => "codex"
+      )
+      state = HQ::ScheduleState.new(
+        key: "weekday",
+        enabled: true,
+        last_status: "skipped",
+        last_error: "interactive",
+        last_target_kind: "agent",
+        last_target_key: created[:key],
+        next_due_at: Time.now + 3600,
+        run_count: 1,
+        skip_count: 1
+      )
+      HQ::ScheduleStore.new.save("weekday" => state)
+
+      archived = service.archive_agent(created[:key])
+      assert(archived[:schedule_reconciled], "expected Remote archive to reconcile schedule state")
+      updated = HQ::ScheduleStore.new.load.fetch("weekday")
+      assert(updated.last_status == "resumed", "expected Remote archive to resume schedule")
+      assert(updated.last_error.nil?, "expected Remote archive to clear interactive state")
+      assert(updated.last_target_key.nil?, "expected Remote archive to clear stale target")
+      assert(updated.previous_target_key == created[:key], "expected Remote archive to keep previous target")
     end
   end
 

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -179,6 +179,20 @@ module SchedulerTest
       agents = read_agents
       assert(agents.map(&:key) == [first_agent.key], "expected interactive scheduled agent to remain active")
       assert(File.exist?(first_agent.raw_log_path), "expected interactive scheduled logs to remain in place")
+
+      resume_at = Time.at((Time.now + 30).to_i)
+      reconciled = scheduler.reconcile_archived_agent!(first_agent.key, now: resume_at)
+      assert(reconciled, "expected archived interactive scheduled agent to reconcile schedule state")
+      state = store.load.fetch("weekday")
+      assert(state.last_status == "resumed", "expected archive to resume interactive schedule state")
+      assert(state.last_error.nil?, "expected archive to clear interactive skip reason")
+      assert(state.last_target_key.nil?, "expected archive to clear stale scheduled agent target")
+      assert(state.previous_target_key == first_agent.key, "expected archive to record previous scheduled agent")
+      assert(state.next_due_at == resume_at, "expected archive to requeue the schedule immediately")
+
+      HQ::AgentStore.new(projects).save([])
+      resumed = scheduler.tick(now: resume_at)
+      assert(resumed[:started] == 1, "expected next scheduler tick to start after archive reconciliation")
     end
   end
 


### PR DESCRIPTION
## Summary

- Reconcile schedule state when a manually archived agent is the schedule's last target.
- Clear stale interactive skip state and requeue enabled schedules immediately after archiving an interactive scheduled agent.
- Wire reconciliation through Remote single/bulk/clone archive paths and TUI agent/project archive paths.

## Root Cause

Interactive scheduled agents were intentionally left active and marked as `skipped` with `last_error: "interactive"`. When that agent was archived outside the scheduler-owned archive path, the schedule retained `last_target_key` and stayed stuck in interactive state with no way for the scheduler to resume.

## Verification

- `bundle exec ruby test/scheduler_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
