### PR TITLE
[codex] Add copyable Web UI details

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -402,6 +402,42 @@ h3 {
   padding: 10px;
 }
 
+.growl {
+  position: fixed;
+  z-index: 30;
+  top: calc(var(--safe-area-top) + 72px);
+  left: 50%;
+  width: min(calc(100% - 24px), 420px);
+  min-height: 42px;
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 96%, transparent);
+  box-shadow: var(--shadow);
+  color: var(--text);
+  padding: 10px 12px;
+  pointer-events: none;
+  opacity: 1;
+  transform: translate(-50%, 0);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.growl.hidden {
+  opacity: 0;
+  transform: translate(-50%, -8px);
+}
+
+.growl.done {
+  border-color: color-mix(in srgb, var(--ok) 58%, var(--border));
+}
+
+.growl.need {
+  border-color: color-mix(in srgb, var(--warning) 58%, var(--border));
+}
+
+.growl.fail {
+  border-color: color-mix(in srgb, var(--danger) 58%, var(--border));
+}
+
 .unread-panel-header {
   display: flex;
   align-items: baseline;
@@ -1289,6 +1325,33 @@ button.restart-server-button {
   border-radius: 8px;
   padding: 9px;
   background: var(--panel-soft);
+}
+
+.kv-copyable {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 8px;
+}
+
+.kv-copyable > span,
+.kv-copyable > strong {
+  grid-column: 1;
+}
+
+.kv-copy-button {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+}
+
+.kv-copy-button .ui-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .message-list {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -348,6 +348,7 @@ const state = {
   unreadPanelOpen: false,
   readMarkTimer: null,
   lastAppBadgeCount: null,
+  growlTimer: null,
 };
 
 const markdownParser = {
@@ -366,6 +367,7 @@ const els = {
   agentSettingsPanel: document.getElementById("agent-settings-panel"),
   unreadPanel: document.getElementById("unread-agents-panel"),
   authPanel: document.getElementById("auth-panel"),
+  growl: document.getElementById("growl"),
   tokenInput: document.getElementById("token-input"),
   saveToken: document.getElementById("save-token-button"),
   view: document.getElementById("view"),
@@ -1512,11 +1514,11 @@ function renderSetup() {
       <div class="detail-card-body" style="padding-top: 12px;">
         <div class="section-label"><strong>Configuration</strong><span>local files</span></div>
         <div class="kv-grid">
-          ${kv("Projects", `${setup.counts?.projects || 0} active`)}
-          ${kv("Hidden", `${setup.counts?.hidden_projects || 0} projects`)}
-          ${kv("Archived", `${setup.counts?.archived_projects || 0} archived`)}
-          ${kv("Config", setup.config?.loaded ? "hq.yml loaded" : "not loaded")}
-          ${kv("Prompts", `${setup.config?.prompt_template_count || 0} templates`)}
+          ${copyableKv("Projects", `${setup.counts?.projects || 0} active`)}
+          ${copyableKv("Hidden", `${setup.counts?.hidden_projects || 0} projects`)}
+          ${copyableKv("Archived", `${setup.counts?.archived_projects || 0} archived`)}
+          ${copyableKv("Config", setup.config?.loaded ? "hq.yml loaded" : "not loaded")}
+          ${copyableKv("Prompts", `${setup.config?.prompt_template_count || 0} templates`)}
         </div>
         <div class="button-row">
           <button type="button" data-open-hidden-settings>Hidden projects</button>
@@ -1531,19 +1533,19 @@ function renderSetup() {
     <details class="detail-card">
       <summary>Logs and storage</summary>
       <div class="kv-grid">
-        ${kv("Root", setup.logs?.root)}
-        ${kv("Agent runs", setup.logs?.agent_runs)}
-        ${kv("Agent logs", setup.logs?.agent_log_files)}
-        ${kv("Action logs", setup.logs?.project_action_logs)}
+        ${copyableKv("Root", setup.logs?.root)}
+        ${copyableKv("Agent runs", setup.logs?.agent_runs)}
+        ${copyableKv("Agent logs", setup.logs?.agent_log_files)}
+        ${copyableKv("Action logs", setup.logs?.project_action_logs)}
       </div>
     </details>
     <details class="detail-card">
       <summary>Refresh and preferences</summary>
       <div class="kv-grid">
-        ${kv("Running", `${setup.refresh_intervals?.running_agent_ms || 0}ms`)}
-        ${kv("Idle", `${setup.refresh_intervals?.idle_ms || 0}ms`)}
-        ${kv("Hidden", `${setup.refresh_intervals?.hidden_ms || 0}ms`)}
-        ${kv("Auth", setup.auth?.status)}
+        ${copyableKv("Running", `${setup.refresh_intervals?.running_agent_ms || 0}ms`)}
+        ${copyableKv("Idle", `${setup.refresh_intervals?.idle_ms || 0}ms`)}
+        ${copyableKv("Hidden", `${setup.refresh_intervals?.hidden_ms || 0}ms`)}
+        ${copyableKv("Auth", setup.auth?.status)}
       </div>
     </details>
     <section class="detail-card server-lifecycle-card">
@@ -2246,21 +2248,21 @@ function renderProject(key) {
     <details class="detail-card">
       <summary>Deploy details</summary>
       <div class="kv-grid">
-        ${kv("Service", project.service)}
-        ${kv("Image", project.image)}
-        ${kv("Hosts", (project.hosts || []).join(", ") || "n/a")}
-        ${kv("Proxy", project.proxy)}
-        ${kv("Action log", project.action_log_path)}
-        ${kv("Health path", project.healthcheck_path)}
+        ${copyableKv("Service", project.service)}
+        ${copyableKv("Image", project.image)}
+        ${copyableKv("Hosts", (project.hosts || []).join(", ") || "n/a")}
+        ${copyableKv("Proxy", project.proxy)}
+        ${copyableKv("Action log", project.action_log_path)}
+        ${copyableKv("Health path", project.healthcheck_path)}
       </div>
     </details>
     <details class="detail-card">
       <summary>Versions and templates</summary>
       <div class="kv-grid">
-        ${kv("Kamal", project.kamal_version)}
-        ${kv("Rails", project.rails_version)}
-        ${kv("Templates", (project.agent_template_summaries || []).map((item) => item.name).join(", ") || "n/a")}
-        ${kv("Path", project.path)}
+        ${copyableKv("Kamal", project.kamal_version)}
+        ${copyableKv("Rails", project.rails_version)}
+        ${copyableKv("Templates", (project.agent_template_summaries || []).map((item) => item.name).join(", ") || "n/a")}
+        ${copyableKv("Path", project.path)}
       </div>
     </details>
     <section class="field-card">
@@ -3339,9 +3341,31 @@ function emptyRow(title, body) {
   `;
 }
 
-function kv(label, value) {
+function kv(label, value, options = {}) {
   const display = value === null || value === undefined || value === "" ? "n/a" : String(value);
-  return `<div class="kv"><span>${escapeHtml(label)}</span><strong class="wrap-anywhere">${escapeHtml(display)}</strong></div>`;
+  const copyValue = options.copyValue === undefined ? display : String(options.copyValue || "");
+  const copyDisabled = !copyValue || display === "n/a";
+  const copyData = escapeAttr(copyDisabled ? "" : copyValue);
+  const copyLabel = escapeAttr(label);
+  const disabledAttr = copyDisabled ? "disabled" : "";
+  const copyButton = options.copyable
+    ? `
+      <button class="icon-button kv-copy-button" type="button" data-copy="${copyData}" aria-label="Copy ${copyLabel}" title="Copy ${copyLabel}" ${disabledAttr}>
+        ${iconSvg("copy")}
+      </button>
+    `
+    : "";
+  return `
+    <div class="kv ${options.copyable ? "kv-copyable" : ""}">
+      <span>${escapeHtml(label)}</span>
+      <strong class="wrap-anywhere">${escapeHtml(display)}</strong>
+      ${copyButton}
+    </div>
+  `;
+}
+
+function copyableKv(label, value) {
+  return kv(label, value, { copyable: true });
 }
 
 function unreadAgents() {
@@ -3696,19 +3720,19 @@ function agentSettingsHtml(agent) {
   const disabled = agentIsRunning(agent) ? "disabled" : "";
   return `
     <div class="agent-settings-grid">
-      ${kv("Project", agentProjectLabel(agent))}
-      ${kv("Template", agentTemplateLabel(agent))}
-      ${kv("Harness", agent.agent || "agent")}
-      ${kv("Model", agent.model || "default")}
-      ${kv("Effort", agent.reasoning_effort || "default")}
-      ${kv("Status", statusLabel(agent))}
-      ${kv("Runs", agent.run_count)}
-      ${kv("Exit", agent.last_exit_code ?? "n/a")}
-      ${kv("Started", timeShort(agent.started_at))}
-      ${kv("Finished", timeShort(agent.finished_at))}
-      ${kv("Workspace", agent.workspace)}
-      ${kv("Sandbox", agent.sandbox_mode)}
-      ${kv("Raw log", agent.log_path)}
+      ${copyableKv("Project", agentProjectLabel(agent))}
+      ${copyableKv("Template", agentTemplateLabel(agent))}
+      ${copyableKv("Harness", agent.agent || "agent")}
+      ${copyableKv("Model", agent.model || "default")}
+      ${copyableKv("Effort", agent.reasoning_effort || "default")}
+      ${copyableKv("Status", statusLabel(agent))}
+      ${copyableKv("Runs", agent.run_count)}
+      ${copyableKv("Exit", agent.last_exit_code ?? "n/a")}
+      ${copyableKv("Started", timeShort(agent.started_at))}
+      ${copyableKv("Finished", timeShort(agent.finished_at))}
+      ${copyableKv("Workspace", agent.workspace)}
+      ${copyableKv("Sandbox", agent.sandbox_mode)}
+      ${copyableKv("Raw log", agent.log_path)}
     </div>
     <div class="agent-settings-actions">
       <button class="inline-icon-button" type="button" data-edit-agent="${escapeAttr(agent.key)}" ${disabled}>${iconSvg("pencil")}<span>Edit agent</span></button>
@@ -3726,6 +3750,19 @@ function setConnection(text) {
   } else {
     setHeaderSubtitle(text);
   }
+}
+
+function showGrowl(message, kind = "info") {
+  const text = String(message || "").trim();
+  if (!text || !els.growl) return;
+
+  window.clearTimeout(state.growlTimer);
+  els.growl.textContent = text;
+  els.growl.className = `growl ${kind}`;
+  state.growlTimer = window.setTimeout(() => {
+    els.growl.classList.add("hidden");
+    state.growlTimer = null;
+  }, 2400);
 }
 
 function connectionText() {
@@ -4468,21 +4505,30 @@ function formatBytes(value) {
 
 async function copyToClipboard(value) {
   if (!value) {
-    setConnection("Nothing to copy");
+    showGrowl("Nothing to copy", "need");
     return;
   }
 
   if (!navigator.clipboard) {
-    setConnection("Copy unavailable in this browser");
+    showGrowl("Copy unavailable in this browser", "need");
     return;
   }
 
   try {
     await navigator.clipboard.writeText(value);
-    setConnection("Copied to clipboard");
+    showGrowl("Copied to clipboard", "done");
   } catch (_error) {
-    setConnection("Copy failed");
+    showGrowl("Copy failed", "fail");
   }
+}
+
+function handleDocumentCopyClick(event) {
+  const copyButton = event.target.closest("[data-copy]");
+  if (!copyButton) return false;
+
+  event.preventDefault();
+  copyToClipboard(copyButton.dataset.copy || "");
+  return true;
 }
 
 async function enablePushNotifications() {
@@ -4889,13 +4935,6 @@ els.view.addEventListener("click", (event) => {
     return;
   }
 
-  const copyButton = event.target.closest("[data-copy]");
-  if (copyButton) {
-    const value = copyButton.dataset.copy || "";
-    copyToClipboard(value);
-    return;
-  }
-
   if (event.target.closest("[data-enable-push]")) {
     enablePushNotifications();
     return;
@@ -4935,6 +4974,10 @@ els.view.addEventListener("click", (event) => {
     scrollConversationToRecent();
     return;
   }
+});
+
+document.addEventListener("click", (event) => {
+  handleDocumentCopyClick(event);
 });
 
 document.addEventListener("click", (event) => {

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -70,6 +70,8 @@
         <section id="agent-settings-panel" class="agent-settings-panel hidden" aria-label="Agent settings"></section>
       </header>
 
+      <section id="growl" class="growl hidden" role="status" aria-live="polite" aria-atomic="true"></section>
+
       <main id="view" class="content" aria-live="polite"></main>
 
       <nav id="bottom-nav" class="bottom-nav" aria-label="Primary navigation">

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1331,6 +1331,8 @@ module RemoteServerTest
            "expected root shell logo to control the unread agents panel")
     assert(response[:body].include?('id="unread-agents-panel"'),
            "expected root shell to expose the unread agents popup")
+    assert(response[:body].include?('id="growl"'),
+           "expected root shell to expose growl notifications")
     assert(response[:body].include?("pull-refresh-spinner ui-icon"),
            "expected root shell to render the pull refresh hourglass icon")
     assert(response[:body].match?(%r{href="/ui\.css\?v=[0-9a-f]{12}"}),
@@ -1394,6 +1396,7 @@ module RemoteServerTest
            "expected Agent detail shortcuts to float above the dock")
     assert(css[:body].include?(".go-recent-fab"), "expected Agent detail to include Go to recent")
     assert(css[:body].include?(".agent-settings-panel"), "expected Agent settings to render in the header")
+    assert(css[:body].include?(".growl"), "expected Remote UI to style growl notifications")
     assert(css[:body].include?(".agent-settings-actions"),
            "expected Agent settings to hide edit/archive actions behind the settings panel")
     assert(css[:body].include?(".agent-form"), "expected Remote UI to style agent lifecycle forms")
@@ -1549,6 +1552,8 @@ module RemoteServerTest
            "expected Schedule details wrapper to preserve compact top breathing room")
     assert(css[:body].include?(".schedule-disclosure") && css[:body].include?("position: absolute"),
            "expected Schedule block to pin a visible collapsible disclosure control")
+    assert(css[:body].include?(".kv-copy-button"),
+           "expected copyable key/value rows to style their copy button")
     assert(css[:body].include?(".hidden-toggle-button.active.visible-state"),
            "expected Hidden settings rows to style the visible segment in the triple toggle")
     assert(css[:body].include?("flex-wrap: nowrap"),
@@ -1568,7 +1573,25 @@ module RemoteServerTest
            "expected selected Remote UI nav clicks to scroll the current tab to the top")
     assert(js[:body].include?('route.type === "tab" && route.tab === tab'),
            "expected selected Remote UI nav detection to require the current top-level tab")
-    assert(js[:body].include?("Copied to clipboard"), "expected UI JavaScript to include copy feedback")
+    assert(js[:body].include?("function showGrowl"), "expected UI JavaScript to expose growl notifications")
+    assert(js[:body].include?("function handleDocumentCopyClick"),
+           "expected copy buttons to be handled outside the main view")
+    assert(js[:body].include?('showGrowl("Copied to clipboard", "done")'),
+           "expected copy success to use growl feedback")
+    assert(!js[:body].include?('setConnection("Copied to clipboard")'),
+           "expected copy success to avoid changing the header subtitle")
+    assert(js[:body].include?("function copyableKv"),
+           "expected Remote UI to expose copyable key/value rows")
+    assert(js[:body].include?("kv-copy-button"),
+           "expected copyable key/value rows to render a copy control")
+    assert(js[:body].include?('copyableKv("Raw log", agent.log_path)'),
+           "expected Conversation settings rows to be copyable")
+    assert(js[:body].include?('copyableKv("Service", project.service)') &&
+           js[:body].include?('copyableKv("Templates",'),
+           "expected Project deploy and template details to be copyable")
+    assert(js[:body].include?('copyableKv("Root", setup.logs?.root)') &&
+           js[:body].include?('copyableKv("Auth", setup.auth?.status)'),
+           "expected Settings configuration, logs, and preferences rows to be copyable")
     assert(js[:body].include?("data-agent-dock"), "expected Agent detail composer to live in a dock")
     assert(js[:body].include?("function renderInquiryForm"),
            "expected Agent detail to render structured inquiry forms")


### PR DESCRIPTION
## Summary
- Add copy buttons to requested Remote UI key/value details across Conversation, Project, and Settings surfaces.
- Move copy handling to a document-level click handler so Conversation settings copy buttons work from the header panel.
- Show copy success and failure through a growl-style notification instead of changing the header subtitle.

## Validation
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- isolated Chrome/CDP check against `bin/tycho serve`
- `bin/test`