### PR TITLE
[codex] Add agent sort dropdown

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -495,6 +495,7 @@ h3 {
 .top-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
@@ -504,12 +505,11 @@ h3 {
 }
 
 .top-actions .search-box {
-  flex: 1 1 auto;
+  flex: 1 1 260px;
 }
 
 .top-actions > button {
   flex: 0 0 auto;
-  margin-left: auto;
 }
 
 .compact-actions button {
@@ -1130,6 +1130,79 @@ select {
   border: 0;
   background: transparent;
   padding: 2px 0;
+}
+
+.agent-sort-menu {
+  position: relative;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.agent-sort-trigger {
+  display: inline-grid;
+  width: 42px;
+  min-width: 42px;
+  min-height: 42px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.agent-sort-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.agent-sort-trigger::marker {
+  content: "";
+}
+
+.agent-sort-menu[open] .agent-sort-trigger,
+.agent-sort-trigger:hover,
+.agent-sort-trigger:focus-visible {
+  border-color: var(--accent);
+  background: var(--panel-soft);
+}
+
+.agent-sort-trigger .ui-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.agent-sort-options {
+  position: absolute;
+  z-index: 18;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  gap: 2px;
+  width: min(72vw, 230px);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  padding: 4px;
+}
+
+.agent-sort-option {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 34px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  padding: 0 9px;
+  text-align: left;
+}
+
+.agent-sort-option:hover,
+.agent-sort-option:focus-visible,
+.agent-sort-option.active {
+  background: var(--panel-soft);
 }
 
 .agent-group {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -34,6 +34,21 @@ const CLIPBOARD_ATTACHMENT_EXTENSIONS = {
 };
 const FORM_DRAFT_STORAGE_PREFIX = "hq.remote.formDraft.";
 const FORM_DRAFT_TEXT_INPUT_TYPES = new Set(["text", "search", "email", "url", "tel", "password", "number"]);
+const AGENT_SORT_STORAGE_KEY = "hq.remote.agentSort";
+const DEFAULT_AGENT_SORT = "project_asc";
+const AGENT_SORT_OPTIONS = [
+  { value: "agent_name_asc", label: "Agents A-Z", icon: "arrowDownAZ", scope: "agents" },
+  { value: "agent_name_desc", label: "Agents Z-A", icon: "arrowDownZA", scope: "agents" },
+  { value: "agent_updated_desc", label: "Agents latest update", icon: "clockArrowDown", scope: "agents" },
+  { value: "agent_updated_asc", label: "Agents oldest update", icon: "clockArrowUp", scope: "agents" },
+  { value: "project_asc", label: "Projects ascending", icon: "arrowDownWideNarrow", scope: "projects" },
+  { value: "project_desc", label: "Projects descending", icon: "arrowUpWideNarrow", scope: "projects" },
+];
+const AGENT_SORT_ALIASES = {
+  alphabetical: "agent_name_asc",
+  updated_desc: "agent_updated_desc",
+  updated_asc: "agent_updated_asc",
+};
 const MARKDOWN_SCRIPT_URLS = {
   dompurify: "https://cdn.jsdelivr.net/npm/dompurify@3.2.7/dist/purify.min.js",
   marked: "https://cdn.jsdelivr.net/npm/marked@18.0.3/lib/marked.umd.js",
@@ -50,6 +65,42 @@ const ICONS = {
   activity: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="M22 12h-4l-3 9L9 3l-3 9H2"></path>
+    </svg>
+  `,
+  arrowDownAZ: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="m3 16 4 4 4-4"></path>
+      <path d="M7 20V4"></path>
+      <path d="M20 8h-5"></path>
+      <path d="M15 10V6.5a2.5 2.5 0 0 1 5 0V10"></path>
+      <path d="M15 14h5l-5 6h5"></path>
+    </svg>
+  `,
+  arrowDownZA: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="m3 16 4 4 4-4"></path>
+      <path d="M7 4v16"></path>
+      <path d="M15 4h5l-5 6h5"></path>
+      <path d="M15 20v-3.5a2.5 2.5 0 0 1 5 0V20"></path>
+      <path d="M20 18h-5"></path>
+    </svg>
+  `,
+  arrowDownWideNarrow: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="m3 16 4 4 4-4"></path>
+      <path d="M7 20V4"></path>
+      <path d="M11 4h10"></path>
+      <path d="M11 8h7"></path>
+      <path d="M11 12h4"></path>
+    </svg>
+  `,
+  arrowUpWideNarrow: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="m3 8 4-4 4 4"></path>
+      <path d="M7 4v16"></path>
+      <path d="M11 4h10"></path>
+      <path d="M11 8h7"></path>
+      <path d="M11 12h4"></path>
     </svg>
   `,
   badgeQuestionMark: `
@@ -71,6 +122,22 @@ const ICONS = {
   chevronDown: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="m6 9 6 6 6-6"></path>
+    </svg>
+  `,
+  clockArrowDown: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M12.338 21.994A10 10 0 1 1 21.925 13.227"></path>
+      <path d="M12 6v6l2 1"></path>
+      <path d="m14 18 4 4 4-4"></path>
+      <path d="M18 14v8"></path>
+    </svg>
+  `,
+  clockArrowUp: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M12.338 21.994A10 10 0 1 1 21.925 13.227"></path>
+      <path d="M12 6v6l2 1"></path>
+      <path d="m14 18 4-4 4 4"></path>
+      <path d="M18 22v-8"></path>
     </svg>
   `,
   arrowLeft: `
@@ -329,6 +396,7 @@ const state = {
   filters: {
     agents: "",
   },
+  agentSort: initialAgentSort(),
   bulkArchiveMode: false,
   bulkArchiveSelection: new Set(),
   failureCount: 0,
@@ -375,6 +443,32 @@ const els = {
 };
 
 syncPlatformClasses();
+
+function initialAgentSort() {
+  return normalizeAgentSort(sessionStorageValue(AGENT_SORT_STORAGE_KEY, DEFAULT_AGENT_SORT));
+}
+
+function normalizeAgentSort(value) {
+  const raw = String(value || "").trim();
+  const normalized = AGENT_SORT_ALIASES[raw] || raw;
+  return AGENT_SORT_OPTIONS.some((option) => option.value === normalized) ? normalized : DEFAULT_AGENT_SORT;
+}
+
+function sessionStorageValue(key, fallback = "") {
+  try {
+    return window.sessionStorage?.getItem(key) || fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function setSessionStorageValue(key, value) {
+  try {
+    window.sessionStorage?.setItem(key, value);
+  } catch (_error) {
+    // Session storage can be unavailable in locked-down browser contexts.
+  }
+}
 
 function syncPlatformClasses() {
   const standalone = window.navigator.standalone === true ||
@@ -1369,9 +1463,11 @@ function renderScheduleDaemonActions(daemon, schedules) {
   `;
 }
 
-function renderAgents() {
+function renderAgents(options = {}) {
   const query = state.filters.agents.trim().toLowerCase();
-  const groups = agentProjectGroups(query);
+  const groupMode = agentSortUsesProjectGroups();
+  const groups = groupMode ? agentProjectGroups(query) : [];
+  const flatAgents = groupMode ? [] : sortedAgentList(query);
   const unread = state.agents.filter((agent) => agent.unread).length;
   setHeader("Agents", `${state.agents.length} managed / ${state.projects.length} projects / ${unread} unread`, "A");
 
@@ -1381,12 +1477,49 @@ function renderAgents() {
         <span class="nav-mark" aria-hidden="true">${iconSvg("search")}</span>
         <input id="agent-filter" type="search" value="${escapeAttr(state.filters.agents)}" placeholder="Filter agents and projects" aria-label="Filter agents and projects" data-filter="agents">
       </label>
+      ${agentSortMenuHtml()}
       <button class="inline-icon-button" type="button" data-toggle-bulk-archive ${state.agents.length ? "" : "disabled"}>${iconSvg(state.bulkArchiveMode ? "x" : "archive")}<span>${state.bulkArchiveMode ? "Cancel" : "Select"}</span></button>
     </div>
     ${renderBulkArchiveBar()}
-    ${groups.length ? groups.map((group) => renderAgentGroup(group.projectKey, group.agents)).join("") : renderAgentsEmpty(query)}
+    ${groupMode
+      ? (groups.length ? groups.map((group) => renderAgentGroup(group.projectKey, group.agents)).join("") : renderAgentsEmpty(query))
+      : renderFlatAgentList(flatAgents, query)}
   `);
-  focusFilterInput("agents", "agent-filter");
+  if (options.focusFilter !== false) focusFilterInput("agents", "agent-filter");
+}
+
+function agentSortMenuHtml() {
+  const current = currentAgentSortOption();
+  const options = AGENT_SORT_OPTIONS.map((option) => {
+    const active = state.agentSort === option.value;
+    return `
+      <button class="agent-sort-option ${active ? "active" : ""}" type="button" role="menuitemradio" data-agent-sort-choice="${escapeAttr(option.value)}" aria-checked="${active ? "true" : "false"}">
+        <span>${escapeHtml(option.label)}</span>
+      </button>
+    `;
+  }).join("");
+
+  return `
+    <details class="agent-sort-menu" data-agent-sort-menu>
+      <summary class="agent-sort-trigger" aria-label="Sort agents: ${escapeAttr(current.label)}" title="${escapeAttr(current.label)}">
+        ${iconSvg(current.icon)}
+        <span class="sr-only">Sort agents</span>
+      </summary>
+      <div class="agent-sort-options" role="menu" aria-label="Sort agents">
+        ${options}
+      </div>
+    </details>
+  `;
+}
+
+function renderFlatAgentList(agents, query) {
+  if (!agents.length) return renderAgentsEmpty(query);
+
+  return `
+    <section class="agent-group agent-flat-list" aria-label="Agents">
+      ${agents.map(renderAgentRow).join("")}
+    </section>
+  `;
 }
 
 function renderBulkArchiveBar() {
@@ -3396,9 +3529,27 @@ function agentProjectGroups(query) {
   ]);
 
   return [...projectKeys]
-    .sort(compareAgentProjectKeys)
+    .sort(compareAgentProjectKeysForCurrentSort)
     .map((projectKey) => agentProjectGroup(projectKey, agentsByProject[projectKey] || [], query))
     .filter(Boolean);
+}
+
+function sortedAgentList(query) {
+  return state.agents
+    .filter((agent) => {
+      const project = findProject(agent.project_key);
+      return !query || (project && projectMatches(project, query)) || agentMatches(agent, query);
+    })
+    .sort(compareAgentsForCurrentSort);
+}
+
+function agentSortUsesProjectGroups() {
+  return currentAgentSortOption()?.scope !== "agents";
+}
+
+function currentAgentSortOption() {
+  return AGENT_SORT_OPTIONS.find((option) => option.value === state.agentSort) ||
+    AGENT_SORT_OPTIONS.find((option) => option.value === DEFAULT_AGENT_SORT);
 }
 
 function agentProjectGroup(projectKey, agents, query) {
@@ -3406,7 +3557,7 @@ function agentProjectGroup(projectKey, agents, query) {
   const projectMatch = project ? projectMatches(project, query) : String(projectKey || "").toLowerCase().includes(query);
   const filteredAgents = agents
     .filter((agent) => !query || projectMatch || agentMatches(agent, query))
-    .sort(compareAgentsByName);
+    .sort(compareAgentsForCurrentSort);
 
   if (query && !projectMatch && filteredAgents.length === 0) return null;
   if (!query && !project && filteredAgents.length === 0) return null;
@@ -3417,7 +3568,7 @@ function agentProjectGroup(projectKey, agents, query) {
 function agentsForProject(projectKey) {
   return state.agents
     .filter((agent) => agent.project_key === projectKey)
-    .sort(compareAgentsByName);
+    .sort(compareAgentsForCurrentSort);
 }
 
 function agentArchiveable(agent) {
@@ -3453,11 +3604,46 @@ function compareAgentProjectKeys(a, b) {
   return compareDisplayText(a, b);
 }
 
+function compareAgentProjectKeysForCurrentSort(a, b) {
+  const comparison = compareAgentProjectKeys(a, b);
+  return state.agentSort === "project_desc" ? -comparison : comparison;
+}
+
 function compareAgentsByName(a, b) {
   const byName = compareDisplayText(a.name || a.key, b.name || b.key);
   if (byName !== 0) return byName;
 
   return compareDisplayText(a.key, b.key);
+}
+
+function compareAgentsByNameDesc(a, b) {
+  return -compareAgentsByName(a, b);
+}
+
+function compareAgentsForCurrentSort(a, b) {
+  return compareAgentsBySort(a, b, state.agentSort);
+}
+
+function compareAgentsBySort(a, b, sort) {
+  switch (normalizeAgentSort(sort)) {
+    case "agent_name_desc":
+      return compareAgentsByNameDesc(a, b);
+    case "agent_updated_desc":
+      return compareAgentsByUpdatedAt(a, b, "desc");
+    case "agent_updated_asc":
+      return compareAgentsByUpdatedAt(a, b, "asc");
+    default:
+      return compareAgentsByName(a, b);
+  }
+}
+
+function compareAgentsByUpdatedAt(a, b, direction) {
+  const left = agentActivityTimestamp(a);
+  const right = agentActivityTimestamp(b);
+  const byUpdatedAt = direction === "asc" ? left - right : right - left;
+  if (byUpdatedAt !== 0) return byUpdatedAt;
+
+  return compareAgentsByName(a, b);
 }
 
 function compareDisplayText(a, b) {
@@ -4775,6 +4961,9 @@ els.view.addEventListener("click", (event) => {
   if (!event.target.closest("[data-skill-flyout]") && !event.target.closest("[data-toggle-skills]")) {
     closeSkillFlyout();
   }
+  if (!event.target.closest("[data-agent-sort-menu]")) {
+    closeAgentSortMenu();
+  }
 
   const summaryButton = event.target.closest("[data-open-agent-summary]");
   if (summaryButton) {
@@ -4794,6 +4983,17 @@ els.view.addEventListener("click", (event) => {
 
   if (event.target.closest("[data-toggle-bulk-archive]")) {
     toggleBulkArchiveMode();
+    return;
+  }
+
+  const agentSortButton = event.target.closest("[data-agent-sort-choice]");
+  if (agentSortButton) {
+    const nextSort = normalizeAgentSort(agentSortButton.dataset.agentSortChoice);
+    state.agentSort = nextSort;
+    setSessionStorageValue(AGENT_SORT_STORAGE_KEY, state.agentSort);
+    renderAgents({ focusFilter: false });
+    closeAgentSortMenu();
+    els.view.querySelector(".agent-sort-trigger")?.focus({ preventScroll: true });
     return;
   }
 
@@ -5494,6 +5694,10 @@ function toggleSkillFlyout() {
 
 function closeSkillFlyout() {
   setSkillFlyoutOpen(false);
+}
+
+function closeAgentSortMenu() {
+  document.querySelector("[data-agent-sort-menu]")?.removeAttribute("open");
 }
 
 function setSkillFlyoutOpen(open) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1397,6 +1397,9 @@ module RemoteServerTest
     assert(css[:body].include?(".go-recent-fab"), "expected Agent detail to include Go to recent")
     assert(css[:body].include?(".agent-settings-panel"), "expected Agent settings to render in the header")
     assert(css[:body].include?(".growl"), "expected Remote UI to style growl notifications")
+    assert(css[:body].include?(".agent-sort-menu"), "expected Remote UI to style agent sort dropdowns")
+    assert(css[:body].include?(".agent-sort-trigger"), "expected Remote UI to style icon-only sort triggers")
+    assert(css[:body].include?(".agent-sort-option"), "expected Remote UI to style text sort options")
     assert(css[:body].include?(".agent-settings-actions"),
            "expected Agent settings to hide edit/archive actions behind the settings panel")
     assert(css[:body].include?(".agent-form"), "expected Remote UI to style agent lifecycle forms")
@@ -1573,6 +1576,30 @@ module RemoteServerTest
            "expected selected Remote UI nav clicks to scroll the current tab to the top")
     assert(js[:body].include?('route.type === "tab" && route.tab === tab'),
            "expected selected Remote UI nav detection to require the current top-level tab")
+    assert(js[:body].include?('const DEFAULT_AGENT_SORT = "project_asc"'),
+           "expected agent sorting to default to project grouping ascending")
+    assert(js[:body].include?('const AGENT_SORT_STORAGE_KEY = "hq.remote.agentSort"'),
+           "expected agent sort selection to use session storage")
+    assert(js[:body].include?("data-agent-sort-choice"),
+           "expected Agents screen to expose sort dropdown choices")
+    assert(js[:body].include?('icon: "arrowDownAZ"') &&
+           js[:body].include?('icon: "clockArrowDown"') &&
+           js[:body].include?('icon: "arrowDownWideNarrow"'),
+           "expected agent sort trigger to use lucide sort icons")
+    assert(js[:body].include?('M20 8h-5') &&
+           js[:body].include?('M15 10V6.5a2.5 2.5 0 0 1 5 0V10') &&
+           js[:body].include?('M15 20v-3.5a2.5 2.5 0 0 1 5 0V20'),
+           "expected A-Z and Z-A sort icons to use Lucide SVG paths")
+    assert(js[:body].include?("function agentSortMenuHtml"),
+           "expected Agents screen to render an icon-triggered sort dropdown")
+    assert(js[:body].include?("setSessionStorageValue(AGENT_SORT_STORAGE_KEY, state.agentSort)"),
+           "expected chosen agent sort to persist for the browser session")
+    assert(js[:body].include?("function sortedAgentList"),
+           "expected agent sort to support flat agent lists")
+    assert(js[:body].include?("function agentSortUsesProjectGroups"),
+           "expected agent sort to support project-grouped lists")
+    assert(js[:body].include?("function compareAgentsBySort"),
+           "expected agent list sorting to support multiple sort modes")
     assert(js[:body].include?("function showGrowl"), "expected UI JavaScript to expose growl notifications")
     assert(js[:body].include?("function handleDocumentCopyClick"),
            "expected copy buttons to be handled outside the main view")


### PR DESCRIPTION
## Summary
- Add a session-persisted agent sort dropdown with an icon-only trigger and text menu options.
- Support flat agent sorting by A-Z, Z-A, latest, and oldest, plus grouped project ascending/descending with project ascending as the default.
- Use corrected Lucide SVG paths for arrow-down-a-z and arrow-down-z-a.

## Validation
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- isolated Chrome/CDP checks for dropdown behavior and Lucide paths
- `bin/test`