### PR TITLE
[codex] Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.4.0 - 2026-06-06
+
+- Add grouped Web Push badge support so Remote UI notifications can update
+  scoped browser badges and document push behavior.
+- Improve the Remote UI Summary surface and keep run summary blocks out of the
+  main conversation stream.
+- Fix Remote readiness checks by sharing executable resolution for `mise`,
+  Kamal, Codex, Claude, and compatible harnesses.
+- Fix Claude structured output schema handling so Claude-compatible runs can
+  produce and parse structured results reliably.
+- Resume stopped schedules safely after interactive scheduled agents are
+  archived, while preserving protection for user-touched sessions.
+- Add managed-agent model and reasoning effort settings with config inheritance,
+  harness catalog suggestions, and TUI/Remote UI editing.
+- Keep schedule rows visible in the Remote UI as schedule and daemon state
+  changes.
+- Add copyable Remote UI details for operator-facing metadata.
+- Add a Remote UI agent sort dropdown for faster agent list triage.
+- Clarify scheduled-agent titles so recurring run history is easier to scan.
+- Add Remote UI project editing with JSON API support.
+- Add drag-and-drop file attachments to the Remote UI composer.
+- Simplify schedule status handling to `scheduled`, `paused`, and `stopped`,
+  with last outcome and error diagnostics tracked separately.
+
 ## 0.3.0 - 2026-05-31
 
 - Add first-run onboarding for pristine installs, including TUI and Remote UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,35 @@ All notable changes to Tycho will be documented in this file.
 
 ## 0.4.0 - 2026-06-06
 
