### PR TITLE
[codex] Add Remote UI project editing

### DIFF
--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -240,6 +240,7 @@ module HQ
         key = parts[1]
         tail = parts.drop(2)
         return ok(project: service.project(key)) if method == "GET" && tail.empty?
+        return ok(project: service.update_project(key, body)) if %w[PATCH PUT].include?(method) && tail.empty?
         return ok(actions: service.project_action_preflights(key)) if method == "GET" && tail == ["actions"]
         return ok(service.start_project_action(key, body["action"], body)) if method == "POST" && tail == ["actions"]
         if tail.length == 2 && tail.first == "actions"
@@ -656,6 +657,17 @@ module HQ
       refresh_project!(target)
       agents = load_agents.select { |agent| agent.project_key == target.key }
       project_detail_payload(target, agents:, active_action: active_actions[target.key])
+    end
+
+    def update_project(key, attrs)
+      current = find_project!(key)
+      updated = @registry.update_project!(current.key, project_attrs(current, attrs))
+      raise Error.new("Unknown project: #{key}", status: 404) unless updated
+
+      reload_projects_from_registry!
+      project(current.key)
+    rescue ConfigError => e
+      raise Error.new(e.message)
     end
 
     def search_index
@@ -1413,6 +1425,9 @@ module HQ
         commit_url: project.commit_url(project.commit_hash),
         dirty: project.dirty_files.to_i.positive?,
         dirty_files: project.dirty_files.to_i,
+        agent: project.config.agent,
+        model: project.config.model,
+        reasoning_effort: project.config.reasoning_effort,
         service: project.service,
         image: project.image,
         hosts: Array(project.hosts),
@@ -1726,6 +1741,41 @@ module HQ
         model: model.empty? ? nil : model,
         reasoning_effort: reasoning_effort.empty? ? nil : reasoning_effort
       }
+    end
+
+    def project_attrs(target, attrs)
+      immutable_project_field!(attrs, "key", target.key)
+      immutable_project_field!(attrs, "path", target.path)
+      immutable_project_field!(attrs, "apps", target.apps_enabled?)
+      immutable_project_field!(attrs, "pr_url", target.pr_url.to_s)
+
+      name = attrs.key?("name") ? attrs["name"].to_s.strip : target.name.to_s
+      raise Error.new("Name is required") if name.empty?
+
+      agent = attrs.key?("agent") ? attrs["agent"].to_s.strip.downcase : target.config.agent.to_s
+      unless HQ.supported_harness?(agent)
+        raise Error.new("Unsupported agent #{agent.inspect}. Supported agents: #{HQ.harness_keys.join(", ")}")
+      end
+
+      result = {
+        "name" => name,
+        "group" => attrs.key?("group") ? attrs["group"].to_s.strip : target.group.to_s,
+        "agent" => agent,
+        "model" => attrs.key?("model") ? attrs["model"].to_s.strip : target.config.model.to_s,
+        "reasoning_effort" => attrs.key?("reasoning_effort") ? attrs["reasoning_effort"].to_s.strip.downcase : target.config.reasoning_effort.to_s
+      }
+      result["model"] = nil if result["model"].to_s.empty?
+      result["reasoning_effort"] = nil if result["reasoning_effort"].to_s.empty?
+      result
+    end
+
+    def immutable_project_field!(attrs, field, expected)
+      return unless attrs.key?(field)
+
+      value = attrs[field].to_s.strip
+      return if value.empty? || value == expected.to_s
+
+      raise Error.new("Project #{field} cannot be changed from Remote UI")
     end
 
     def required_text(attrs, key, fallback:)

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1286,6 +1286,14 @@ select {
   gap: 12px;
 }
 
