### PR TITLE
Add drag-and-drop prompt attachments

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -2334,6 +2334,36 @@ button.restart-server-button {
   gap: 8px;
 }
 
+.composer-drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 9;
+  display: grid;
+  place-items: center;
+  border: 1px dashed color-mix(in srgb, var(--muted) 38%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 62%, transparent);
+  color: var(--muted);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+  backdrop-filter: blur(2px);
+}
+
+.composer-drop-overlay span {
+  border: 1px solid color-mix(in srgb, var(--muted) 34%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 76%, transparent);
+  padding: 8px 12px;
+  color: color-mix(in srgb, var(--muted) 86%, transparent);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.composer.drop-active .composer-drop-overlay {
+  opacity: .88;
+}
+
 .inquiry-form {
   position: relative;
   display: grid;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2012,6 +2012,9 @@ function renderAgentComposer(agent, skills, options = {}) {
   return `
     <form id="composer" class="composer" data-agent-key="${escapeAttr(agent.key)}">
       <textarea id="prompt-input" rows="4" placeholder="Send a prompt" aria-label="Prompt" enterkeyhint="enter"></textarea>
+      <div class="composer-drop-overlay" data-composer-drop-overlay aria-hidden="true">
+        <span>Drop files to attach</span>
+      </div>
       ${renderPromptAttachmentInput(agent)}
       ${renderPendingAttachments(agent)}
       ${renderAgentAttachments(agent)}
@@ -3164,6 +3167,79 @@ function handleClipboardAttachmentPaste(event) {
   const beforeCount = pendingAttachmentsFor(agentKey).length;
   handlePromptAttachmentFiles(agentKey, files);
   if (pendingAttachmentsFor(agentKey).length > beforeCount) event.preventDefault();
+}
+
+function handlePromptAttachmentDrag(event) {
+  const targetComposer = promptAttachmentFileComposer(event);
+  if (!targetComposer) return;
+
+  const composer = promptAttachmentDropComposer(event);
+  event.preventDefault();
+  event.dataTransfer.dropEffect = composer ? "copy" : "none";
+  if (!composer) return;
+
+  setComposerDropActive(composer, true);
+}
+
+function handlePromptAttachmentDragLeave(event) {
+  const composer = event.target?.closest?.("#composer");
+  if (!composer) return;
+  if (dragEventInsideElement(event, composer)) return;
+
+  setComposerDropActive(composer, false);
+}
+
+function handlePromptAttachmentDrop(event) {
+  const targetComposer = promptAttachmentFileComposer(event);
+  clearComposerDropTargets();
+  if (!targetComposer) return;
+
+  event.preventDefault();
+  const composer = promptAttachmentDropComposer(event);
+  if (!composer) return;
+
+  const files = promptAttachmentDropFiles(event);
+  if (!files.length) return;
+
+  handlePromptAttachmentFiles(composer.dataset.agentKey, files);
+}
+
+function promptAttachmentFileComposer(event) {
+  if (!dataTransferHasFiles(event.dataTransfer)) return null;
+  return event.target?.closest?.("#composer") || null;
+}
+
+function promptAttachmentDropComposer(event) {
+  const composer = promptAttachmentFileComposer(event);
+  if (!composer) return null;
+
+  const agent = findAgent(composer.dataset.agentKey);
+  if (!agent || agentIsRunning(agent)) return null;
+
+  return composer;
+}
+
+function dataTransferHasFiles(dataTransfer) {
+  if (!dataTransfer) return false;
+  if (Array.from(dataTransfer.types || []).includes("Files")) return true;
+  return Array.from(dataTransfer.items || []).some((item) => item.kind === "file");
+}
+
+function promptAttachmentDropFiles(event) {
+  return Array.from(event.dataTransfer?.files || []).filter(Boolean);
+}
+
+function setComposerDropActive(composer, active) {
+  composer.classList.toggle("drop-active", active);
+}
+
+function clearComposerDropTargets() {
+  els.view.querySelectorAll("#composer.drop-active").forEach((composer) => setComposerDropActive(composer, false));
+}
+
+function dragEventInsideElement(event, element) {
+  const rect = element.getBoundingClientRect();
+  return event.clientX >= rect.left && event.clientX <= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom;
 }
 
 function clipboardAttachmentAgentKey(event) {
@@ -5363,6 +5439,14 @@ els.view.addEventListener("keydown", (event) => {
 els.view.addEventListener("paste", (event) => {
   handleClipboardAttachmentPaste(event);
 });
+
+els.view.addEventListener("dragenter", handlePromptAttachmentDrag);
+els.view.addEventListener("dragover", handlePromptAttachmentDrag);
+els.view.addEventListener("dragleave", handlePromptAttachmentDragLeave);
+els.view.addEventListener("drop", handlePromptAttachmentDrop);
+
+document.addEventListener("dragend", clearComposerDropTargets);
+document.addEventListener("drop", clearComposerDropTargets);
 
 els.view.addEventListener("input", (event) => {
   const filter = event.target.closest("[data-filter]");

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1550,6 +1550,10 @@ module RemoteServerTest
     assert(css[:body].include?(".attachment-nav-item.active"), "expected Attachment detail navigation to highlight the current item")
     assert(css[:body].include?(".pending-attachments"), "expected Agent detail to style pending prompt attachments")
     assert(css[:body].include?(".attachment-upload-button"), "expected Agent detail to style upload attachment controls")
+    assert(css[:body].include?(".composer-drop-overlay"),
+           "expected Agent detail composer to style drag-and-drop attachment overlays")
+    assert(css[:body].include?(".composer.drop-active .composer-drop-overlay"),
+           "expected Agent detail composer to reveal the drag-and-drop attachment overlay while active")
     assert(css[:body].include?(".message-attachments"), "expected chat messages to style attached prompt files")
     assert(css[:body].include?(".attachment-text-viewer"), "expected Attachment detail to style plain text")
     assert(css[:body].include?(".attachment-image-viewer"), "expected Attachment detail to style image previews")
@@ -2012,6 +2016,14 @@ module RemoteServerTest
            "expected Remote UI to route pasted clipboard files into pending attachments")
     assert(js[:body].include?("function clipboardAttachmentFiles"),
            "expected Remote UI to extract files from clipboard data")
+    assert(js[:body].include?('els.view.addEventListener("dragover"'),
+           "expected Agent detail composer to listen for dragged attachment files")
+    assert(js[:body].include?("function handlePromptAttachmentDrop"),
+           "expected Remote UI to route dropped files into pending attachments")
+    assert(js[:body].include?("function dataTransferHasFiles"),
+           "expected Remote UI to ignore non-file drag events")
+    assert(js[:body].include?("Drop files to attach"),
+           "expected Remote UI composer drop overlay to explain the action")
     assert(js[:body].include?("function clipboardAttachmentFilename"),
            "expected Remote UI to synthesize filenames for nameless clipboard blobs")
     assert(js[:body].include?("new File([file], filename"),


### PR DESCRIPTION
## Summary
- Add drag-and-drop file attachment support to the Remote UI agent composer.
- Show a muted full-composer drop overlay while a droppable file is hovering.
- Cover the overlay and drag/drop asset hooks in the Remote UI route regression test.

## Validation
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- Chrome/Playwright drag/drop verification against a throwaway `bin/tycho serve` instance
- `git diff --check HEAD~1..HEAD`