+### Notable Releases
+
 - Add grouped Web Push badge support so Remote UI notifications can update
   scoped browser badges and document push behavior. (#10)
 - Improve the Remote UI Summary surface and keep run summary blocks out of the
   main conversation stream. (#11)
+- Add managed-agent model and reasoning effort settings with config inheritance,
+  harness catalog suggestions, and TUI/Remote UI editing. (#15)
+- Add copyable Remote UI details for operator-facing metadata. (#16)
+- Add a Remote UI agent sort dropdown for faster agent list triage. (#17)
+- Add Remote UI project editing with JSON API support. (#19)
+- Add drag-and-drop file attachments to the Remote UI composer. (#20)
+- Simplify schedule status handling to `scheduled`, `paused`, and `stopped`,
+  with last outcome and error diagnostics tracked separately. (#21)
+
+### Bugfixes
+
 - Fix Remote readiness checks by sharing executable resolution for `mise`,
   Kamal, Codex, Claude, and compatible harnesses. (#12)
 - Fix Claude structured output schema handling so Claude-compatible runs can
   produce and parse structured results reliably. (#13)
 - Resume stopped schedules safely after interactive scheduled agents are
   archived, while preserving protection for user-touched sessions. (#14)
-- Add managed-agent model and reasoning effort settings with config inheritance,
-  harness catalog suggestions, and TUI/Remote UI editing. (#15)
 - Keep schedule rows visible in the Remote UI as schedule and daemon state
   changes.
-- Add copyable Remote UI details for operator-facing metadata. (#16)
-- Add a Remote UI agent sort dropdown for faster agent list triage. (#17)
+
+### Others
+
 - Clarify scheduled-agent titles so recurring run history is easier to scan. (#18)
-- Add Remote UI project editing with JSON API support. (#19)
-- Add drag-and-drop file attachments to the Remote UI composer. (#20)
-- Simplify schedule status handling to `scheduled`, `paused`, and `stopped`,
-  with last outcome and error diagnostics tracked separately. (#21)
 
 ## 0.3.0 - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,26 @@ All notable changes to Tycho will be documented in this file.
 ## 0.4.0 - 2026-06-06
 
 - Add grouped Web Push badge support so Remote UI notifications can update
-  scoped browser badges and document push behavior.
+  scoped browser badges and document push behavior. (#10)
 - Improve the Remote UI Summary surface and keep run summary blocks out of the
-  main conversation stream.
+  main conversation stream. (#11)
 - Fix Remote readiness checks by sharing executable resolution for `mise`,
-  Kamal, Codex, Claude, and compatible harnesses.
+  Kamal, Codex, Claude, and compatible harnesses. (#12)
 - Fix Claude structured output schema handling so Claude-compatible runs can
-  produce and parse structured results reliably.
+  produce and parse structured results reliably. (#13)
 - Resume stopped schedules safely after interactive scheduled agents are
-  archived, while preserving protection for user-touched sessions.
+  archived, while preserving protection for user-touched sessions. (#14)
 - Add managed-agent model and reasoning effort settings with config inheritance,
-  harness catalog suggestions, and TUI/Remote UI editing.
+  harness catalog suggestions, and TUI/Remote UI editing. (#15)
 - Keep schedule rows visible in the Remote UI as schedule and daemon state
   changes.
-- Add copyable Remote UI details for operator-facing metadata.
-- Add a Remote UI agent sort dropdown for faster agent list triage.
-- Clarify scheduled-agent titles so recurring run history is easier to scan.
-- Add Remote UI project editing with JSON API support.
-- Add drag-and-drop file attachments to the Remote UI composer.
+- Add copyable Remote UI details for operator-facing metadata. (#16)
+- Add a Remote UI agent sort dropdown for faster agent list triage. (#17)
+- Clarify scheduled-agent titles so recurring run history is easier to scan. (#18)
+- Add Remote UI project editing with JSON API support. (#19)
+- Add drag-and-drop file attachments to the Remote UI composer. (#20)
 - Simplify schedule status handling to `scheduled`, `paused`, and `stopped`,
-  with last outcome and error diagnostics tracked separately.
+  with last outcome and error diagnostics tracked separately. (#21)
 
 ## 0.3.0 - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,14 @@ All notable changes to Tycho will be documented in this file.
 
 - Add grouped Web Push badge support so Remote UI notifications can update
   scoped browser badges and document push behavior. (#10)
-- Improve the Remote UI Summary surface and keep run summary blocks out of the
-  main conversation stream. (#11)
 - Add managed-agent model and reasoning effort settings with config inheritance,
   harness catalog suggestions, and TUI/Remote UI editing. (#15)
-- Add copyable Remote UI details for operator-facing metadata. (#16)
-- Add a Remote UI agent sort dropdown for faster agent list triage. (#17)
-- Add Remote UI project editing with JSON API support. (#19)
 - Add drag-and-drop file attachments to the Remote UI composer. (#20)
-- Simplify schedule status handling to `scheduled`, `paused`, and `stopped`,
-  with last outcome and error diagnostics tracked separately. (#21)
 
-### Bugfixes
+### Others
+
+- Improve the Remote UI Summary surface and keep run summary blocks out of the
+  main conversation stream. (#11)
 
 - Fix Remote readiness checks by sharing executable resolution for `mise`,
   Kamal, Codex, Claude, and compatible harnesses. (#12)
@@ -31,10 +27,12 @@ All notable changes to Tycho will be documented in this file.
   archived, while preserving protection for user-touched sessions. (#14)
 - Keep schedule rows visible in the Remote UI as schedule and daemon state
   changes.
-
-### Others
-
+- Add copyable Remote UI details for operator-facing metadata. (#16)
+- Add a Remote UI agent sort dropdown for faster agent list triage. (#17)
 - Clarify scheduled-agent titles so recurring run history is easier to scan. (#18)
+- Add Remote UI project editing with JSON API support. (#19)
+- Simplify schedule status handling to `scheduled`, `paused`, and `stopped`,
+  with last outcome and error diagnostics tracked separately. (#21)
 
 ## 0.3.0 - 2026-05-31
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-06-03
+2026-06-06
 
 ## Strategic Direction
 
@@ -64,9 +64,10 @@ Key references:
 
 ## Current Focus
 
-**v0.3.0 release**: Tycho's current release focus is packaging first-run
-onboarding, the simplified Remote UI agent workspace, clipboard attachment
-uploads, and attachment dedupe/prepend behavior. After release, the next focus is
+**v0.4.0 release**: Tycho's current release focus is Remote UI project editing,
+agent operator ergonomics, managed-agent model/effort controls, schedule
+resilience, simplified schedule statuses, and grouped web push badges. After
+release, the next focus is completing schedule management surfaces and
 stabilizing install/update paths through Homebrew checks and browser/TUI smoke
 verification.
 

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## Summary

Prepare Tycho v0.4.0 by bumping `HQ::VERSION`, moving post-v0.3.0 work into a dated changelog section, and refreshing the durable project-status release focus.

## Changes since v0.3.0

### Notable Releases

- Add grouped Web Push badge support so Remote UI notifications can update scoped browser badges and document push behavior. (#10)
- Add managed-agent model and reasoning effort settings with config inheritance, harness catalog suggestions, and TUI/Remote UI editing. (#15)
- Add drag-and-drop file attachments to the Remote UI composer. (#20)

### Others

- Improve the Remote UI Summary surface and keep run summary blocks out of the main conversation stream. (#11)
- Fix Remote readiness checks by sharing executable resolution for `mise`, Kamal, Codex, Claude, and compatible harnesses. (#12)
- Fix Claude structured output schema handling so Claude-compatible runs can produce and parse structured results reliably. (#13)
- Resume stopped schedules safely after interactive scheduled agents are archived, while preserving protection for user-touched sessions. (#14)
- Keep schedule rows visible in the Remote UI as schedule and daemon state changes.
- Add copyable Remote UI details for operator-facing metadata. (#16)
- Add a Remote UI agent sort dropdown for faster agent list triage. (#17)
- Clarify scheduled-agent titles so recurring run history is easier to scan. (#18)
- Add Remote UI project editing with JSON API support. (#19)
- Simplify schedule status handling to `scheduled`, `paused`, and `stopped`, with last outcome and error diagnostics tracked separately. (#21)

## Validation

- `bin/test`
- `bundle exec ruby -c bin/tycho`

## Follow-up after merge

- Tag and publish `v0.4.0` from `main`.
- Update `firewalker06/homebrew-tycho` with the `v0.4.0` tarball URL and SHA after the GitHub release exists.
