### PR TITLE
[codex] Add managed agent model settings

### DIFF
--- a/config/hq.yml.example
+++ b/config/hq.yml.example
@@ -11,6 +11,8 @@
 #   path    (required) absolute path to the project checkout on this machine
 #   apps    (required) true if the project is Kamal-deployed and should show app/health columns
 #   agent   (optional) managed-agent backend: "codex", "claude", or a custom_harnesses key
+#   model   (optional) default model string for new managed agents
+#   reasoning_effort (optional) default effort string for new managed agents
 #   hidden  (optional) true hides the project and its agents; false overrides a hidden group
 #
 # Groups can define shared metadata by display name. Missing hidden settings are
@@ -44,6 +46,9 @@ projects: []
 #   group: Personal
 #   path: "/Users/you/Code/my-app"
 #   apps: true
+#   agent: codex
+#   model: gpt-5.1-codex-max
+#   reasoning_effort: high
 #
 # - key: notes
 #   name: Notes

--- a/config/system_prompts.yml.example
+++ b/config/system_prompts.yml.example
@@ -3,6 +3,15 @@
 # Each top-level key is a prompt the managed-agent chat composer can select.
 # The value is the system prompt sent to the agent when that option is chosen.
 # "custom" is reserved for free-form ad-hoc prompts (leave it empty by default).
+#
+# A prompt may also be a mapping with prompt metadata:
+#
+# reviewer:
+#   name: Reviewer
+#   agent: claude
+#   model: sonnet
+#   reasoning_effort: xhigh
+#   prompt: Review %{project_name}.
 
 custom: ""
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -92,9 +92,9 @@ Handler blocks receive a frozen payload Hash with string keys. Blocking Ruby han
 | `agent.message.assistant_added` | `agent_key`, `project_key`, `content` | Assistant summary/message appended. |
 | `agent.memory.captured` | `agent_key`, `project_key`, `status` | After `memory.jsonl` write completes for a run. |
 | `agent.session.captured` | `agent_key`, `project_key`, `session_id` | First time a native session id is discovered. |
-| `agent.updated` | `agent_key`, `project_key`, `name`, `template_key`, `workspace`, `agent` | After the agent editor saves an edit. |
-| `agent.created` | `agent_key`, `project_key`, `template_key`, `name`, `workspace` | After the agent editor creates a new agent. |
-| `agent.cloned` | `agent_key`, `source_agent_key`, `project_key`, `name` | After cloning an agent. |
+| `agent.updated` | `agent_key`, `project_key`, `name`, `template_key`, `workspace`, `agent`, `model`, `reasoning_effort` | After the agent editor saves an edit. |
+| `agent.created` | `agent_key`, `project_key`, `template_key`, `name`, `workspace`, `agent`, `model`, `reasoning_effort` | After the agent editor creates a new agent. |
+| `agent.cloned` | `agent_key`, `source_agent_key`, `project_key`, `name`, `agent`, `model`, `reasoning_effort` | After cloning an agent. |
 | `agent.deleted` | `agent_key`, `project_key`, `name` | After an agent is deleted and its logs archived. |
 
 ### Registry / config

