### PR TITLE
Clarify scheduled agent titles

### DIFF
--- a/docs/SCHEDULED_RUNS.md
+++ b/docs/SCHEDULED_RUNS.md
@@ -27,6 +27,7 @@ Prompt input is limited to inline text in `~/.tycho/config/schedules.yml` or a f
 - Unsupported commands: `project_action`, `health_check`, `shell`, `agent_template`, `agent_existing`, and `agent_clone`.
 - Prompt sources: only inline text or files under `~/.tycho/schedules/`.
 - Scheduled prompts always include the final-output attachment checklist so created or referenced durable artifacts are reported in `attachments`.
+- Scheduled agent display names are prefixed with `[Scheduled]` and do not include the internal agent-key number.
 - Retention: archive the previous schedule-created agent for a repeating schedule before creating the next one.
 - Interactive protection: skip a due run instead of archiving when the previous scheduled agent has a later user message.
 - Failure management: stop or pause the schedule and notify via web push when a scheduled job fails.
@@ -54,6 +55,7 @@ Schedules support exactly one target type:
 - Uses the project's path and default agent harness from `~/.tycho/config/hq.yml`.
 - Does not select a project agent template.
 - Seeds the scheduled text as the agent's instruction.
+- Names the managed agent from `target.name`, falling back to the schedule name or key, with a `[Scheduled]` prefix.
 - Starts the agent through `ManagedAgent#start!`.
 - Archives the previous schedule-created agent for the same schedule before creating the next repetitive run.
 - Keeps session context fresh and avoids stale native agent sessions.

--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -8,6 +8,7 @@ require_relative "../ui/rendering/styles"
 module HQ
   class AgentStore
     PALETTE_SIZE = HQ::UI::Rendering::Styles::CHAT_BORDER_PALETTE.length
+    SCHEDULED_NAME_PREFIX = "[Scheduled]"
     PollEvent = Struct.new(:agent_key, :from_status, :to_status, :run_count, keyword_init: true)
 
     def initialize(projects)
@@ -90,7 +91,7 @@ module HQ
       system_messages = system_messages_for(project, prompt)
       agent = ManagedAgent.new(
         key: key,
-        name: scheduled_agent_name(project, schedule_key:, name:, suffix:),
+        name: scheduled_agent_name(project, schedule_key:, name:),
         project_key: project.key,
         template_key: "scheduled",
         workspace: project.path,
@@ -176,10 +177,12 @@ module HQ
       (prefixes.max || 0) + 1
     end
 
-    def scheduled_agent_name(project, schedule_key:, name:, suffix:)
+    def scheduled_agent_name(project, schedule_key:, name:)
       label = name.to_s.strip
       label = "#{project.name} #{schedule_key}" if label.empty?
-      "#{label} #{suffix}"
+      return label if label == SCHEDULED_NAME_PREFIX || label.start_with?("#{SCHEDULED_NAME_PREFIX} ")
+
+      "#{SCHEDULED_NAME_PREFIX} #{label}"
     end
 
     def template_for(project, template_key)

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -120,6 +120,8 @@ module SchedulerTest
 
       agents = read_agents
       assert(agents.map(&:key) == [first_agent.key], "expected first scheduled agent to be active")
+      assert(first_agent.name == "[Scheduled] Weekday maintenance",
+             "expected scheduled agent name to be prefixed without numeric suffix")
       assert(File.exist?(first_agent.raw_log_path), "expected stubbed agent start to write a raw log")
       memory = File.read(first_agent.memory_path)
       assert(memory.include?("Run maintenance."), "expected scheduled message to be written to agent memory")
@@ -130,6 +132,8 @@ module SchedulerTest
       second_agent = second.fetch(:agent)
       agents = read_agents
       assert(agents.map(&:key) == [second_agent.key], "expected second run to replace active scheduled agent")
+      assert(second_agent.name == "[Scheduled] Weekday maintenance",
+             "expected replacement scheduled agent name to stay suffix-free")
       archived = Dir.glob(File.join(HQ::AGENT_ARCHIVE_DIR, "**", File.basename(first_agent.raw_log_path)))
       assert(!archived.empty?, "expected previous scheduled agent logs to be archived")
     end


### PR DESCRIPTION
## Summary

- Prefix scheduled managed-agent display names with `[Scheduled]`
- Remove the visible numeric suffix from scheduled-agent names while keeping internal agent keys numbered
- Document the scheduled-agent naming behavior

## Validation

- `bundle exec ruby test/scheduler_test.rb`
- `bin/test`