+.read-only-project-fields {
+  padding-top: 12px;
+}
+
+.project-info-title {
+  padding: 12px 12px 0;
+}
+
 .form-actions {
   flex-wrap: wrap;
   justify-content: flex-end;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -430,6 +430,7 @@ const els = {
   subtitle: document.getElementById("screen-subtitle"),
   mark: document.getElementById("header-mark"),
   back: document.getElementById("back-button"),
+  projectEdit: document.getElementById("project-edit-button"),
   agentProject: document.getElementById("agent-project-button"),
   agentSettings: document.getElementById("agent-settings-button"),
   agentSettingsPanel: document.getElementById("agent-settings-panel"),
@@ -580,6 +581,9 @@ function parseRoute() {
   if (parts[0] === "project" && parts[1] && parts[2] === "agent" && parts[3] === "new") {
     return { type: "agentForm", mode: "create", projectKey: parts[1] };
   }
+  if (parts[0] === "project" && parts[1] && parts[2] === "edit") {
+    return { type: "projectForm", key: parts[1] };
+  }
   if (parts[0] === "project" && parts[1] && parts[2] === "action" && parts[3]) {
     return { type: "guard", key: parts[1], action: parts[3] };
   }
@@ -608,6 +612,7 @@ function routeHash(route) {
     return `#agent/${encodeURIComponent(route.key)}/attachment/${encodeURIComponent(route.attachmentId)}`;
   }
   if (route.type === "attachment") return `#attachment/${encodeURIComponent(route.id)}`;
+  if (route.type === "projectForm") return `#project/${encodeURIComponent(route.key)}/edit`;
   if (route.type === "project") return `#project/${encodeURIComponent(route.key)}`;
   if (route.type === "guard") {
     return `#project/${encodeURIComponent(route.key)}/action/${encodeURIComponent(route.action)}`;
@@ -646,7 +651,7 @@ function scrollPageToTop() {
 
 function currentTopTab(route) {
   if (route.type === "tab") return route.tab;
-  if (route.type === "project" || route.type === "guard") return "agents";
+  if (route.type === "project" || route.type === "projectForm" || route.type === "guard") return "agents";
   if (route.type === "agentForm") return "agents";
   if (route.type === "agent" || route.type === "agentSummary" || route.type === "agentAttachment" || route.type === "agentArchive" || route.type === "attachment") return "agents";
   if (route.type === "hiddenSettings") return "settings";
@@ -758,6 +763,9 @@ async function ensureRouteData(options = {}) {
   if (route.type === "agentForm" && route.mode === "clone") {
     const agent = findAgent(route.key);
     if (agent) await ensureProject(agent.project_key, true);
+  }
+  if (route.type === "projectForm") {
+    await ensureProject(route.key, true);
   }
   if (route.type === "agentArchive") {
     const agent = findAgent(route.key);
@@ -897,6 +905,7 @@ function render() {
   els.header.classList.toggle("detail-header", subpage && !onboarding);
   els.header.classList.remove("header-hidden");
   if (!agentShellRoute(route)) setAgentSettings(null);
+  setProjectEditButton(route.type === "project" ? findProject(route.key) : null);
   syncDetailHeaderLayout();
   if (onboarding) {
     setNavHidden(false);
@@ -928,6 +937,8 @@ function render() {
     }
   } else if (route.type === "project") {
     renderProject(route.key);
+  } else if (route.type === "projectForm") {
+    renderProjectForm(route.key);
   } else if (route.type === "agentForm") {
     renderAgentForm(route);
   } else if (route.type === "agentArchive") {
@@ -974,6 +985,7 @@ function routeStateKey(route) {
   if (route.type === "agentForm" && route.mode === "edit") return `agent-form:edit:${route.key}`;
   if (route.type === "agentForm" && route.mode === "clone") return `agent-form:clone:${route.key}`;
   if (route.type === "agentArchive") return `agent-archive:${route.key}`;
+  if (route.type === "projectForm") return `project-form:${route.key}`;
   if (route.type === "project") return `project:${route.key}`;
   if (route.type === "guard") return `guard:${route.key}:${route.action}`;
   if (route.type === "hiddenSettings") return "settings:hidden";
@@ -2404,10 +2416,97 @@ function renderProject(key) {
         ${PROJECT_ACTIONS.map((action) => `<button type="button" data-guard-action="${action}" data-project-key="${escapeAttr(project.key)}" ${project.apps_enabled ? "" : "disabled"}>${capitalize(action)}</button>`).join("")}
       </div>
     </section>
-    <section class="notice">
-      <strong>Project editing opens in the TUI</strong>
-      <p>Mobile project modification is disabled because setup still needs terminal directory access.</p>
-    </section>
+  `);
+}
+
+function renderProjectForm(key) {
+  const project = findProject(key);
+  if (!project) {
+    if (initialDataPending()) {
+      setHeader("Loading project", "Fetching remote state", "folder");
+      replaceView(emptyState("Loading project", "Fetching the selected project state."));
+      return;
+    }
+
+    setHeader("Project not found", "It may have been removed from config.", "folder");
+    replaceView(emptyState("Project not found", "Return to the Agents tab and choose an active project."));
+    return;
+  }
+
+  const harness = normalizeAgentHarness(project.agent || agentTemplateFor(project)?.agent);
+  const values = {
+    name: project.name || "",
+    group: project.group || "",
+    agent: harness,
+    model: project.model || "",
+    reasoningEffort: project.reasoning_effort || "",
+  };
+  const groups = [...new Set(state.projects.map((item) => item.group).filter(Boolean))].sort(compareDisplayText);
+
+  setHeader("Edit project", `${project.name || project.key} / key ${project.key}`, "folder");
+  replaceView(`
+    <form id="project-form" class="agent-form project-form" data-project-key="${escapeAttr(project.key)}">
+      <section class="detail-card">
+        <div class="card-title project-info-title">
+          <strong>Project Information</strong>
+        </div>
+        <div class="detail-card-body read-only-project-fields">
+          <div class="detail-row">
+            <span class="status-mark detail" aria-hidden="true">${iconSvg("folder")}</span>
+            <div><strong>Key</strong><span class="wrap-anywhere">${escapeHtml(project.key)}</span></div>
+            <span class="pill detail">Fixed</span>
+          </div>
+          <div class="detail-row">
+            <span class="status-mark detail" aria-hidden="true">${iconSvg("folder")}</span>
+            <div><strong>Workspace</strong><span class="wrap-anywhere">${escapeHtml(project.path || "n/a")}</span></div>
+            <span class="pill detail">Fixed</span>
+          </div>
+          <div class="detail-row">
+            <span class="status-mark detail" aria-hidden="true">${iconSvg("gitCommit")}</span>
+            <div><strong>PR URL</strong><span class="wrap-anywhere">${escapeHtml(project.pr_url || "n/a")}</span></div>
+            <span class="pill detail">Read only</span>
+          </div>
+          <div class="detail-row">
+            <span class="status-mark ${project.apps_enabled ? "done" : "detail"}" aria-hidden="true">${iconSvg("rocket")}</span>
+            <div><strong>Kamal deploy</strong><span>${escapeHtml(kamalDeploymentText(project))}</span></div>
+            <span class="pill ${project.apps_enabled ? "done" : "detail"}">${project.apps_enabled ? "Available" : "Unavailable"}</span>
+          </div>
+        </div>
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="project-name">Name</label>
+        <input id="project-name" name="name" type="text" value="${escapeAttr(values.name)}" autocomplete="off" required>
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="project-group">Group</label>
+        <input id="project-group" name="group" type="text" value="${escapeAttr(values.group)}" autocomplete="off" list="project-group-options">
+        <datalist id="project-group-options">
+          ${groups.map((group) => `<option value="${escapeAttr(group)}"></option>`).join("")}
+        </datalist>
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="project-harness">Default harness</label>
+        <select id="project-harness" name="agent" data-project-harness-select>
+          ${agentHarnessOptions().map((option) => `<option value="${escapeAttr(option)}" ${option === values.agent ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}
+        </select>
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="project-model">Default model</label>
+        <select id="project-model" name="model" data-project-model-select>
+          ${modelChoiceOptions(values.agent, values.model)}
+        </select>
+      </section>
+      <section class="field-card">
+        <label class="field-label" for="project-reasoning-effort">Default effort</label>
+        <select id="project-reasoning-effort" name="reasoning_effort" data-project-reasoning-effort-select>
+          ${reasoningEffortChoiceOptions(values.agent, values.model, values.reasoningEffort)}
+        </select>
+      </section>
+      <div class="button-row form-actions">
+        <button type="button" data-cancel-project-form>Cancel</button>
+        <button class="primary inline-icon-button" type="submit" value="save">${iconSvg("pencil")}<span>Save project</span></button>
+      </div>
+    </form>
   `);
 }
 
@@ -3892,6 +3991,22 @@ function setAgentProjectButton(agent) {
   els.agentProject.setAttribute("title", label);
 }
 
+function setProjectEditButton(project) {
+  if (!project?.key) {
+    els.projectEdit.classList.add("hidden");
+    delete els.projectEdit.dataset.editProject;
+    els.projectEdit.setAttribute("aria-label", "Edit project");
+    els.projectEdit.setAttribute("title", "Edit project");
+    return;
+  }
+
+  const label = `Edit project ${project.name || project.key}`;
+  els.projectEdit.classList.remove("hidden");
+  els.projectEdit.dataset.editProject = project.key;
+  els.projectEdit.setAttribute("aria-label", label);
+  els.projectEdit.setAttribute("title", label);
+}
+
 function toggleAgentSettings() {
   const route = parseRoute();
   const agent = agentShellRoute(route) ? findAgent(route.key) : null;
@@ -4039,6 +4154,15 @@ function removeAgent(key) {
 
 function findProject(key) {
   return state.projectDetails[key] || state.projects.find((project) => project.key === key) || null;
+}
+
+function upsertProject(project) {
+  if (!project?.key) return;
+
+  const index = state.projects.findIndex((item) => item.key === project.key);
+  if (index >= 0) state.projects[index] = { ...state.projects[index], ...project };
+  else state.projects.push(project);
+  state.projectDetails[project.key] = project;
 }
 
 function agentTemplateSummaries(project) {
@@ -4580,6 +4704,10 @@ function actionText(actionState) {
   return [actionState.label, actionState.status, timeShort(actionState.started_at)].filter(Boolean).join(" / ");
 }
 
+function kamalDeploymentText(project) {
+  return project?.apps_enabled ? "Can be deployed with Kamal" : "Kamal deploy actions are not configured";
+}
+
 function latencyText(project) {
   return project.latency_ms === null || project.latency_ms === undefined ? "latency n/a" : `${project.latency_ms}ms`;
 }
@@ -4894,9 +5022,15 @@ els.back.addEventListener("click", () => {
   else if (route.type === "agentForm" && route.mode === "clone") navigate({ type: "agentArchive", key: route.key });
   else if (route.type === "agentForm" && route.mode === "create") navigate({ type: "project", key: route.projectKey });
   else if (route.type === "agentArchive") navigate({ type: "agent", key: route.key });
+  else if (route.type === "projectForm") navigate({ type: "project", key: route.key });
   else if (route.type === "project" || route.type === "guard") navigate({ type: "tab", tab: "agents" });
   else if (route.type === "hiddenSettings") navigate({ type: "tab", tab: "settings" });
   else navigate({ type: "tab", tab: "now" });
+});
+
+els.projectEdit.addEventListener("click", () => {
+  const projectKey = els.projectEdit.dataset.editProject;
+  if (projectKey) navigate({ type: "projectForm", key: projectKey });
 });
 
 els.agentProject.addEventListener("click", () => {
@@ -5063,6 +5197,15 @@ els.view.addEventListener("click", (event) => {
     if (route.type === "agentForm" && route.mode === "edit") navigate({ type: "agent", key: route.key });
     else if (route.type === "agentForm" && route.mode === "clone") navigate({ type: "agentArchive", key: route.key });
     else if (route.type === "agentForm" && route.mode === "create") navigate({ type: "project", key: route.projectKey });
+    return;
+  }
+
+  const cancelProjectForm = event.target.closest("[data-cancel-project-form]");
+  if (cancelProjectForm) {
+    const route = parseRoute();
+    const form = cancelProjectForm.closest("form");
+    if (form) clearFormDraft(form);
+    if (route.type === "projectForm") navigate({ type: "project", key: route.key });
     return;
   }
 
@@ -5297,6 +5440,21 @@ els.view.addEventListener("change", (event) => {
 
   const harnessSelect = event.target.closest("[data-agent-harness-select]");
   if (harnessSelect) applyAgentHarnessSelection(harnessSelect);
+
+  const projectModelChoice = event.target.closest("[data-project-model-select]");
+  if (projectModelChoice) {
+    applyProjectModelChoice(projectModelChoice);
+    return;
+  }
+
+  const projectReasoningEffortChoice = event.target.closest("[data-project-reasoning-effort-select]");
+  if (projectReasoningEffortChoice) {
+    applyProjectReasoningEffortChoice(projectReasoningEffortChoice);
+    return;
+  }
+
+  const projectHarnessSelect = event.target.closest("[data-project-harness-select]");
+  if (projectHarnessSelect) applyProjectHarnessSelection(projectHarnessSelect);
 });
 
 els.view.addEventListener("submit", (event) => {
@@ -5350,6 +5508,22 @@ els.view.addEventListener("submit", (event) => {
     mutate(async () => {
       await apiPost(`/projects/${encodeURIComponent(projectKey)}/actions/${encodeURIComponent(action)}`, { confirm: true });
       navigate({ type: "project", key: projectKey });
+    });
+  }
+
+  if (event.target.id === "project-form") {
+    const form = event.target;
+    const projectKey = form.dataset.projectKey;
+    if (!projectKey) return;
+    const payload = projectFormPayload(form);
+
+    mutate(async () => {
+      const data = await apiPatch(`/projects/${encodeURIComponent(projectKey)}`, payload);
+      if (data.project?.key) {
+        upsertProject(data.project);
+        clearFormDraft(form);
+        navigate({ type: "project", key: data.project.key });
+      }
     });
   }
 
@@ -5584,6 +5758,31 @@ function applyAgentReasoningEffortChoice(select) {
   saveFormDraft(form);
 }
 
+function applyProjectHarnessSelection(select) {
+  const form = select.closest("#project-form");
+  if (!form) return;
+
+  updateProjectModelChoices(form, normalizeAgentHarness(select.value));
+  saveFormDraft(form);
+}
+
+function applyProjectModelChoice(select) {
+  const form = select.closest("#project-form");
+  if (!form) return;
+
+  select.dataset.dirty = "true";
+  syncProjectReasoningEffortForModel(form, { applyDefault: true });
+  saveFormDraft(form);
+}
+
+function applyProjectReasoningEffortChoice(select) {
+  const form = select.closest("#project-form");
+  if (!form) return;
+
+  select.dataset.dirty = "true";
+  saveFormDraft(form);
+}
+
 function updateAgentModelChoices(form, harness) {
   const modelSelect = form.querySelector("#agent-model");
   const model = modelSelect?.value || "";
@@ -5591,10 +5790,31 @@ function updateAgentModelChoices(form, harness) {
   syncReasoningEffortForModel(form, { applyDefault: false });
 }
 
+function updateProjectModelChoices(form, harness) {
+  const modelSelect = form.querySelector("#project-model");
+  const model = modelSelect?.value || "";
+  if (modelSelect) modelSelect.innerHTML = modelChoiceOptions(harness, model);
+  syncProjectReasoningEffortForModel(form, { applyDefault: false });
+}
+
 function syncReasoningEffortForModel(form, options = {}) {
   const harness = normalizeAgentHarness(form.querySelector("#agent-harness")?.value);
   const model = form.querySelector("#agent-model")?.value || "";
   const effortSelect = form.querySelector("#agent-reasoning-effort");
+  if (effortSelect) effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, model, effortSelect.value || "");
+  if (options.applyDefault && effortSelect && effortSelect.dataset.dirty !== "true") {
+    const defaultEffort = defaultReasoningEffortForModel(harness, model);
+    if (defaultEffort) {
+      effortSelect.value = defaultEffort;
+      effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, model, effortSelect.value);
+    }
+  }
+}
+
+function syncProjectReasoningEffortForModel(form, options = {}) {
+  const harness = normalizeAgentHarness(form.querySelector("#project-harness")?.value);
+  const model = form.querySelector("#project-model")?.value || "";
+  const effortSelect = form.querySelector("#project-reasoning-effort");
   if (effortSelect) effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, model, effortSelect.value || "");
   if (options.applyDefault && effortSelect && effortSelect.dataset.dirty !== "true") {
     const defaultEffort = defaultReasoningEffortForModel(harness, model);
@@ -5617,6 +5837,17 @@ function agentFormPayload(form) {
     sandbox_mode: String(formData.get("sandbox_mode") || "").trim(),
   };
   return payload;
+}
+
+function projectFormPayload(form) {
+  const formData = new FormData(form);
+  return {
+    name: String(formData.get("name") || "").trim(),
+    group: String(formData.get("group") || "").trim(),
+    agent: normalizeAgentHarness(formData.get("agent")),
+    model: String(formData.get("model") || "").trim(),
+    reasoning_effort: String(formData.get("reasoning_effort") || "").trim().toLowerCase(),
+  };
 }
 
 function inquiryAnswerPayload(form) {

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -43,6 +43,13 @@
             </div>
           </div>
           <div class="header-actions">
+            <button id="project-edit-button" class="icon-button hidden" type="button" aria-label="Edit project" title="Edit project">
+              <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+                <path d="M12 20h9"></path>
+                <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
+              </svg>
+              <span class="sr-only">Edit project</span>
+            </button>
             <button id="agent-project-button" class="icon-button hidden" type="button" aria-label="Open project" title="Open project">
               <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
                 <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9l-.81-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -23,6 +23,7 @@ module RemoteServerTest
     assert_remote_prompt_start_accepts_dash_prefixed_message
     assert_remote_agent_conversation_hides_run_summary
     assert_remote_project_payloads_include_status_and_detail
+    assert_remote_project_update_route_edits_metadata
     assert_remote_agent_model_and_effort_payloads
     assert_remote_hidden_settings_filter_projects_and_agents
     assert_remote_schedule_routes
@@ -776,6 +777,72 @@ module RemoteServerTest
     end
   end
 
+  def assert_remote_project_update_route_edits_metadata
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace, apps: true)
+      service = HQ::RemoteService.new(registry: registry)
+      server = HQ::RemoteServer.new
+
+      updated = server.send(
+        :route,
+        service,
+        "PATCH",
+        "/projects/web",
+        {
+          "name" => "Web Renamed",
+          "group" => "Ops",
+          "agent" => "claude",
+          "model" => "sonnet",
+          "reasoning_effort" => "low"
+        },
+        nil
+      )
+      project = updated.dig(:body, :project)
+      assert(project[:name] == "Web Renamed", "expected updated project name in response")
+      assert(project[:group] == "Ops", "expected updated project group in response")
+      assert(project[:path] == workspace, "expected project workspace path to stay unchanged")
+      assert(project[:apps_enabled] == true, "expected app actions setting to stay unchanged")
+      assert(project[:agent] == "claude", "expected default harness to update")
+      assert(project[:model] == "sonnet", "expected project model to update")
+      assert(project[:reasoning_effort] == "low", "expected project effort to update")
+      assert(project[:pr_url].end_with?("/pull/123"), "expected PR URL to stay unchanged")
+
+      persisted = YAML.safe_load(File.read(registry.path), aliases: true)
+      entry = persisted["projects"].find { |item| item["key"] == "web" }
+      assert(entry["name"] == "Web Renamed", "expected updated project name to persist")
+      assert(entry["group"] == "Ops", "expected updated project group to persist")
+      assert(entry["path"] == workspace, "expected persisted workspace path to stay unchanged")
+      assert(entry["apps"] == true, "expected apps setting to stay unchanged")
+      assert(entry["agent"] == "claude", "expected default harness to persist")
+      assert(entry["model"] == "sonnet", "expected model to persist")
+      assert(entry["reasoning_effort"] == "low", "expected effort to persist")
+      assert(entry["pr_url"].end_with?("/pull/123"), "expected PR URL to stay unchanged")
+
+      begin
+        server.send(:route, service, "PATCH", "/projects/web", { "path" => File.join(dir, "other") }, nil)
+        raise "expected Remote project path edits to be rejected"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.message.include?("path cannot be changed"), "expected immutable path error")
+      end
+
+      begin
+        server.send(:route, service, "PATCH", "/projects/web", { "apps" => false }, nil)
+        raise "expected Remote project app action edits to be rejected"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.message.include?("apps cannot be changed"), "expected immutable apps error")
+      end
+
+      begin
+        server.send(:route, service, "PATCH", "/projects/web", { "pr_url" => "https://github.com/example/web/pull/12" }, nil)
+        raise "expected Remote project PR URL edits to be rejected"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.message.include?("pr_url cannot be changed"), "expected immutable PR URL error")
+      end
+    end
+  end
+
   def assert_remote_agent_model_and_effort_payloads
     with_remote_temp_store do |dir|
       workspace = File.join(dir, "workspace")
@@ -1339,6 +1406,9 @@ module RemoteServerTest
            "expected root CSS reference to be asset-versioned")
     assert(response[:body].match?(%r{src="/ui\.js\?v=[0-9a-f]{12}"}),
            "expected root JavaScript reference to be asset-versioned")
+    assert(response[:body].include?("project-edit-button"), "expected root shell to expose Project edit")
+    assert(response[:body].include?('<span class="sr-only">Edit project</span>'),
+           "expected Project edit header control to be icon-only with accessible text")
     assert(response[:body].include?("agent-settings-button"), "expected root shell to expose Agent settings")
     assert(response[:body].include?('data-tab="settings"'), "expected root shell to expose Settings navigation")
     assert(response[:body].include?("<span>Settings</span>"), "expected root shell to label setup navigation as Settings")
@@ -1561,6 +1631,8 @@ module RemoteServerTest
            "expected Hidden settings rows to style the visible segment in the triple toggle")
     assert(css[:body].include?("flex-wrap: nowrap"),
            "expected Hidden settings toggle segments to stay horizontal")
+    assert(css[:body].include?(".project-info-title"),
+           "expected Project edit form to style the read-only information title")
     js = server.send(:route_ui, "/ui.js")
     assert(js[:content_type].include?("javascript"), "expected /ui.js to return JavaScript")
     assert(js[:body].include?("DEFAULT_REFRESH_INTERVALS"), "expected UI JavaScript to define refresh defaults")
@@ -1704,6 +1776,38 @@ module RemoteServerTest
            "expected Remote UI agent forms to let the server preserve/default workspace")
     assert(js[:body].include?("data-create-agent"),
            "expected Project detail to expose Add agent navigation")
+    assert(js[:body].include?("function setProjectEditButton"),
+           "expected Project detail to expose edit navigation in the header")
+    assert(js[:body].include?("els.projectEdit.dataset.editProject"),
+           "expected Project edit header button to route to the edit form")
+    assert(js[:body].include?('return { type: "projectForm", key: parts[1] };'),
+           "expected Remote UI to parse Project edit routes")
+    assert(js[:body].include?("function renderProjectForm"),
+           "expected Remote UI to render Project edit forms")
+    assert(js[:body].include?("Project Information"),
+           "expected Project edit form to label read-only project metadata")
+    assert(js[:body].include?('id="project-form"'),
+           "expected Project edit form to use a dedicated form")
+    assert(js[:body].include?('id="project-harness" name="agent"'),
+           "expected Project edit form to expose default harness")
+    assert(js[:body].include?("data-project-model-select"),
+           "expected Project edit form to expose model choices")
+    assert(js[:body].include?("Can be deployed with Kamal"),
+           "expected Project edit form to describe app actions as Kamal deploy capability")
+    assert(!js[:body].include?('id="project-pr-url"'),
+           "expected Project edit form to keep PR URL readonly")
+    assert(!js[:body].include?('id="project-apps"'),
+           "expected Project edit form to keep app actions readonly")
+    assert(!js[:body].include?('formData.get("pr_url")'),
+           "expected Project edit form payload to omit PR URL")
+    assert(!js[:body].include?('formData.get("apps")'),
+           "expected Project edit form payload to omit app actions")
+    assert(js[:body].include?("function projectFormPayload"),
+           "expected Project edit form to serialize project metadata")
+    assert(js[:body].include?('apiPatch(`/projects/${encodeURIComponent(projectKey)}`'),
+           "expected Project edit form to update projects through the API")
+    assert(!js[:body].include?("Project editing opens in the TUI"),
+           "expected Project detail to remove the old TUI-only edit notice")
     assert(js[:body].include?("data-edit-agent"),
            "expected Agent settings to expose edit navigation")
     assert(js[:body].include?("data-archive-agent"),


### PR DESCRIPTION
## Summary
- add a Remote UI project edit route and PATCH/PUT project update API
- allow editing only project name, group, default harness, model, and reasoning effort
- keep key, workspace, PR URL, and Kamal deploy capability read-only, with the edit button moved to the header navigation

## Validation
- `node --check lib/hq/remote_ui/assets/app.js`
- `bin/test`
- Browser verification with Chrome/Playwright against a temporary `bin/tycho serve` instance before publishing

## Notes
- Pulled `main` with `git pull --ff-only origin main`; feature branch is based on current `main` at `3b3ded4`.