--- a/docs/MODEL_ARGUMENTS_PLAN.md
+++ b/docs/MODEL_ARGUMENTS_PLAN.md
@@ -1,0 +1,367 @@
+---
+name: MODEL_ARGUMENTS_PLAN
+description: Implementation plan for model and reasoning argument support in Tycho managed agents
+type: project-plan
+---
+
+# Model Arguments Plan
+
+## Goal
+
+Add first-class optional agent-level `model` and `reasoning_effort` settings for Tycho managed agents, then show the selected model and effort consistently in the TUI and Remote UI.
+
+The first implementation should accept model names as free-form strings instead of hardcoding current provider catalogs. Model availability changes outside Tycho, and users may need aliases, full provider model IDs, or custom wrapper-specific IDs.
+
+For reasoning/thinking controls, use `reasoning_effort` as Tycho's cross-harness field and display it as `Effort`. This maps cleanly to Codex's `model_reasoning_effort` and Claude Code's `--effort`. Do not introduce a generic `thinking` object in the first version; Claude's visible thinking, adaptive thinking, fixed thinking budgets, and Codex reasoning summaries are related but not equivalent.
+
+Implementation status: implemented on 2026-06-03 with free-form model/effort fields, project/template inheritance, agent persistence, command argument mapping, Codex/Claude suggestion hints, and TUI/Remote UI display/editing.
+
+## Current Findings
+
+### Codex CLI
+
+Checked on 2026-06-03 using local `codex` help and OpenAI Codex docs.
+
+- `codex exec` supports `--model <MODEL>` and `-m <MODEL>`.
+- `codex exec resume` also supports `--model <MODEL>` and `-m <MODEL>`.
+- `codex` interactive top-level help exposes `--model <MODEL>` as a global option.
+- Codex config also has a `model` string key in `~/.codex/config.toml`.
+- OpenAI's Codex CLI reference describes `--model, -m` as overriding the configured model for the run, and the config reference documents `model` as the configured default model.
+- Current local `codex` help does not expose a dedicated `--reasoning` or `--effort` CLI flag, but all relevant entry points accept `-c/--config <key=value>`.
+- OpenAI's Codex config reference documents `model_reasoning_effort` with `minimal`, `low`, `medium`, `high`, and `xhigh` values for supported Responses API models.
+- The same config reference also documents `plan_mode_reasoning_effort`, `model_reasoning_summary`, `model_verbosity`, and reasoning display flags. Treat these as later, separate features unless a user explicitly needs them.
+- `codex debug models` can render Codex's raw model catalog as JSON, including a `--bundled` mode. Local `codex debug models --bundled` prints JSON directly; there is no separate `--json` flag in the checked build.
+- The Codex model catalog includes `slug`, `display_name`, `visibility`, `supported_in_api`, `default_reasoning_level`, and `supported_reasoning_levels`. Use this as the preferred source for Codex model and effort suggestions.
+
+Sources:
+
+- OpenAI Codex CLI reference: <https://developers.openai.com/codex/cli/reference#codex-exec>
+- OpenAI Codex config reference: <https://developers.openai.com/codex/config-reference#configtoml>
+- Local help: `codex --help`, `codex exec --help`, `codex exec resume --help`, `codex debug models --help`
+
+### Claude Code CLI
+
+Checked on 2026-06-03 using local `claude` help and Anthropic docs.
+
+- `claude` supports `--model <model>` for the current session.
+- The flag works with print mode (`claude -p`) because `claude -p --help` exposes the same option.
+- The flag can be combined with `--resume` or `--session-id` because local help lists all of these as session options.
+- Anthropic's CLI reference says `--model` accepts aliases for the latest model, such as `sonnet` or `opus`, or a full model name.
+- Local `claude` help exposes `--effort <level>` for the current session, with `low`, `medium`, `high`, `xhigh`, and `max`.
+- Anthropic's model configuration docs describe effort as adaptive reasoning control. Available levels depend on the model; unsupported levels fall back to the highest supported level at or below the requested level.
+- Claude Code's settings docs expose `effortLevel` for persistent settings, while the model configuration docs say `--effort` is the right per-session startup override. `max` is session-only.
+- Claude Code also has extended-thinking controls such as `alwaysThinkingEnabled`, `MAX_THINKING_TOKENS`, and `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, but those are not the same as a per-run effort level.
+- No non-interactive model-catalog command was found in local Claude Code 2.1.150. Official docs say `/model` is the source of truth for account-specific model availability, and the `/model` picker can also show the effort slider for supported models.
+- Claude Code can restrict model selection through `availableModels` settings and can add one custom picker entry through `ANTHROPIC_CUSTOM_MODEL_OPTION`. For LLM gateways, docs mention `/v1/models` discovery when `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, but that still affects Claude's picker rather than exposing a general CLI list command.
+
+Sources:
+
+- Anthropic Claude Code CLI reference: <https://docs.anthropic.com/en/docs/claude-code/cli-usage>
+- Anthropic Claude Code model configuration: <https://code.claude.com/docs/en/model-config>
+- Anthropic Claude Code settings: <https://code.claude.com/docs/en/settings>
+- Local help: `claude --help`, `claude -p --help`, `claude --version`
+
+## Harness Discovery Strategy
+
+Use discovered catalogs for suggestions only. Do not use catalog data as a hard validation gate, because users may need aliases, newly released models, custom gateway IDs, or wrapper-specific names before Tycho knows about them.
+
+Codex discovery:
+
+- Preferred command: `codex debug models`.
+- Fallback command: `codex debug models --bundled`.
+- Parse JSON into lightweight suggestion records: `model`, `display_name`, `default_reasoning_effort`, `supported_reasoning_efforts`, and `visibility`.
+- Filter hidden models from ordinary pickers unless Tycho is in a debug/admin view.
+- Cache the result for the current Tycho process or a short TTL. If the command fails, keep the form free-form and show no suggestions.
+
+Claude discovery:
+
+- Do not screen-scrape interactive `/model` or `/effort` in the first version. It is account-specific and interactive; automating it would be brittle and could start real sessions.
+- Keep model input free-form, with lightweight suggestions for stable aliases such as `default`, `best`, `sonnet`, `opus`, `haiku`, and `opusplan`.
+- Optionally read local `availableModels` from accessible Claude settings files later, but treat that as an incomplete hint because managed/policy settings and account availability may still differ.
+- For effort suggestions, parse `claude --help` at runtime when possible and fall back to `low`, `medium`, `high`, `xhigh`, `max`. Let Claude Code apply its documented model-specific fallback when the chosen model does not support an effort level.
+
+Custom harness discovery:
+
+- Keep custom harnesses free-form by default.
+- Add optional custom harness config later if needed, such as `model_catalog_command` returning JSON with model and effort suggestions. This avoids maintaining static Tycho tables for wrappers that already know their own provider.
+
+## Dynamic Selection Rules
+
+Agent-level values are part of the plan. `ManagedAgent` should persist the model and reasoning effort actually selected for that agent, even when those values came from a project/template default at creation time.
+
+Effective defaults when creating a new agent:
+
+1. Selected template `model` / `reasoning_effort`.
+2. Project `model` / `reasoning_effort`.
+3. Empty value, meaning harness default.
+
+Effective values when editing an existing agent:
+
+1. Existing agent-level `model` / `reasoning_effort`.
+2. Empty value, meaning harness default.
+
+Dynamic form behavior:
+
+- Track whether the user has manually edited model and effort fields during the current form session.
+- When the selected harness changes, refresh the model catalog/suggestions for the new harness.
+- If the model field is not dirty, replace it with the inherited default for the new template/project/harness context.
+- If the model field is dirty, preserve the user's current value even when it is not in the suggestion list. Display it as custom/free-form instead of clearing it.
+- When the selected model changes, recompute effort suggestions from the selected harness and model. For Codex, use that model's `supported_reasoning_levels` and `default_reasoning_level` from the catalog.
+- If the effort field is not dirty, replace it with the catalog/model default when available, otherwise use the inherited effort default, otherwise keep it empty.
+- If the effort field is dirty, preserve the user's current value even when the new model does not advertise it. Provider CLIs remain the final validator.
+- On template changes, update harness, model, effort suggestions, and defaults together. Preserve dirty model/effort fields unless the user explicitly resets them to template defaults.
+- Cloned agents should copy the source agent-level model and effort, not recalculate from current template/project defaults.
+
+## Existing Tycho Shape
+
+Tycho currently has no model or reasoning-effort field. The relevant state today is:
+
+- `Registry::ProjectConfig`: project-level `agent`.
+- `Registry::AgentTemplateConfig`: template-level `agent` and `sandbox_mode`.
+- `ManagedAgent`: persisted `agent`, `template_key`, `workspace`, `prompt`, `sandbox_mode`, session state, run history, summary, and structured result.
+- `AgentStore`: creates agents from project templates, clones agents, and creates scheduled agents.
+- `ManagedAgent#build_codex_command`: builds `codex exec` and `codex exec resume`.
+- `ManagedAgent#build_claude_like_command`: builds Claude-compatible print-mode runs.
+- `ManagedAgent#build_interactive_*_command`: builds interactive terminal commands.
+- `RemoteServer#agent_payload` and `#agent_template_summaries`: expose agent/template data to the Web UI.
+- `UI::AgentEditor` and `renderAgentForm`: already provide harness selectors, which can be mirrored for model input.
+
+## Proposed Data Model
+
+Use `model` and `reasoning_effort` as the field names everywhere.
+
+Configuration inheritance for new agents:
+
+1. Template-level `model` wins.
+2. Project-level `model` is the fallback.
+3. Empty or omitted `model` means use the harness default, such as `~/.codex/config.toml`, Claude settings, or wrapper defaults.
+4. Template-level `reasoning_effort` wins.
+5. Project-level `reasoning_effort` is the fallback.
+6. Empty or omitted `reasoning_effort` means use the harness/model default.
+
+After creation, the resolved values are agent-level settings on `ManagedAgent`. Editing an agent should update those agent-level values directly; later template/project default changes should not silently rewrite existing agents.
+
+Recommended config examples:
+
+```yaml
+projects:
+- key: app
+  name: App
+  path: /Users/you/Code/app
+  apps: true
+  agent: codex
+  model: gpt-5.1-codex-max
+  reasoning_effort: high
+```
+
+```yaml
+reviewer:
+  name: Reviewer
+  agent: claude
+  model: sonnet
+  reasoning_effort: xhigh
+  prompt: Review %{project_name}.
+```
+
+Implementation notes:
+
+- Add `:model` and `:reasoning_effort` to `AgentTemplateConfig` and `ProjectConfig`.
+- Add `model:` and `reasoning_effort:` to `ManagedAgent#initialize`, `from_hash`, `to_hash`, `update!`, and `clone_agent`.
+- Store `model` and `reasoning_effort` only when non-empty to keep existing `managed_agents.json` compatible.
+- Normalize by trimming whitespace. Do not downcase model names; provider IDs can be case-sensitive or include punctuation.
+- Normalize `reasoning_effort` by trimming whitespace and downcasing. Keep it as a string rather than a hard enum so Tycho does not need a release when providers add new levels.
+- Suggested known values:
+  - Codex: `minimal`, `low`, `medium`, `high`, `xhigh`
+  - Claude: `low`, `medium`, `high`, `xhigh`, `max`
+- Avoid validating against a static allowlist in the first version.
+- Add a small display helper such as `model_label`, returning the configured model or `default`.
+- Add a small display helper such as `reasoning_effort_label`, returning the configured effort or `default`.
+
+## Command Construction
+
+Add a helper:
+
+```ruby
+def model_arguments
+  @model.to_s.strip.empty? ? [] : ["--model", @model.to_s.strip]
+end
+
+def codex_reasoning_effort_arguments
+  effort = @reasoning_effort.to_s.strip.downcase
+  effort.empty? ? [] : ["-c", "model_reasoning_effort=\"#{effort}\""]
+end
+
+def claude_effort_arguments
+  effort = @reasoning_effort.to_s.strip.downcase
+  effort.empty? ? [] : ["--effort", effort]
+end
+```
+
+Apply it to all built-in adapter paths:
+
+- Codex first run: `codex exec --model <model> -c model_reasoning_effort="<effort>" ...`
+- Codex resume: `codex exec resume --model <model> -c model_reasoning_effort="<effort>" ... <session_id> -- <prompt>`
+- Codex interactive: `codex --model <model> -c model_reasoning_effort="<effort>" ...` before `resume <session_id>` when resuming.
+- Claude print mode: `claude --model <model> --effort <effort> --print --output-format stream-json ...`
+- Claude resume/session-id print mode: same `--model` and `--effort` before session arguments or prompt.
+- Claude interactive: `claude --model <model> --effort <effort> ... --resume <session_id>` when applicable.
+
+Use no argument when the corresponding field is empty. Model and effort should be independently optional.
+
+Custom Claude-compatible harnesses need one explicit decision:
+
+- Recommended first behavior: pass `--model` to custom harnesses whose `adapter: claude`, because Tycho already appends Claude CLI flags to those wrappers.
+- Also pass `--effort` to custom harnesses whose `adapter: claude` when `reasoning_effort` is configured.
+- Document that custom wrappers must either forward or consume `--model` and `--effort`.
+- If this is too risky for local wrappers, add `supports_model_argument: false` and `supports_effort_argument: false` custom harness config later. Do not add those switches until a real wrapper needs them.
+
+## TUI Display And Editing
+
+Agent creation/editing:
+
+- Add a `Model` field to `UI::AgentEditor`.
+- Add an `Effort` field to `UI::AgentEditor`.
+- Keep both as text inputs, not fixed selects, for the first version.
+- When catalog suggestions are available, surface them as autocomplete/picker hints while preserving manual entry.
+- On harness changes, refresh model and effort suggestions for the new harness.
+- On model changes, refresh effort suggestions for the selected model when the harness exposes per-model effort metadata.
+- On template changes, update the model field from the selected template's inherited model unless editing an existing agent or the field is dirty.
+- On template changes, update the effort field from the selected template's inherited effort unless editing an existing agent or the field is dirty.
+- Add an explicit "use default" or "clear" affordance later if users need to reset an agent-level value back to harness default without deleting text manually.
+- Show a short hint such as `empty uses harness default`.
+- Include `model` and `reasoning_effort` in `AgentEditor#attributes`.
+
+Agent detail:
+
+- Add model and effort to the hero crumb or footer metadata. Preferred:
+  - crumb: `Project · template · harness · model · effort`
+  - footer row: `Model default` and `Effort default` or configured values
+- Keep the agent list compact. If adding model or effort to the list, put them in secondary text after harness only when width allows.
+
+Rendering tests:
+
+- Agent editor renders the model field and template default.
+- Agent editor renders the effort field and template default.
+- Agent detail shows configured model.
+- Agent detail shows configured effort.
+- Empty model renders as `default`.
+- Empty effort renders as `default`.
+- Existing agents without `model` or `reasoning_effort` still render.
+
+## Remote API And Web UI
+
+Remote API:
+
+- Add `model` to `agent_payload`.
+- Add `model` to `agent_template_summaries`.
+- Add `reasoning_effort` to `agent_payload`.
+- Add `reasoning_effort` to `agent_template_summaries`.
+- Accept `model` and `reasoning_effort` in create, update, and clone payloads through `agent_attrs`.
+- Update `docs/REMOTE_SERVER.md` with the new request and response field.
+
+Remote UI:
+
+- Add a model text input to `renderAgentForm`.
+- Add an effort input to `renderAgentForm`, with suggested values in placeholder/help text such as `default, minimal, low, medium, high, xhigh, max`.
+- Use Codex catalog suggestions when available, especially per-model effort suggestions from `supported_reasoning_levels`.
+- For Claude, show alias and effort suggestions as hints only; do not imply the list is complete.
+- Populate model and effort from `agent.model` and `agent.reasoning_effort` when editing/cloning, or from selected template/project defaults when creating.
+- Add `data-model`, `data-reasoning-effort`, and harness/catalog metadata to template `<option>` nodes and update the fields when the template changes.
+- Track dirty state for model and effort inputs so polling, template changes, and harness changes do not overwrite user-entered values.
+- When the selected harness changes, refresh model suggestions and effort suggestions.
+- When the selected model changes, refresh effort suggestions and default effort if the effort field is not dirty.
+- Add `model` and `reasoning_effort` to `agentFormPayload`.
+- Include model and effort in:
+  - `agentMeta(agent)`, probably `project / harness / model / effort`
+  - agent settings grid
+  - archive/clone confirmation metadata
+  - project template detail if enough room
+- Add `agent.model` and `agent.reasoning_effort` to search matching.
+- Render empty model and effort as `default` in display contexts.
+
+Browser verification for Remote UI changes should cover:
+
+- Create form preserves typed model across polling/refresh.
+- Create form preserves typed effort across polling/refresh.
+- Changing harness updates model and effort suggestion sets.
+- Changing model updates effort suggestions for Codex catalog-backed models.
+- Changing template updates the model and effort defaults only while the corresponding fields are not dirty.
+- Editing an existing agent preserves its model and effort.
+- Agent row/card/settings display the model and effort after create/update.
+- Mobile viewport does not overflow long provider model IDs.
+
+## Tests
+
+Add or update focused tests:
+
+- `test/registry_test.rb`
+  - project-level model inheritance
+  - template-level model override
+  - project-level reasoning effort inheritance
+  - template-level reasoning effort override
+  - empty model normalizes to nil/empty
+  - empty reasoning effort normalizes to nil/empty
+- `test/managed_agent_test.rb`
+  - created agents persist resolved model and reasoning effort as agent-level values
+  - editing an agent updates agent-level model and reasoning effort without changing template/project defaults
+  - cloning an agent copies agent-level model and reasoning effort
+  - Codex first-run command includes `--model`
+  - Codex resume command includes `--model`
+  - Codex first-run command includes `-c model_reasoning_effort="..."`
+  - Codex resume command includes `-c model_reasoning_effort="..."`
+  - Claude print command includes `--model`
+  - Claude print command includes `--effort`
+  - Claude-compatible custom harness command includes `--model`
+  - Claude-compatible custom harness command includes `--effort`
+  - `ManagedAgent#from_hash` handles old persisted agents with no model or reasoning effort
+- catalog/discovery tests
+  - Codex catalog parser extracts visible model suggestions and per-model reasoning effort options
+  - Codex catalog discovery falls back from refreshed catalog to `--bundled` when refresh fails
+  - Claude effort discovery parses `claude --help` output when available
+  - Discovery failure leaves fields free-form and does not block create/update
+- `test/remote_server_test.rb`
+  - create/update/clone accept and return `model` and `reasoning_effort`
+  - project detail template summaries include `model` and `reasoning_effort`
+- `test/rendering_test.rb`
+  - TUI agent editor and detail display model and effort correctly
+  - TUI agent editor updates model/effort suggestions on harness changes
+  - TUI agent editor preserves dirty model/effort fields on template changes
+  - long model names fit without corrupting layout
+  - long effort values fit without corrupting layout
+- Manual Web UI verification or Playwright fallback for visible Remote UI behavior.
+
+Run at least:
+
+```sh
+bundle exec ruby -c bin/tycho
+bundle exec ruby test/registry_test.rb
+bundle exec ruby test/managed_agent_test.rb
+bundle exec ruby test/remote_server_test.rb
+bundle exec ruby test/rendering_test.rb
+bin/test
+```
+
+## Rollout Plan
+
+1. Add the model and reasoning-effort fields to config and domain persistence.
+2. Pass `--model` and the harness-specific effort argument through Codex and Claude command builders.
+3. Add harness catalog discovery for suggestions, with Codex JSON catalog support first and Claude help/alias hints second.
+4. Add TUI editor/detail/list display with dirty-field-aware dynamic suggestion updates.
+5. Add Remote API request/response support.
+6. Add Web UI form/display/search support with the same dynamic suggestion behavior.
+7. Update `config/hq.yml.example`, `docs/REMOTE_SERVER.md`, and any README config examples that show managed-agent fields.
+8. Add tests and run the verification suite.
+
+## Risks And Decisions
+
+- Do not hardcode current model catalogs in Tycho. Use free-form input first.
+- Do not expose provider-specific thinking budgets in the first version. Use `reasoning_effort` because it has a clean mapping across Codex and Claude Code.
+- Do not hard-reject unknown effort strings initially. Provider CLIs will produce the authoritative error, and Tycho can add suggestions or validation later.
+- Do not maintain static model catalogs per harness version. Prefer harness discovery where available, and keep a free-form fallback everywhere.
+- Codex catalog data can include hidden/internal models. Filter by `visibility` for normal UI suggestions.
+- Claude Code's `/model` picker is the account-specific source of truth, but there is no non-interactive catalog command in the checked local build. Tycho should present Claude suggestions as hints, not as a complete list.
+- Passing `--model` on resume is supported by current local CLI help for both Codex and Claude, but behavior can still depend on provider/session rules. Tycho should record the configured model it requested, not try to infer the model actually used unless parser events expose it reliably later.
+- Passing effort on resume should be treated similarly: Tycho records the requested effort and passes the current harness argument, but the harness decides how it applies to existing sessions.
+- Claude stream events include `message.model` in observed fixtures, but Codex/Claude output parsing should not be the primary source of truth for display. Persist the requested model on the agent.
+- Custom harnesses may not accept `--model` or `--effort` even if they claim Claude compatibility. Document the expectation first; add opt-outs only if needed.
+- Existing agents should remain valid. Missing `model` and `reasoning_effort` should display as `default` and should not add model or effort flags to commands.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-05-28
+2026-06-03
 
 ## Strategic Direction
 
@@ -27,6 +27,7 @@ Key references:
 - [REMOTE_SERVER.md](./REMOTE_SERVER.md) — Remote Sessions server architecture, runtime behavior, and API endpoint reference.
 - [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md) — planned browser push notifications for Remote UI, including the hard HTTPS-over-Tailscale requirement.
 - [SCHEDULED_RUNS.md](./SCHEDULED_RUNS.md) — planned cron-like scheduled runs, `tycho schedule daemon`, command targets, and prompt/message tradeoffs.
+- [MODEL_ARGUMENTS_PLAN.md](./MODEL_ARGUMENTS_PLAN.md) — planned managed-agent `model` and `reasoning_effort` configuration, command mapping, and TUI/Remote UI display.
 
 ## Key Decisions
 
@@ -39,6 +40,7 @@ Key references:
 | Health checks | HEAD requests, concurrent via Ruby threads | HEAD is required for kamal-proxy maintenance detection (503 on root URL) |
 | Config split | `~/.tycho/config/hq.yml` (active) + `~/.tycho/config/hq.archived.yml` (archived) | Archive without losing history; logs move to `~/.tycho/logs/projects/archived/` |
 | Agent transport | Codex JSON output; Claude-compatible `--output-format stream-json` | Streaming logs render incrementally in the chat viewport |
+| Agent model controls | Optional per-agent `model` and `reasoning_effort`, inherited from project/template config and passed as harness run arguments | Model catalogs change outside Tycho; use harness discovery for suggestions where available, keep free-form fallback everywhere, and keep provider-specific thinking budgets out of first-version scope |
 | Agent session strategy | Persist native Claude/Codex `session_id` per managed agent and resume after the first run; keep `memory.jsonl` as HQ's canonical transcript | Native resume recovers agent-side continuity and prompt-cache reuse. HQ only replays bounded `memory.jsonl` on first run or when no native session is known |
 | Agent log layout | New agents use a per-agent stem `<project-key>-<created-at>-<nonce>` for `.raw.log`, `.conversation.log`, `.system.log`, `.memory.jsonl`, `.attachments.json`, `.status`, and `.last_message.json`; legacy `<key>.raw.log` records remain readable | Raw stream + parsed conversation + tool/system events + canonical event log + durable artifact links without collisions when agent keys are reused after Remote/TUI archive timing differences |
 | Chat viewport rendering | Hybrid: `memory.jsonl` for history, `raw.log` tail for live streaming | User messages appear immediately (written to `memory.jsonl` on send); assistant turns commit on run finalization |
@@ -141,6 +143,16 @@ verification.
 - [x] Add README screenshots for TUI and Remote UI workflows
 
 ## Features Candidates
+
+### Model And Effort Arguments
+
+- [x] Add planning doc for managed-agent model and reasoning effort fields in `docs/MODEL_ARGUMENTS_PLAN.md`
+- [x] Add Codex catalog-driven model and effort suggestions from `codex debug models`
+- [x] Add Claude alias/help-derived suggestions without hard validation
+- [x] Add config inheritance and persisted `ManagedAgent` fields for `model` and `reasoning_effort`
+- [x] Add dirty-field-aware dynamic model/effort suggestions when harness, template, or model selection changes
+- [x] Pass model and effort through Codex, Claude, and Claude-compatible command builders
+- [x] Display and edit model and effort in the TUI and Remote UI
 
 ### Scheduled Runs
 

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -343,6 +343,8 @@ Request:
   "workspace": "/Users/example/Code/web",
   "sandbox_mode": "danger-full-access",
   "agent": "codex",
+  "model": "gpt-5.1-codex-max",
+  "reasoning_effort": "high",
   "start": false
 }
 ```
@@ -359,6 +361,8 @@ Optional fields:
 - `workspace`: defaults to the project path on create.
 - `sandbox_mode`: defaults to the selected template sandbox mode.
 - `agent`: one of `codex`, `claude`, or a configured `custom_harnesses` key.
+- `model`: optional free-form per-agent model. Omit to inherit the template/project default; send an empty string when editing to clear the agent-level value.
+- `reasoning_effort`: optional free-form per-agent effort. Omit to inherit the template/project default; send an empty string when editing to clear the agent-level value.
 - `start`: when truthy, starts the agent immediately after creation.
 
 Response:
@@ -580,7 +584,7 @@ Response:
 
 ### `POST /agents/{key}/clone`
 
-Creates a fresh managed agent from an existing one with a new key, empty logs, no runs, and no native session id. Form fields such as `name`, `template_key`, `agent`, `workspace`, `prompt`, and `sandbox_mode` may be supplied to edit the clone before it is saved. Set `archive_source: true` to archive the source agent after the clone is created.
+Creates a fresh managed agent from an existing one with a new key, empty logs, no runs, and no native session id. Form fields such as `name`, `template_key`, `agent`, `model`, `reasoning_effort`, `workspace`, `prompt`, and `sandbox_mode` may be supplied to edit the clone before it is saved. Set `archive_source: true` to archive the source agent after the clone is created.
 
 ```bash
 curl -X POST http://127.0.0.1:7373/agents/web-charlie-agent-8/clone \
@@ -679,7 +683,7 @@ Returns active projects after refreshing metadata and health:
 
 ### `GET /projects/{key}`
 
-Returns project detail data for the mobile detail view, including branch/commit metadata, Kamal deploy details, versions, agent template summaries, action log path, managed-agent count, and recent agent summary.
+Returns project detail data for the mobile detail view, including branch/commit metadata, Kamal deploy details, versions, agent template summaries with model/effort defaults, action log path, managed-agent count, and recent agent summary.
 
 ### `GET /projects/{key}/actions/{action}`
 
@@ -721,7 +725,7 @@ Discovers skills for the project workspace and agent harness, reusing `HQ::Skill
 
 ### `GET /setup`
 
-Returns Remote UI readiness metadata: local URL, public Tailscale/MagicDNS URL, auth state, counts, harness readiness, schema/config readiness, log/storage summary, refresh intervals, and safety defaults.
+Returns Remote UI readiness metadata: local URL, public Tailscale/MagicDNS URL, auth state, counts, harness readiness, schema/config readiness, log/storage summary, refresh intervals, and safety defaults. Harness readiness entries may include `model_suggestions`, `reasoning_effort_suggestions`, and `catalog_source`; these are UI hints only and are not validation allowlists.
 
 When no projects are configured, the payload includes onboarding metadata so the
 Remote UI can render a first-run screen without the normal header or footer.

--- a/lib/hq/app.rb
+++ b/lib/hq/app.rb
@@ -1067,7 +1067,10 @@ def selected_screen_items
                        agent_key: new_agent.key,
                        source_agent_key: old_agent.key,
                        project_key: new_agent.project_key,
-                       name: new_agent.name)
+                       name: new_agent.name,
+                       agent: new_agent.agent,
+                       model: new_agent.model,
+                       reasoning_effort: new_agent.reasoning_effort)
       [self, nil]
     end
 
@@ -1343,6 +1346,12 @@ def selected_screen_items
       when @agent_editor.name_field_index then @agent_editor.instance_variable_set(:@name_input, updated_input)
       when @agent_editor.workspace_field_index
         @agent_editor.instance_variable_set(:@workspace_input, updated_input)
+      when @agent_editor.model_field_index
+        @agent_editor.mark_model_dirty!
+        @agent_editor.instance_variable_set(:@model_input, updated_input)
+      when @agent_editor.reasoning_effort_field_index
+        @agent_editor.mark_reasoning_effort_dirty!
+        @agent_editor.instance_variable_set(:@reasoning_effort_input, updated_input)
       else
         @agent_editor.instance_variable_set(:@prompt_input, updated_input)
       end
@@ -1369,7 +1378,10 @@ def selected_screen_items
                          project_key: agent.project_key,
                          template_key: agent.template_key.to_s,
                          name: agent.name,
-                         workspace: agent.workspace)
+                         workspace: agent.workspace,
+                         agent: agent.agent,
+                         model: agent.model,
+                         reasoning_effort: agent.reasoning_effort)
         if @agent_editor.run_on_submit?
           begin
             agent.start!

--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -26,6 +26,7 @@ module HQ
       events = []
       agents = JSON.parse(File.read(AGENTS_FILE)).map do |hash|
         agent = ManagedAgent.from_hash(hash)
+        changed = true if hash != agent.to_hash
         before_hash = agent.to_hash
         was_running = running_for_poll_event?(agent)
         agent.poll!
@@ -72,6 +73,8 @@ module HQ
         prompt: template.prompt,
         sandbox_mode: template.sandbox_mode,
         agent: template.agent,
+        model: template.model,
+        reasoning_effort: template.reasoning_effort,
         messages: system_messages_for(project, template.prompt),
         color_index: next_color_index(existing)
       )
@@ -94,6 +97,8 @@ module HQ
         prompt: prompt,
         sandbox_mode: "danger-full-access",
         agent: project.respond_to?(:agent) ? project.agent : project.config.agent,
+        model: project.respond_to?(:model) ? project.model : project.config.model,
+        reasoning_effort: project.respond_to?(:reasoning_effort) ? project.reasoning_effort : project.config.reasoning_effort,
         messages: system_messages,
         created_at: now,
         color_index: next_color_index(existing_agents)
@@ -121,6 +126,8 @@ module HQ
         prompt: agent.prompt,
         sandbox_mode: agent.sandbox_mode,
         agent: agent.agent,
+        model: agent.model,
+        reasoning_effort: agent.reasoning_effort,
         skills: agent.skills,
         color_index: next_color_index(existing_agents)
       )

--- a/lib/hq/domain/harness_catalog.rb
+++ b/lib/hq/domain/harness_catalog.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "timeout"
+
+require_relative "../harness_registry"
+require_relative "executable_resolver"
+
+module HQ
+  module HarnessCatalog
+    REASONING_EFFORT_ORDER = %w[minimal low medium high xhigh max].freeze
+    CLAUDE_MODEL_SUGGESTIONS = %w[default best sonnet opus haiku opusplan].freeze
+    CLAUDE_REASONING_EFFORTS = %w[low medium high xhigh max].freeze
+    COMMAND_TIMEOUT = 2
+
+    module_function
+
+    def for_builtin(name, resolution)
+      cache_key = ["builtin", name.to_s, resolution&.command.to_s, resolution&.path.to_s]
+      catalog_cache[cache_key] ||= build_builtin_catalog(name, resolution)
+    end
+
+    def for_custom(config)
+      cache_key = ["custom", config.key.to_s, config.adapter.to_s, config.execution_command.to_s]
+      catalog_cache[cache_key] ||= build_custom_catalog(config)
+    end
+
+    def build_builtin_catalog(name, resolution)
+      case name.to_s
+      when "codex"
+        codex_catalog(resolution)
+      when "claude"
+        claude_catalog(resolution)
+      else
+        empty_catalog
+      end
+    end
+
+    def build_custom_catalog(config)
+      case config.adapter.to_s
+      when "claude"
+        claude_compatible_catalog(source: "claude-compatible defaults")
+      else
+        empty_catalog
+      end
+    end
+
+    def catalog_cache
+      @catalog_cache ||= {}
+    end
+
+    def codex_catalog(resolution)
+      unless resolution&.available?
+        return {
+          model_suggestions: [],
+          reasoning_effort_suggestions: REASONING_EFFORT_ORDER - ["max"],
+          catalog_source: "codex defaults"
+        }
+      end
+
+      data = capture_json([resolution.command, "debug", "models"]) ||
+             capture_json([resolution.command, "debug", "models", "--bundled"])
+      return empty_catalog.merge(catalog_source: "codex debug models unavailable") unless data
+
+      model_rows = if data.is_a?(Hash)
+                     Array(data["models"] || data[:models] || data.values.find { |value| value.is_a?(Array) })
+                   else
+                     Array(data)
+                   end.select { |item| item.is_a?(Hash) }
+      suggestions = model_rows.filter_map do |item|
+        slug = item["slug"].to_s.strip
+        next if slug.empty?
+        next if item["visibility"].to_s == "hide"
+
+        efforts = Array(item["supported_reasoning_levels"]).filter_map do |level|
+          level.is_a?(Hash) ? level["effort"].to_s.strip : nil
+        end.reject(&:empty?)
+
+        {
+          value: slug,
+          label: item["display_name"].to_s.empty? ? slug : item["display_name"].to_s,
+          default_reasoning_effort: empty_to_nil(item["default_reasoning_level"]),
+          reasoning_efforts: sort_efforts(efforts)
+        }
+      end
+
+      {
+        model_suggestions: suggestions,
+        reasoning_effort_suggestions: sort_efforts(suggestions.flat_map { |item| item[:reasoning_efforts] }),
+        catalog_source: "codex debug models"
+      }
+    end
+
+    def claude_catalog(resolution)
+      efforts = resolution&.available? ? claude_help_efforts(resolution.command) : []
+      claude_compatible_catalog(
+        reasoning_efforts: efforts.empty? ? CLAUDE_REASONING_EFFORTS : efforts,
+        source: efforts.empty? ? "claude defaults" : "claude --help"
+      )
+    end
+
+    def claude_compatible_catalog(reasoning_efforts: CLAUDE_REASONING_EFFORTS, source:)
+      {
+        model_suggestions: CLAUDE_MODEL_SUGGESTIONS.map { |model| { value: model, label: model } },
+        reasoning_effort_suggestions: reasoning_efforts,
+        catalog_source: source
+      }
+    end
+
+    def claude_help_efforts(command)
+      _out, err, status = nil
+      out = ""
+      Timeout.timeout(COMMAND_TIMEOUT) do
+        out, err, status = Open3.capture3(command, "--help")
+      end
+      return [] unless status.success?
+
+      text = "#{out}\n#{err}"
+      match = text.match(/--effort\s+<[^>]+>.*?\(([^)]+)\)/m)
+      return [] unless match
+
+      match[1].split(/,\s*/).map { |value| value.strip.downcase }.reject(&:empty?)
+    rescue StandardError
+      []
+    end
+
+    def capture_json(command)
+      out = ""
+      status = nil
+      Timeout.timeout(COMMAND_TIMEOUT) do
+        out, _err, status = Open3.capture3(*command)
+      end
+      return nil unless status.success?
+
+      JSON.parse(out)
+    rescue StandardError
+      nil
+    end
+
+    def sort_efforts(values)
+      values = Array(values).map { |value| value.to_s.strip.downcase }.reject(&:empty?).uniq
+      values.sort_by { |value| [REASONING_EFFORT_ORDER.index(value) || 99, value] }
+    end
+
+    def empty_catalog
+      {
+        model_suggestions: [],
+        reasoning_effort_suggestions: [],
+        catalog_source: nil
+      }
+    end
+
+    def empty_to_nil(value)
+      text = value.to_s.strip
+      text.empty? ? nil : text
+    end
+  end
+end

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -11,6 +11,7 @@ require_relative "agent_chat_log"
 require_relative "process_liveness"
 require "digest"
 require "securerandom"
+require "shellwords"
 
 module HQ
   class ManagedAgent
@@ -87,14 +88,15 @@ module HQ
 
     attr_reader :key, :name, :project_key, :template_key, :workspace, :prompt, :created_at, :started_at,
                 :finished_at, :pid, :last_exit_code, :log_path, :runs, :sandbox_mode, :agent, :messages, :skills,
-                :session_id, :session_bootstrapped, :color_index, :summary, :structured_result
+                :model, :reasoning_effort, :session_id, :session_bootstrapped, :color_index, :summary,
+                :structured_result
     attr_writer :summary, :structured_result
 
     def initialize(key:, name:, project_key:, template_key:, workspace:, prompt:, created_at: nil, started_at: nil,
                    finished_at: nil, pid: nil, last_exit_code: nil, log_path: nil, runs: nil,
                    stop_requested_at: nil, sandbox_mode: "danger-full-access", agent: "codex", messages: nil,
-                   skills: nil, unread: false, session_id: nil, session_bootstrapped: nil, color_index: nil,
-                   summary: nil, structured_result: nil)
+                   model: nil, reasoning_effort: nil, skills: nil, unread: false, session_id: nil,
+                   session_bootstrapped: nil, color_index: nil, summary: nil, structured_result: nil)
       @key = key
       @name = name
       @project_key = project_key
@@ -111,6 +113,8 @@ module HQ
       @stop_requested_at = stop_requested_at
       @sandbox_mode = normalize_sandbox_mode(sandbox_mode)
       @agent = normalize_agent(agent)
+      @model = normalize_model(model)
+      @reasoning_effort = normalize_reasoning_effort(reasoning_effort)
       @messages = normalize_messages(messages)
       seed_memory_from_initial_messages!(messages)
       @skills = normalize_skills(skills)
@@ -142,6 +146,14 @@ module HQ
     end
 
     def self.from_hash(hash)
+      runs = Array(hash["runs"]).map { |run| AgentRun.from_hash(run) }
+      launch_settings = launch_settings_from_runs(runs)
+      model = hash["model"].to_s.strip.empty? ? launch_settings[:model] : hash["model"]
+      reasoning_effort = if hash["reasoning_effort"].to_s.strip.empty?
+                           launch_settings[:reasoning_effort]
+                         else
+                           hash["reasoning_effort"]
+                         end
       new(
         key: hash["key"],
         name: hash["name"],
@@ -155,10 +167,12 @@ module HQ
         pid: hash["pid"],
         last_exit_code: hash["last_exit_code"],
         log_path: hash["log_path"] || LogPaths.legacy_agent_raw_log_path(hash["key"]),
-        runs: Array(hash["runs"]).map { |run| AgentRun.from_hash(run) },
+        runs: runs,
         stop_requested_at: parse_time(hash["stop_requested_at"]),
         sandbox_mode: hash["sandbox_mode"],
         agent: hash["agent"],
+        model: model,
+        reasoning_effort: reasoning_effort,
         skills: hash["skills"],
         unread: hash["unread"],
         session_id: hash["session_id"],
@@ -168,6 +182,84 @@ module HQ
         structured_result: hash["structured_result"]
       )
     end
+
+    def self.launch_settings_from_runs(runs)
+      settings = {}
+      runs.reverse_each do |run|
+        parts = split_command(run.command)
+        next if parts.empty?
+
+        settings[:model] ||= model_from_command(parts)
+        settings[:reasoning_effort] ||= reasoning_effort_from_command(parts)
+        break if settings[:model] && settings[:reasoning_effort]
+      end
+      settings
+    end
+
+    def self.split_command(command)
+      Shellwords.split(command.to_s)
+    rescue ArgumentError
+      []
+    end
+
+    def self.model_from_command(parts)
+      command_option_parts(parts).each_with_index do |part, index|
+        return nonempty_argument(parts[index + 1]) if part == "--model" || part == "-m"
+        return nonempty_argument(part.split("=", 2).last) if part.start_with?("--model=")
+      end
+      nil
+    end
+
+    def self.reasoning_effort_from_command(parts)
+      command_option_parts(parts).each_with_index do |part, index|
+        return nonempty_argument(parts[index + 1]) if part == "--effort"
+        return nonempty_argument(part.split("=", 2).last) if part.start_with?("--effort=")
+
+        if part == "-c" || part == "--config"
+          effort = reasoning_effort_from_config(parts[index + 1])
+          return effort if effort
+        elsif part.start_with?("--config=")
+          effort = reasoning_effort_from_config(part.split("=", 2).last)
+          return effort if effort
+        end
+      end
+      nil
+    end
+
+    def self.command_option_parts(parts)
+      separator = parts.index("--")
+      separator ? parts[0...separator] : parts
+    end
+
+    def self.reasoning_effort_from_config(value)
+      text = value.to_s.strip
+      return nil unless text.start_with?("model_reasoning_effort")
+
+      raw_value = text.split("=", 2).last
+      return nil if raw_value == text
+
+      nonempty_argument(unquote_argument(raw_value))
+    end
+
+    def self.unquote_argument(value)
+      text = value.to_s.strip
+      if (text.start_with?("\"") && text.end_with?("\"")) ||
+         (text.start_with?("'") && text.end_with?("'"))
+        return text[1...-1]
+      end
+
+      text
+    end
+
+    def self.nonempty_argument(value)
+      text = value.to_s.strip
+      text.empty? ? nil : text
+    end
+
+    private_class_method :launch_settings_from_runs, :split_command, :model_from_command,
+                         :reasoning_effort_from_command, :command_option_parts,
+                         :reasoning_effort_from_config, :unquote_argument,
+                         :nonempty_argument
 
     def to_hash
       result = {
@@ -190,6 +282,8 @@ module HQ
         "skills" => @skills,
         "unread" => @unread
       }
+      result["model"] = @model unless @model.to_s.empty?
+      result["reasoning_effort"] = @reasoning_effort unless @reasoning_effort.to_s.empty?
       unless @session_id.to_s.empty?
         result["session_id"] = @session_id
         result["session_bootstrapped"] = @session_bootstrapped
@@ -446,13 +540,16 @@ module HQ
       [claude_executable]
     end
 
-    def update!(name:, template_key:, workspace:, prompt:, sandbox_mode: @sandbox_mode, agent: @agent)
+    def update!(name:, template_key:, workspace:, prompt:, sandbox_mode: @sandbox_mode, agent: @agent,
+                model: @model, reasoning_effort: @reasoning_effort)
       @name = name
       @template_key = template_key
       @workspace = workspace
       @prompt = prompt
       @sandbox_mode = normalize_sandbox_mode(sandbox_mode)
       @agent = normalize_agent(agent)
+      @model = normalize_model(model)
+      @reasoning_effort = normalize_reasoning_effort(reasoning_effort)
       reset_base_prompt!
       memory_store.append_system_prompt!(@prompt, created_at: Time.now)
       HQ.hooks.publish("agent.updated",
@@ -461,7 +558,9 @@ module HQ
                        name: @name,
                        template_key: @template_key,
                        workspace: @workspace,
-                       agent: @agent)
+                       agent: @agent,
+                       model: @model,
+                       reasoning_effort: @reasoning_effort)
     end
 
     def add_user_message!(content, inquiry_id: nil, attachments: nil, metadata: nil)
@@ -641,6 +740,8 @@ module HQ
     def build_codex_command
       command = [codex_executable, "exec"]
       command << "resume" unless @session_id.to_s.empty?
+      command.concat(model_arguments)
+      command.concat(codex_reasoning_effort_arguments)
       if @sandbox_mode == "danger-full-access"
         command << "--dangerously-bypass-approvals-and-sandbox"
       else
@@ -667,6 +768,8 @@ module HQ
 
     def build_interactive_codex_command
       command = [codex_executable]
+      command.concat(model_arguments)
+      command.concat(codex_reasoning_effort_arguments)
       if @sandbox_mode == "danger-full-access"
         command << "--dangerously-bypass-approvals-and-sandbox"
       else
@@ -683,6 +786,8 @@ module HQ
 
     def build_interactive_claude_like_command(command_prefix:, env: {})
       command = command_prefix.dup
+      command.concat(model_arguments)
+      command.concat(claude_effort_arguments)
       command << "--dangerously-skip-permissions" if @sandbox_mode == "danger-full-access"
       command.concat(["--resume", @session_id]) unless @session_id.to_s.empty?
       { command: command, env: env }
@@ -690,6 +795,8 @@ module HQ
 
     def build_claude_like_command(command_prefix:, env: {})
       command = command_prefix.dup
+      command.concat(model_arguments)
+      command.concat(claude_effort_arguments)
       command << "--dangerously-skip-permissions" if @sandbox_mode == "danger-full-access"
       command.concat(["--print", "--output-format", "stream-json", "--verbose"])
       command.concat(claude_session_arguments)
@@ -697,6 +804,18 @@ module HQ
       command.concat(["--json-schema", schema]) if schema
       command << prompt_for_execution
       { command: command, env: env }
+    end
+
+    def model_arguments
+      @model.to_s.empty? ? [] : ["--model", @model]
+    end
+
+    def codex_reasoning_effort_arguments
+      @reasoning_effort.to_s.empty? ? [] : ["-c", "model_reasoning_effort=\"#{@reasoning_effort}\""]
+    end
+
+    def claude_effort_arguments
+      @reasoning_effort.to_s.empty? ? [] : ["--effort", @reasoning_effort]
     end
 
     def missing_executable_for(command)
@@ -1379,6 +1498,16 @@ module HQ
       return "danger-full-access" if value.empty? || value == "none"
 
       value
+    end
+
+    def normalize_model(value)
+      text = value.to_s.strip
+      text.empty? ? nil : text
+    end
+
+    def normalize_reasoning_effort(value)
+      text = value.to_s.strip.downcase
+      text.empty? ? nil : text
     end
 
     def normalize_skills(value)

--- a/lib/hq/registry.rb
+++ b/lib/hq/registry.rb
@@ -7,7 +7,16 @@ require_relative "domain/constants"
 module HQ
   class ConfigError < StandardError; end
 
-  AgentTemplateConfig = Struct.new(:key, :name, :prompt, :sandbox_mode, :agent, keyword_init: true)
+  AgentTemplateConfig = Struct.new(
+    :key,
+    :name,
+    :prompt,
+    :sandbox_mode,
+    :agent,
+    :model,
+    :reasoning_effort,
+    keyword_init: true
+  )
   GroupConfig = Struct.new(:name, :hidden, keyword_init: true)
   ProjectConfig = Struct.new(
     :key,
@@ -16,6 +25,8 @@ module HQ
     :path,
     :apps,
     :agent,
+    :model,
+    :reasoning_effort,
     :agent_templates,
     :hooks,
     :pr_url,
@@ -52,6 +63,7 @@ module HQ
       @groups = build_groups(data["groups"])
       HQ.custom_harnesses = @custom_harnesses
       remove_instance_variable(:@normalized_system_prompts) if instance_variable_defined?(:@normalized_system_prompts)
+      remove_instance_variable(:@system_prompt_templates) if instance_variable_defined?(:@system_prompt_templates)
       write_yaml(@path, data) if persist_detected_apps!(data)
       @projects = build_projects(data["projects"] || [])
       validate!
@@ -256,6 +268,8 @@ module HQ
           path: path,
           apps: apps_enabled,
           agent: normalize_agent(project["agent"]),
+          model: normalize_model(project["model"]),
+          reasoning_effort: normalize_reasoning_effort(project["reasoning_effort"]),
           agent_templates: build_agent_templates(
             project,
             project_key: key,
@@ -338,6 +352,8 @@ module HQ
       templates = system_prompt_templates
       templates = [default_template(project)] if templates.empty?
       project_agent = normalize_agent(project["agent"])
+      project_model = normalize_model(project["model"])
+      project_reasoning_effort = normalize_reasoning_effort(project["reasoning_effort"])
 
       built_templates = templates.map.with_index(1) do |template, index|
         prompt = resolve_template_prompt(
@@ -353,7 +369,11 @@ module HQ
           name: (template["name"] || humanize_template_key(template["key"]) || "Template #{index}").to_s,
           prompt: prompt.to_s.strip,
           sandbox_mode: (template["sandbox_mode"] || "danger-full-access").to_s,
-          agent: normalize_agent(template["agent"] || project_agent)
+          agent: normalize_agent(template["agent"] || project_agent),
+          model: normalize_model(template.key?("model") ? template["model"] : project_model),
+          reasoning_effort: normalize_reasoning_effort(
+            template.key?("reasoning_effort") ? template["reasoning_effort"] : project_reasoning_effort
+          )
         )
       end
 
@@ -366,8 +386,20 @@ module HQ
         "name" => "Default",
         "prompt" => "Work inside #{expand_path(project["path"])}. Inspect the repository, identify the highest-value next task, implement it if safe, run the relevant checks, and summarize the result.",
         "sandbox_mode" => "danger-full-access",
-        "agent" => normalize_agent(project["agent"])
+        "agent" => normalize_agent(project["agent"]),
+        "model" => normalize_model(project["model"]),
+        "reasoning_effort" => normalize_reasoning_effort(project["reasoning_effort"])
       }
+    end
+
+    def normalize_model(value)
+      text = value.to_s.strip
+      text.empty? ? nil : text
+    end
+
+    def normalize_reasoning_effort(value)
+      text = value.to_s.strip.downcase
+      text.empty? ? nil : text
     end
 
     def normalize_agent(agent)
@@ -421,7 +453,19 @@ module HQ
     end
 
     def system_prompt_templates
-      normalized_system_prompts.keys.map { |prompt_key| { "key" => prompt_key.to_s } }
+      return @system_prompt_templates if defined?(@system_prompt_templates)
+
+      @system_prompt_templates = @system_prompts.map do |prompt_key, prompt|
+        if prompt.is_a?(Hash)
+          prompt.each_with_object({ "key" => prompt_key.to_s }) do |(key, value), result|
+            next if %w[prompt content].include?(key.to_s)
+
+            result[key.to_s] = value
+          end
+        else
+          { "key" => prompt_key.to_s }
+        end
+      end
     end
 
     def interpolate_prompt(prompt, prompt_key:, project_key:, project_name:, project_path:, project_group:)
@@ -452,7 +496,12 @@ module HQ
       return @normalized_system_prompts if defined?(@normalized_system_prompts)
 
       @normalized_system_prompts = @system_prompts.each_with_object({}) do |(prompt_key, prompt), prompts|
-        prompts[prompt_key.to_s] = prompt.to_s
+        prompt_value = if prompt.is_a?(Hash)
+                         prompt["prompt"] || prompt["content"] || prompt[:prompt] || prompt[:content]
+                       else
+                         prompt
+                       end
+        prompts[prompt_key.to_s] = prompt_value.to_s
       end
     end
 

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -16,6 +16,7 @@ require_relative "domain/agent_attachment_store"
 require_relative "domain/agent_chat_log"
 require_relative "domain/agent_store"
 require_relative "domain/executable_resolver"
+require_relative "domain/harness_catalog"
 require_relative "domain/kamal_action"
 require_relative "domain/push_notification_store"
 require_relative "domain/push_subscription_store"
@@ -1006,7 +1007,10 @@ module HQ
                        agent_key: target.key,
                        source_agent_key: source.key,
                        project_key: target.project_key,
-                       name: target.name)
+                       name: target.name,
+                       agent: target.agent,
+                       model: target.model,
+                       reasoning_effort: target.reasoning_effort)
 
       {
         agent: agent_payload(target),
@@ -1492,6 +1496,8 @@ module HQ
           key: template.key,
           name: template.name,
           agent: template.agent,
+          model: template.model,
+          reasoning_effort: template.reasoning_effort,
           sandbox_mode: template.sandbox_mode,
           skill_trigger: SkillDiscovery.trigger_for(template.agent),
           prompt: template.prompt,
@@ -1532,8 +1538,8 @@ module HQ
 
     def harness_readiness
       builtins = [
-        resolver_payload("codex", ExecutableResolver.resolve_tool("codex")),
-        resolver_payload("claude", ExecutableResolver.resolve_tool("claude"))
+        harness_resolver_payload("codex", ExecutableResolver.resolve_tool("codex")),
+        harness_resolver_payload("claude", ExecutableResolver.resolve_tool("claude"))
       ]
       custom = HQ.custom_harnesses.values.sort_by(&:key).map { |config| custom_harness_payload(config) }
       builtins + custom
@@ -1559,6 +1565,10 @@ module HQ
       }
     end
 
+    def harness_resolver_payload(name, resolution)
+      resolver_payload(name, resolution).merge(HarnessCatalog.for_builtin(name, resolution))
+    end
+
     def custom_harness_payload(config)
       command = readiness_command_for(config.command_parts)
       resolution = command ? ExecutableResolver.resolve(command) : nil
@@ -1576,7 +1586,7 @@ module HQ
         adapter: config.adapter,
         path: resolution&.path,
         source: resolution&.source
-      }
+      }.merge(HarnessCatalog.for_custom(config))
     end
 
     def executable_detail(resolution)
@@ -1695,6 +1705,8 @@ module HQ
       sandbox_mode = attrs.key?("sandbox_mode") ? attrs["sandbox_mode"].to_s : target.sandbox_mode.to_s
       sandbox_mode = template.sandbox_mode.to_s if sandbox_mode.empty?
       agent = (attrs.key?("agent") ? attrs["agent"].to_s : target.agent.to_s).strip.downcase
+      model = attrs.key?("model") ? attrs["model"].to_s.strip : target.model.to_s
+      reasoning_effort = attrs.key?("reasoning_effort") ? attrs["reasoning_effort"].to_s.strip.downcase : target.reasoning_effort.to_s
       workspace = project.path if workspace.empty? && creating
 
       raise Error.new("Name is required") if name.strip.empty?
@@ -1710,7 +1722,9 @@ module HQ
         workspace: workspace.strip,
         prompt: prompt.strip,
         sandbox_mode: sandbox_mode,
-        agent: agent
+        agent: agent,
+        model: model.empty? ? nil : model,
+        reasoning_effort: reasoning_effort.empty? ? nil : reasoning_effort
       }
     end
 
@@ -1754,6 +1768,8 @@ module HQ
         prompt: agent.prompt,
         sandbox_mode: agent.sandbox_mode,
         agent: agent.agent,
+        model: agent.model,
+        reasoning_effort: agent.reasoning_effort,
         status: agent.status,
         running: agent.running?,
         unread: agent.unread?,

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2075,6 +2075,8 @@ function renderAgentForm(route) {
     name: editing || cloning ? agent.name : defaultAgentName(project, selectedTemplate),
     templateKey: selectedTemplate.key,
     harness: normalizeAgentHarness(editing || cloning ? agent.agent : selectedTemplate.agent),
+    model: editing || cloning ? (agent.model || "") : (selectedTemplate.model || ""),
+    reasoningEffort: editing || cloning ? (agent.reasoning_effort || "") : (selectedTemplate.reasoning_effort || ""),
     sandboxMode: editing || cloning ? (agent.sandbox_mode || selectedTemplate.sandbox_mode) : selectedTemplate.sandbox_mode,
     workspace: editing || cloning ? agent.workspace : project.path,
     prompt: prompt || "",
@@ -2096,10 +2098,22 @@ function renderAgentForm(route) {
       </section>
       <section class="field-card">
         <label class="field-label" for="agent-harness">Harness</label>
-        <select id="agent-harness" name="agent">
+        <select id="agent-harness" name="agent" data-agent-harness-select>
           ${agentHarnessOptions().map((harness) => `<option value="${escapeAttr(harness)}" ${harness === values.harness ? "selected" : ""}>${escapeHtml(harness)}</option>`).join("")}
         </select>
         <input id="agent-sandbox-mode" type="hidden" name="sandbox_mode" value="${escapeAttr(values.sandboxMode)}">
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="agent-model">Model</label>
+        <select id="agent-model" name="model" data-agent-model-select>
+          ${modelChoiceOptions(values.harness, values.model)}
+        </select>
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="agent-reasoning-effort">Effort</label>
+        <select id="agent-reasoning-effort" name="reasoning_effort" data-agent-reasoning-effort-select>
+          ${reasoningEffortChoiceOptions(values.harness, values.model, values.reasoningEffort)}
+        </select>
       </section>
       <section class="field-card">
         <label class="field-label" for="agent-name">Name</label>
@@ -2164,6 +2178,8 @@ function renderAgentArchive(key) {
       <div class="kv-grid">
         ${kv("Template", agentTemplateLabel(agent))}
         ${kv("Harness", agent.agent || "agent")}
+        ${kv("Model", agent.model || "default")}
+        ${kv("Effort", agent.reasoning_effort || "default")}
         ${kv("Status", statusLabel(agent))}
         ${kv("Runs", agent.run_count)}
       </div>
@@ -3429,6 +3445,8 @@ function agentMatches(agent, query) {
     agent.project_key,
     agent.template_key,
     agent.agent,
+    agent.model,
+    agent.reasoning_effort,
     agent.status,
     agent.last_result,
     agent.summary,
@@ -3670,6 +3688,8 @@ function agentSettingsHtml(agent) {
       ${kv("Project", agentProjectLabel(agent))}
       ${kv("Template", agentTemplateLabel(agent))}
       ${kv("Harness", agent.agent || "agent")}
+      ${kv("Model", agent.model || "default")}
+      ${kv("Effort", agent.reasoning_effort || "default")}
       ${kv("Status", statusLabel(agent))}
       ${kv("Runs", agent.run_count)}
       ${kv("Exit", agent.last_exit_code ?? "n/a")}
@@ -3802,6 +3822,8 @@ function agentTemplateOptionHtml(template, selected) {
       value="${escapeAttr(template.key)}"
       data-template-name="${escapeAttr(template.name || template.key)}"
       data-agent="${escapeAttr(normalizeAgentHarness(template.agent))}"
+      data-model="${escapeAttr(template.model || "")}"
+      data-reasoning-effort="${escapeAttr(template.reasoning_effort || "")}"
       data-sandbox-mode="${escapeAttr(template.sandbox_mode || "danger-full-access")}"
       data-prompt="${escapeAttr(template.prompt || "")}"
       data-prompt-preview="${escapeAttr(template.prompt_preview || "")}"
@@ -3818,6 +3840,68 @@ function defaultAgentName(project, template) {
 function agentHarnessOptions() {
   const names = (state.setup?.harnesses || []).map((item) => item.name).filter(Boolean);
   return names.length ? names : BUILTIN_AGENT_HARNESSES;
+}
+
+function harnessSetupItem(name) {
+  const normalized = String(name || "").trim().toLowerCase();
+  return (state.setup?.harnesses || []).find((item) => item.name === normalized) || null;
+}
+
+function modelSuggestionsForHarness(name) {
+  const suggestions = harnessSetupItem(name)?.model_suggestions;
+  return Array.isArray(suggestions) ? suggestions : [];
+}
+
+function reasoningEffortSuggestionsForHarness(name) {
+  const suggestions = harnessSetupItem(name)?.reasoning_effort_suggestions;
+  return Array.isArray(suggestions) ? suggestions : [];
+}
+
+function modelChoiceOptions(harness, selectedModel = "") {
+  const selected = String(selectedModel || "").trim();
+  const suggestions = modelSuggestionsForHarness(harness);
+  const hasSelected = suggestions.some((item) => String(item?.value || item || "").trim() === selected);
+  return [
+    `<option value="" ${selected ? "" : "selected"}>Default</option>`,
+    ...suggestions.map((item) => {
+      const value = String(item?.value || item || "").trim();
+      if (!value) return "";
+      const label = String(item?.label || "").trim();
+      const text = label && label !== value ? `${label} (${value})` : value;
+      return `<option value="${escapeAttr(value)}" ${value === selected ? "selected" : ""}>${escapeHtml(text)}</option>`;
+    }),
+    selected && !hasSelected ? `<option value="${escapeAttr(selected)}" selected>Custom (${escapeHtml(selected)})</option>` : "",
+  ].join("");
+}
+
+function modelSuggestionForValue(harness, model) {
+  const value = String(model || "").trim();
+  if (!value) return null;
+  return modelSuggestionsForHarness(harness).find((item) => String(item?.value || item || "").trim() === value) || null;
+}
+
+function reasoningEffortSuggestionsForModel(harness, model) {
+  const suggestion = modelSuggestionForValue(harness, model);
+  const efforts = suggestion?.reasoning_efforts;
+  return Array.isArray(efforts) && efforts.length ? efforts : reasoningEffortSuggestionsForHarness(harness);
+}
+
+function defaultReasoningEffortForModel(harness, model) {
+  return String(modelSuggestionForValue(harness, model)?.default_reasoning_effort || "").trim();
+}
+
+function reasoningEffortChoiceOptions(harness, model = "", selectedEffort = "") {
+  const selected = String(selectedEffort || "").trim().toLowerCase();
+  const suggestions = reasoningEffortSuggestionsForModel(harness, model);
+  const hasSelected = suggestions.some((item) => String(item || "").trim().toLowerCase() === selected);
+  return [
+    `<option value="" ${selected ? "" : "selected"}>Default</option>`,
+    ...suggestions.map((item) => {
+      const value = String(item || "").trim();
+      return value ? `<option value="${escapeAttr(value)}" ${value === selected ? "selected" : ""}>${escapeHtml(value)}</option>` : "";
+    }),
+    selected && !hasSelected ? `<option value="${escapeAttr(selected)}" selected>Custom (${escapeHtml(selected)})</option>` : "",
+  ].join("");
 }
 
 function normalizeAgentHarness(value) {
@@ -3842,7 +3926,7 @@ function agentHarnessLabel(agent) {
 }
 
 function agentHeaderLabel(agent) {
-  return `${agentProjectLabel(agent)} / ${agentHarnessLabel(agent)}`;
+  return [agentProjectLabel(agent), agentHarnessLabel(agent), agent.model, agent.reasoning_effort].filter(Boolean).join(" / ");
 }
 
 function agentTemplateLabel(agent) {
@@ -4246,7 +4330,7 @@ function projectStatusClass(project) {
 }
 
 function agentMeta(agent) {
-  return [agent.project_key, agent.agent].filter(Boolean).join(" / ");
+  return [agent.project_key, agent.agent, agent.model, agent.reasoning_effort].filter(Boolean).join(" / ");
 }
 
 function agentUpdatedAt(agent) {
@@ -4939,10 +5023,26 @@ els.view.addEventListener("change", (event) => {
     return;
   }
 
-  const templateSelect = event.target.closest("[data-agent-template-select]");
-  if (!templateSelect) return;
+  const modelChoice = event.target.closest("[data-agent-model-select]");
+  if (modelChoice) {
+    applyAgentModelChoice(modelChoice);
+    return;
+  }
 
-  applyAgentTemplateSelection(templateSelect);
+  const reasoningEffortChoice = event.target.closest("[data-agent-reasoning-effort-select]");
+  if (reasoningEffortChoice) {
+    applyAgentReasoningEffortChoice(reasoningEffortChoice);
+    return;
+  }
+
+  const templateSelect = event.target.closest("[data-agent-template-select]");
+  if (templateSelect) {
+    applyAgentTemplateSelection(templateSelect);
+    return;
+  }
+
+  const harnessSelect = event.target.closest("[data-agent-harness-select]");
+  if (harnessSelect) applyAgentHarnessSelection(harnessSelect);
 });
 
 els.view.addEventListener("submit", (event) => {
@@ -5182,10 +5282,19 @@ function applyAgentTemplateSelection(select) {
   const harnessSelect = form.querySelector("#agent-harness");
   const sandboxInput = form.querySelector("#agent-sandbox-mode");
   const nameInput = form.querySelector("#agent-name");
+  const modelSelect = form.querySelector("#agent-model");
+  const reasoningEffortSelect = form.querySelector("#agent-reasoning-effort");
   const hint = form.querySelector(".field-hint");
 
   if (promptInput) promptInput.value = option.dataset.prompt || "";
-  if (harnessSelect) harnessSelect.value = normalizeAgentHarness(option.dataset.agent);
+  const harness = normalizeAgentHarness(option.dataset.agent);
+  if (harnessSelect) harnessSelect.value = harness;
+  if (modelSelect && modelSelect.dataset.dirty !== "true") modelSelect.value = option.dataset.model || "";
+  updateAgentModelChoices(form, harness);
+  if (reasoningEffortSelect && reasoningEffortSelect.dataset.dirty !== "true") {
+    reasoningEffortSelect.value = option.dataset.reasoningEffort || defaultReasoningEffortForModel(harness, modelSelect?.value) || "";
+    syncReasoningEffortForModel(form, { applyDefault: false });
+  }
   if (sandboxInput) sandboxInput.value = option.dataset.sandboxMode || "danger-full-access";
   if (hint) hint.textContent = option.dataset.promptPreview || "Template defaults are loaded from the project configuration.";
   if (mode === "create" && nameInput) {
@@ -5196,12 +5305,60 @@ function applyAgentTemplateSelection(select) {
   saveFormDraft(form);
 }
 
+function applyAgentHarnessSelection(select) {
+  const form = select.closest("#agent-form");
+  if (!form) return;
+
+  updateAgentModelChoices(form, normalizeAgentHarness(select.value));
+  saveFormDraft(form);
+}
+
+function applyAgentModelChoice(select) {
+  const form = select.closest("#agent-form");
+  if (!form) return;
+
+  select.dataset.dirty = "true";
+  syncReasoningEffortForModel(form, { applyDefault: true });
+  saveFormDraft(form);
+}
+
+function applyAgentReasoningEffortChoice(select) {
+  const form = select.closest("#agent-form");
+  if (!form) return;
+
+  select.dataset.dirty = "true";
+  saveFormDraft(form);
+}
+
+function updateAgentModelChoices(form, harness) {
+  const modelSelect = form.querySelector("#agent-model");
+  const model = modelSelect?.value || "";
+  if (modelSelect) modelSelect.innerHTML = modelChoiceOptions(harness, model);
+  syncReasoningEffortForModel(form, { applyDefault: false });
+}
+
+function syncReasoningEffortForModel(form, options = {}) {
+  const harness = normalizeAgentHarness(form.querySelector("#agent-harness")?.value);
+  const model = form.querySelector("#agent-model")?.value || "";
+  const effortSelect = form.querySelector("#agent-reasoning-effort");
+  if (effortSelect) effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, model, effortSelect.value || "");
+  if (options.applyDefault && effortSelect && effortSelect.dataset.dirty !== "true") {
+    const defaultEffort = defaultReasoningEffortForModel(harness, model);
+    if (defaultEffort) {
+      effortSelect.value = defaultEffort;
+      effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, model, effortSelect.value);
+    }
+  }
+}
+
 function agentFormPayload(form) {
   const formData = new FormData(form);
   const payload = {
     name: String(formData.get("name") || "").trim(),
     template_key: String(formData.get("template_key") || "").trim(),
     agent: normalizeAgentHarness(formData.get("agent")),
+    model: String(formData.get("model") || "").trim(),
+    reasoning_effort: String(formData.get("reasoning_effort") || "").trim().toLowerCase(),
     prompt: String(formData.get("prompt") || "").trim(),
     sandbox_mode: String(formData.get("sandbox_mode") || "").trim(),
   };

--- a/lib/hq/ui/components/agent_editor.rb
+++ b/lib/hq/ui/components/agent_editor.rb
@@ -7,7 +7,7 @@ module HQ
   module UI
     class AgentEditor
       attr_reader :mode, :project, :agent, :name_input, :workspace_input, :prompt_input, :field_index,
-                  :template_index
+                  :template_index, :model_input, :reasoning_effort_input
       attr_accessor :error_message
 
       def initialize(mode:, project:, agent: nil)
@@ -20,15 +20,21 @@ module HQ
 
         @name_input = build_input("Name: ", 54)
         @workspace_input = build_input("Workspace: ", 54)
+        @model_input = build_input("Model: ", 54)
+        @reasoning_effort_input = build_input("Effort: ", 54)
         @prompt_input = build_text_area
         @error_message = nil
+        @model_dirty = false
+        @reasoning_effort_dirty = false
 
         if agent
           @name_input.value = agent.name
           @workspace_input.value = agent.workspace
+          @model_input.value = agent.model.to_s
+          @reasoning_effort_input.value = agent.reasoning_effort.to_s
           @prompt_input.value = wrap_prompt(agent.prompt)
         else
-          apply_template_defaults!(preserve_name: false)
+          apply_template_defaults!(preserve_name: false, preserve_model_settings: false)
           @workspace_input.value = project.path
         end
 
@@ -67,6 +73,8 @@ module HQ
         case @field_index
         when name_field_index then @name_input
         when workspace_field_index then @workspace_input
+        when model_field_index then @model_input
+        when reasoning_effort_field_index then @reasoning_effort_input
         when prompt_field_index then @prompt_input
         end
       end
@@ -75,7 +83,7 @@ module HQ
         return if @project.agent_templates.empty?
 
         @template_index = (@template_index + delta) % @project.agent_templates.length
-        apply_template_defaults!(preserve_name: mode == :edit)
+        apply_template_defaults!(preserve_name: mode == :edit, preserve_model_settings: mode == :edit)
       end
 
       def cycle_harness(delta)
@@ -104,7 +112,9 @@ module HQ
           workspace: show_workspace? ? @workspace_input.value.strip : @project.path,
           prompt: @prompt_input.value.strip,
           sandbox_mode: template.sandbox_mode,
-          agent: @selected_harness
+          agent: @selected_harness,
+          model: empty_to_nil(@model_input.value),
+          reasoning_effort: empty_to_nil(@reasoning_effort_input.value&.downcase)
         }
       end
 
@@ -125,7 +135,7 @@ module HQ
       end
 
       def prompt_field_index
-        show_workspace? ? 4 : 3
+        show_workspace? ? 6 : 5
       end
 
       def template_field_index
@@ -137,11 +147,19 @@ module HQ
       end
 
       def name_field_index
-        2
+        4
       end
 
       def workspace_field_index
-        show_workspace? ? 3 : nil
+        show_workspace? ? 5 : nil
+      end
+
+      def model_field_index
+        2
+      end
+
+      def reasoning_effort_field_index
+        3
       end
 
       def create_button_index
@@ -203,7 +221,17 @@ module HQ
         prompt_width = [width, 24].max
         @name_input.width = input_width
         @workspace_input.width = input_width
+        @model_input.width = input_width
+        @reasoning_effort_input.width = input_width
         @prompt_input.width = prompt_width
+      end
+
+      def mark_model_dirty!
+        @model_dirty = true
+      end
+
+      def mark_reasoning_effort_dirty!
+        @reasoning_effort_dirty = true
       end
 
       private
@@ -227,10 +255,14 @@ module HQ
         input
       end
 
-      def apply_template_defaults!(preserve_name:)
+      def apply_template_defaults!(preserve_name:, preserve_model_settings:)
         @prompt_input.value = wrap_prompt(template.prompt)
         @name_input.value = default_name unless preserve_name
         @selected_harness = normalize_harness(template.agent)
+        @model_input.value = template.model.to_s unless preserve_model_settings || @model_dirty
+        unless preserve_model_settings || @reasoning_effort_dirty
+          @reasoning_effort_input.value = template.reasoning_effort.to_s
+        end
       end
 
       def default_name
@@ -260,6 +292,11 @@ module HQ
           end
           lines.join("\n")
         end.join("\n")
+      end
+
+      def empty_to_nil(value)
+        text = value.to_s.strip
+        text.empty? ? nil : text
       end
 
       def focus_current!

--- a/lib/hq/ui/rendering/chat_rendering.rb
+++ b/lib/hq/ui/rendering/chat_rendering.rb
@@ -577,8 +577,13 @@ module HQ
 
         def chat_meta_lines(agent)
           prefix = horizontal_margin_prefix
+          execution_parts = ["template=#{agent.template_key}", "agent=#{agent.agent}"]
+          execution_parts << "model=#{agent.model}" unless agent.model.to_s.empty?
+          execution_parts << "effort=#{agent.reasoning_effort}" unless agent.reasoning_effort.to_s.empty?
+          execution_parts << "sandbox=#{agent.sandbox_mode}"
+          execution_parts << "workspace=#{compact_workspace_path(agent.workspace)}"
           lines = [
-            "template=#{agent.template_key}  agent=#{agent.agent}  sandbox=#{agent.sandbox_mode}  workspace=#{compact_workspace_path(agent.workspace)}",
+            execution_parts.join("  "),
             "created #{format_time(agent.created_at)}  #{Styles::MARKERS[:bullet_sep]}  runs #{agent.run_count}  #{Styles::MARKERS[:bullet_sep]}  last result #{agent.last_result_label}"
           ]
           lines.map { |line| dim_style.render("#{prefix}#{wrap_text(line, chat_content_width)}") }.join("\n")

--- a/lib/hq/ui/rendering/views.rb
+++ b/lib/hq/ui/rendering/views.rb
@@ -136,6 +136,12 @@ module HQ
             width: [sidebar_content_width - 2, 20].max
           )
           name_line = @agent_editor.field_index == @agent_editor.name_field_index ? selected_style.render("  #{@agent_editor.name_input.view}") : "  #{@agent_editor.name_input.view}"
+          model_line = @agent_editor.field_index == @agent_editor.model_field_index ? selected_style.render("  #{@agent_editor.model_input.view}") : "  #{@agent_editor.model_input.view}"
+          reasoning_effort_line = if @agent_editor.field_index == @agent_editor.reasoning_effort_field_index
+                                    selected_style.render("  #{@agent_editor.reasoning_effort_input.view}")
+                                  else
+                                    "  #{@agent_editor.reasoning_effort_input.view}"
+                                  end
           workspace_field_index = @agent_editor.workspace_field_index
           prompt_field_index = @agent_editor.prompt_field_index
           prompt_label = @agent_editor.field_index == prompt_field_index ? selected_style.render("  Prompt:") : "  Prompt:"
@@ -151,6 +157,9 @@ module HQ
           body_lines.concat(template_lines)
           body_lines << ""
           body_lines.concat(harness_lines)
+          body_lines << ""
+          body_lines << model_line
+          body_lines << reasoning_effort_line
           body_lines << ""
           body_lines << name_line
           if workspace_field_index
@@ -942,7 +951,7 @@ module HQ
           name_line = truncate_display(name_line, name_budget)
           gap = [width - visible_width(name_line) - status_width, 1].max
           lines << "#{name_line}#{" " * gap}#{status}"
-          crumb = [project&.name, agent.template_key, agent.agent].compact.reject { |s| s.to_s.empty? }.join(" · ")
+          crumb = [project&.name, agent.template_key, agent.agent, agent.model, agent.reasoning_effort].compact.reject { |s| s.to_s.empty? }.join(" · ")
           lines << "#{Styles::ICONS[:project]}  #{dim_style.render(crumb)}" unless crumb.empty?
 
           chips = agent_chip_row(agent, project)

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -19,6 +19,9 @@ module ManagedAgentTest
     assert_final_output_checklist_is_ephemeral_execution_context
     assert_agent_result_schema_describes_summary
     assert_initial_user_message_attachments_seed_memory
+    assert_model_and_reasoning_effort_persist_and_update
+    assert_legacy_run_commands_backfill_model_and_reasoning_effort
+    assert_model_and_reasoning_effort_arguments_apply_to_harnesses
     assert_start_records_missing_harness_without_spawning
     assert_agent_runner_warns_when_command_cannot_execute
     puts "managed_agent_test: ok"
@@ -636,6 +639,153 @@ module ManagedAgentTest
     end
   ensure
     replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
+  end
+
+  def assert_model_and_reasoning_effort_persist_and_update
+    agent = HQ::ManagedAgent.new(
+      key: "model-agent",
+      name: "Model Agent",
+      project_key: "demo",
+      template_key: "custom",
+      workspace: Dir.tmpdir,
+      prompt: "System prompt",
+      model: "gpt-5.1-codex-max",
+      reasoning_effort: "HIGH"
+    )
+
+    data = agent.to_hash
+    assert(data["model"] == "gpt-5.1-codex-max", "expected model to persist")
+    assert(data["reasoning_effort"] == "high", "expected reasoning effort to normalize and persist")
+
+    restored = HQ::ManagedAgent.from_hash(data)
+    assert(restored.model == "gpt-5.1-codex-max", "expected model to restore")
+    assert(restored.reasoning_effort == "high", "expected reasoning effort to restore")
+
+    restored.update!(
+      name: "Updated Model Agent",
+      template_key: "reviewer",
+      workspace: Dir.tmpdir,
+      prompt: "Updated prompt",
+      model: "",
+      reasoning_effort: ""
+    )
+
+    assert(restored.model.nil?, "expected blank model update to clear the agent model")
+    assert(restored.reasoning_effort.nil?, "expected blank reasoning effort update to clear the agent effort")
+    assert(!restored.to_hash.key?("model"), "expected cleared model to be omitted from persisted hash")
+    assert(!restored.to_hash.key?("reasoning_effort"), "expected cleared effort to be omitted from persisted hash")
+  end
+
+  def assert_legacy_run_commands_backfill_model_and_reasoning_effort
+    session_id = "019e8b77-6fe8-7f02-bb5e-3d35902e1f4d"
+    data = {
+      "key" => "legacy-model-agent",
+      "name" => "Legacy Model Agent",
+      "project_key" => "demo",
+      "template_key" => "custom",
+      "workspace" => Dir.tmpdir,
+      "prompt" => "System prompt",
+      "agent" => "codex",
+      "session_id" => session_id,
+      "runs" => [
+        {
+          "command" => Shellwords.join([
+            "/opt/homebrew/bin/codex", "exec", "--model", "gpt-5.5",
+            "-c", "model_reasoning_effort=\"xhigh\"", "--json", "--", "Initial prompt"
+          ])
+        },
+        {
+          "command" => Shellwords.join([
+            "/opt/homebrew/bin/codex", "exec", "resume", "--json",
+            session_id, "--", "Follow-up prompt"
+          ])
+        }
+      ]
+    }
+
+    restored = HQ::ManagedAgent.from_hash(data)
+    assert(restored.model == "gpt-5.5", "expected legacy run command to backfill model")
+    assert(restored.reasoning_effort == "xhigh", "expected legacy run command to backfill reasoning effort")
+    assert(restored.to_hash["model"] == "gpt-5.5", "expected backfilled model to persist")
+    assert(restored.to_hash["reasoning_effort"] == "xhigh", "expected backfilled effort to persist")
+
+    resume_command = restored.send(:build_command)[:command]
+    assert(argument_after(resume_command, "--model") == "gpt-5.5",
+           "expected backfilled Codex resume command to include --model")
+    assert(argument_after(resume_command, "-c") == "model_reasoning_effort=\"xhigh\"",
+           "expected backfilled Codex resume command to include model_reasoning_effort")
+
+    explicit = HQ::ManagedAgent.from_hash(data.merge("model" => "gpt-5.1", "reasoning_effort" => "medium"))
+    assert(explicit.model == "gpt-5.1", "expected explicit persisted model to beat command backfill")
+    assert(explicit.reasoning_effort == "medium", "expected explicit persisted effort to beat command backfill")
+  end
+
+  def assert_model_and_reasoning_effort_arguments_apply_to_harnesses
+    codex = HQ::ManagedAgent.new(
+      key: "codex-model-agent",
+      name: "Codex Model Agent",
+      project_key: "demo",
+      template_key: "custom",
+      workspace: Dir.tmpdir,
+      prompt: "System prompt",
+      agent: "codex",
+      model: "gpt-5.1-codex-max",
+      reasoning_effort: "xhigh"
+    )
+    codex_command = codex.send(:build_command)[:command]
+    assert(argument_after(codex_command, "--model") == "gpt-5.1-codex-max",
+           "expected Codex command to include --model")
+    assert(argument_after(codex_command, "-c") == "model_reasoning_effort=\"xhigh\"",
+           "expected Codex command to include model_reasoning_effort config")
+
+    claude = HQ::ManagedAgent.new(
+      key: "claude-model-agent",
+      name: "Claude Model Agent",
+      project_key: "demo",
+      template_key: "custom",
+      workspace: Dir.tmpdir,
+      prompt: "System prompt",
+      agent: "claude",
+      model: "sonnet",
+      reasoning_effort: "max"
+    )
+    claude_command = claude.send(:build_command)[:command]
+    assert(argument_after(claude_command, "--model") == "sonnet",
+           "expected Claude command to include --model")
+    assert(argument_after(claude_command, "--effort") == "max",
+           "expected Claude command to include --effort")
+
+    old_harnesses = HQ.custom_harnesses
+    HQ.custom_harnesses = [
+      HQ::HarnessConfig.new(
+        key: "claude-wrapper",
+        adapter: "claude",
+        execution_command: "claude-wrapper --model sonnet"
+      )
+    ]
+    wrapper = HQ::ManagedAgent.new(
+      key: "wrapper-model-agent",
+      name: "Wrapper Model Agent",
+      project_key: "demo",
+      template_key: "custom",
+      workspace: Dir.tmpdir,
+      prompt: "System prompt",
+      agent: "claude-wrapper",
+      model: "opus",
+      reasoning_effort: "high"
+    )
+    wrapper_command = wrapper.send(:build_command)[:command]
+    assert(wrapper_command.each_cons(2).select { |left, _right| left == "--model" }.map(&:last) == %w[sonnet opus],
+           "expected custom Claude-compatible wrapper to keep its prefix model and append agent-level override")
+    assert(argument_after(wrapper_command, "--effort") == "high",
+           "expected custom Claude-compatible wrapper to include --effort")
+  ensure
+    HQ.custom_harnesses = old_harnesses if defined?(old_harnesses)
+  end
+
+  def argument_after(command, flag)
+    index = command.index(flag)
+    index ? command[index + 1] : nil
   end
 
   def assert(condition, message)

--- a/test/registry_test.rb
+++ b/test/registry_test.rb
@@ -16,6 +16,7 @@ module RegistryTest
 
   def run!
     assert_registry_loads_system_prompts_from_sibling_config
+    assert_registry_loads_model_and_effort_defaults
     assert_registry_ignores_hq_env_aliases
     assert_registry_uses_tycho_home_defaults
     assert_registry_preserves_false_apps_flags
@@ -63,6 +64,49 @@ module RegistryTest
              "expected inline prompt to load from flat system prompts")
       names = project.agent_templates.each_with_object({}) { |template, result| result[template.key] = template.name }
       assert(names["custom"] == "Custom", "expected template names to be derived from prompt keys")
+    end
+  end
+
+  def assert_registry_loads_model_and_effort_defaults
+    Dir.mktmpdir("hq-registry-model-test") do |dir|
+      config_path = File.join(dir, "hq.yml")
+      prompts_path = File.join(dir, "system_prompts.yml")
+
+      File.write(config_path, <<~YAML)
+        projects:
+          - key: demo
+            name: Demo
+            group: Personal
+            path: #{File.join(dir, "demo")}
+            agent: codex
+            model: gpt-5.1-codex-max
+            reasoning_effort: HIGH
+      YAML
+
+      File.write(prompts_path, <<~YAML)
+        custom: ""
+        reviewer:
+          name: Reviewer
+          prompt: Review %{project_key} at %{workspace}.
+          agent: claude
+          model: sonnet
+          reasoning_effort: xhigh
+      YAML
+
+      registry = HQ::Registry.new(path: config_path)
+      project = registry.projects.fetch(0)
+      custom = project.agent_templates.find { |template| template.key == "custom" }
+      reviewer = project.agent_templates.find { |template| template.key == "reviewer" }
+
+      assert(project.model == "gpt-5.1-codex-max", "expected project-level model to load")
+      assert(project.reasoning_effort == "high", "expected project-level effort to normalize")
+      assert(custom.model == "gpt-5.1-codex-max", "expected flat prompt template to inherit project model")
+      assert(custom.reasoning_effort == "high", "expected flat prompt template to inherit project effort")
+      assert(reviewer.agent == "claude", "expected structured prompt template to override harness")
+      assert(reviewer.model == "sonnet", "expected structured prompt template to override model")
+      assert(reviewer.reasoning_effort == "xhigh", "expected structured prompt template to override effort")
+      assert(reviewer.prompt == "Review demo at #{File.join(dir, "demo")}.",
+             "expected structured prompt template to interpolate prompt text")
     end
   end
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -23,6 +23,7 @@ module RemoteServerTest
     assert_remote_prompt_start_accepts_dash_prefixed_message
     assert_remote_agent_conversation_hides_run_summary
     assert_remote_project_payloads_include_status_and_detail
+    assert_remote_agent_model_and_effort_payloads
     assert_remote_hidden_settings_filter_projects_and_agents
     assert_remote_schedule_routes
     assert_remote_setup_payload_includes_readiness
@@ -775,6 +776,67 @@ module RemoteServerTest
     end
   end
 
+  def assert_remote_agent_model_and_effort_payloads
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      config_path = File.join(dir, "hq.yml")
+      prompts_path = File.join(dir, "system_prompts.yml")
+      File.write(config_path, <<~YAML)
+        projects:
+          - key: web
+            name: Web
+            path: #{workspace}
+            apps: false
+            agent: codex
+            model: gpt-5.1-codex-max
+            reasoning_effort: low
+      YAML
+      File.write(prompts_path, <<~YAML)
+        custom: Default prompt for %{project_key}.
+        reviewer:
+          name: Reviewer
+          prompt: Review %{project_key}.
+          agent: claude
+          model: sonnet
+          reasoning_effort: xhigh
+      YAML
+      registry = HQ::Registry.new(path: config_path, system_prompts_path: prompts_path)
+      service = HQ::RemoteService.new(registry: registry)
+
+      project = service.project("web")
+      reviewer_template = project[:agent_template_summaries].find { |item| item[:key] == "reviewer" }
+      assert(reviewer_template[:model] == "sonnet", "expected project detail to expose template model")
+      assert(reviewer_template[:reasoning_effort] == "xhigh",
+             "expected project detail to expose template reasoning effort")
+
+      inherited = service.create_agent(
+        "project_key" => "web",
+        "template_key" => "custom",
+        "name" => "Inherited",
+        "prompt" => "Use project defaults."
+      )
+      assert(inherited[:model] == "gpt-5.1-codex-max", "expected created agent to inherit project model")
+      assert(inherited[:reasoning_effort] == "low", "expected created agent to inherit project effort")
+
+      updated = service.update_agent(
+        inherited[:key],
+        "model" => "opus",
+        "reasoning_effort" => "max"
+      )
+      assert(updated[:model] == "opus", "expected update payload to save model")
+      assert(updated[:reasoning_effort] == "max", "expected update payload to save effort")
+
+      cloned = service.clone_agent(updated[:key], {})
+      assert(cloned.dig(:agent, :model) == "opus", "expected clone to copy source model")
+      assert(cloned.dig(:agent, :reasoning_effort) == "max", "expected clone to copy source effort")
+
+      cleared = service.update_agent(updated[:key], "model" => "", "reasoning_effort" => "")
+      assert(cleared[:model].nil?, "expected blank model update to clear model")
+      assert(cleared[:reasoning_effort].nil?, "expected blank effort update to clear effort")
+    end
+  end
+
   def assert_remote_hidden_settings_filter_projects_and_agents
     with_remote_temp_store do |dir|
       prompts_path = File.join(dir, "system_prompts.yml")
@@ -960,16 +1022,20 @@ module RemoteServerTest
         "TYCHO_MISE_BIN" => nil
       ) do
         setup = HQ::RemoteService.new(registry: registry).setup
-        codex = setup[:harnesses].find { |item| item[:name] == "codex" }
-        claude = setup[:harnesses].find { |item| item[:name] == "claude" }
+      codex = setup[:harnesses].find { |item| item[:name] == "codex" }
+      claude = setup[:harnesses].find { |item| item[:name] == "claude" }
         mise = setup[:tools].find { |item| item[:name] == "mise" }
         global_kamal = setup[:tools].find { |item| item[:name] == "kamal" }
         project_kamal = setup[:tools].find { |item| item[:name] == "kamal-projects" }
 
         assert(codex[:ready] && codex[:path].end_with?("/.local/bin/codex"),
                "expected Remote setup to find fallback Codex")
+        assert(codex.key?(:model_suggestions), "expected Codex readiness to expose model suggestions")
+        assert(codex.key?(:reasoning_effort_suggestions), "expected Codex readiness to expose effort suggestions")
         assert(claude[:ready] && claude[:path].end_with?("/.local/bin/claude"),
                "expected Remote setup to find fallback Claude")
+        assert(claude[:reasoning_effort_suggestions].include?("low"),
+               "expected Claude readiness to expose fallback effort suggestions")
         assert(mise[:ready] && mise[:path].end_with?("/.local/bin/mise"),
                "expected Remote setup to find fallback mise")
         assert(!global_kamal[:ready], "expected global Kamal to remain PATH-only")
@@ -1527,6 +1593,16 @@ module RemoteServerTest
     assert(js[:body].include?("normalizeInquiryInputType"),
            "expected Remote UI to normalize inquiry field input types")
     assert(js[:body].include?("function setAgentSettings"), "expected Agent metadata to move into header settings")
+    assert(js[:body].include?('id="agent-model" name="model"'),
+           "expected Remote UI agent form to expose model input")
+    assert(js[:body].include?('name="reasoning_effort"'),
+           "expected Remote UI agent form to expose reasoning effort input")
+    assert(js[:body].include?("data-agent-model-select"),
+           "expected Remote UI agent form to expose a persistent model choice control")
+    assert(js[:body].include?("function modelChoiceOptions"),
+           "expected Remote UI agent form to build model suggestions from setup payload")
+    assert(js[:body].include?("model: String(formData.get(\"model\")"),
+           "expected Remote UI agent form payload to include model")
     assert(js[:body].include?("Push notifications"), "expected Settings screen to expose push readiness")
     assert(js[:body].include?("function renderHiddenSettings"),
            "expected Settings screen to expose a dedicated Hidden settings page")

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -105,6 +105,7 @@ module RenderingTest
     assert_chat_content_focus_scrolls_with_arrow_keys
     assert_chat_block_selection_scrolls_with_large_messages
     assert_agent_editor_renders_template_and_harness_choices
+    assert_agent_editor_preserves_dirty_model_and_effort_on_template_change
     assert_web_project_icon_renders_for_project_contexts
     assert_non_app_project_uses_folder_icon
     assert_project_archive_moves_config_logs_and_agents
@@ -2309,8 +2310,40 @@ module RenderingTest
     assert(plain_output.include?("codex"), "expected codex harness choice")
     assert(plain_output.include?("claude"), "expected claude harness choice")
     assert(plain_output.include?("claude-wrapper"), "expected custom Claude harness choice")
+    assert(plain_output.include?("Model:"), "expected model field in form")
+    assert(plain_output.include?("Effort:"), "expected reasoning effort field in form")
     assert(template_names == template_names.sort,
            "expected template choices to be sorted alphabetically, got #{template_names.inspect}")
+  end
+
+  def assert_agent_editor_preserves_dirty_model_and_effort_on_template_change
+    app = HQ::App.new
+    projects = app.instance_variable_get(:@projects)
+    project = projects.find { |item| item.key == "warehouse" } || projects.first
+    raise "expected at least one project for agent editor dirty-field test" unless project
+    return unless project.agent_templates.length >= 2
+
+    project.agent_templates[0].model = "gpt-5.1-codex-max"
+    project.agent_templates[0].reasoning_effort = "high"
+    project.agent_templates[1].model = "sonnet"
+    project.agent_templates[1].reasoning_effort = "xhigh"
+
+    app.instance_variable_set(:@screen, :projects)
+    app.instance_variable_get(:@selected)[:projects] = projects.index(project) || 0
+    app.send(:open_agent_editor_for_selected_project)
+
+    editor = app.instance_variable_get(:@agent_editor)
+    editor.model_input.value = "custom-model"
+    editor.reasoning_effort_input.value = "max"
+    editor.mark_model_dirty!
+    editor.mark_reasoning_effort_dirty!
+
+    editor.cycle_template(1)
+
+    assert(editor.model_input.value == "custom-model",
+           "expected dirty model field to survive template change")
+    assert(editor.reasoning_effort_input.value == "max",
+           "expected dirty reasoning effort field to survive template change")
   end
 
   def assert_web_project_icon_renders_for_project_contexts
@@ -2456,6 +2489,8 @@ module RenderingTest
     form = app.instance_variable_get(:@agent_editor)
     form.cycle_template(1)
     form.cycle_harness(1)
+    form.model_input.value = "sonnet"
+    form.reasoning_effort_input.value = "high"
     form.instance_variable_set(:@field_index, form.create_and_run_button_index)
 
     created_agent = nil
@@ -2484,6 +2519,8 @@ module RenderingTest
     assert(created_agent.instance_variable_get(:@started),
            "expected 'Create and Run' to start the new agent immediately")
     assert(created_agent.agent == "claude", "expected selected harness to override the template default")
+    assert(created_agent.model == "sonnet", "expected created agent to save selected model")
+    assert(created_agent.reasoning_effort == "high", "expected created agent to save selected reasoning effort")
     assert(app.instance_variable_get(:@screen) == :agents, "expected create flow to switch to the agents screen")
     assert(app.instance_variable_get(:@selected)[:agents].zero?, "expected the newly created agent to be selected")
     sidebar = app.instance_variable_get(:@sidebar)
@@ -2619,6 +2656,16 @@ module RenderingTest
     app.instance_variable_set(:@screen, :agents)
 
     old_agent = app.instance_variable_get(:@agents).first
+    old_agent.update!(
+      name: old_agent.name,
+      template_key: old_agent.template_key,
+      workspace: old_agent.workspace,
+      prompt: old_agent.prompt,
+      sandbox_mode: old_agent.sandbox_mode,
+      agent: old_agent.agent,
+      model: "opus",
+      reasoning_effort: "xhigh"
+    )
     old_agent.instance_variable_set(:@session_id, "old-session")
     old_agent.instance_variable_set(:@session_bootstrapped, true)
     old_agent.instance_variable_set(:@started_at, Time.parse("2026-04-05 17:50:00"))
@@ -2645,6 +2692,8 @@ module RenderingTest
     assert(new_agent.prompt == old_agent.prompt, "expected clone to copy prompt")
     assert(new_agent.sandbox_mode == old_agent.sandbox_mode, "expected clone to copy sandbox mode")
     assert(new_agent.agent == old_agent.agent, "expected clone to copy harness")
+    assert(new_agent.model == old_agent.model, "expected clone to copy model")
+    assert(new_agent.reasoning_effort == old_agent.reasoning_effort, "expected clone to copy reasoning effort")
     assert(new_agent.runs.empty?, "expected cloned agent to start with no runs")
     assert(new_agent.started_at.nil?, "expected cloned agent to have no started time")
     assert(new_agent.finished_at.nil?, "expected cloned agent to have no finished time")


### PR DESCRIPTION
## Summary

- Add agent-level `model` and `reasoning_effort` settings with project/template inheritance, persistence, cloning, and scheduled-agent support.
- Pass model and effort arguments through Codex, Claude, and Claude-compatible command builders, including resumed sessions.
- Expose model/effort display and editing in the TUI and Remote UI, with harness-aware suggestions and dropdown-only selection that preserves custom current values.
- Backfill legacy agents by inferring missing model/effort from saved run commands so existing sessions display correctly and future resumes include explicit arguments.
- Document the model-argument plan and update config/API docs.

## Root Cause / Impact

Tycho previously did not persist agent-level model or reasoning effort, so sessions launched with explicit custom arguments could later appear as defaults in the UI. Resume commands could also omit those explicit settings when the persisted agent state lacked them.

## Validation

- `bin/test`
- `bundle exec ruby test/managed_agent_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/registry_test.rb`
- `bundle exec ruby test/rendering_test.rb`
