### PR TITLE
Add Remote UI more action menus

### DIFF
--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -10,6 +10,7 @@ require_relative "harness_registry"
 require_relative "registry"
 require_relative "remote_ui"
 require_relative "terminal_qr"
+require_relative "version"
 require_relative "domain/app_project"
 require_relative "domain/attachment_normalizer"
 require_relative "domain/agent_attachment_store"
@@ -702,6 +703,10 @@ module HQ
         },
         server: {
           restartable: @restartable
+        },
+        build: {
+          version: HQ::VERSION,
+          asset_version: HQ::RemoteUI.asset_version
         },
         counts: {
           projects: visible_projects.length,

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -358,6 +358,37 @@ h3 {
   line-height: 1;
 }
 
+#header-more-button {
+  position: relative;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+#header-more-button:hover,
+#header-more-button:focus-visible,
+#header-more-button[aria-expanded="true"] {
+  background: var(--panel-soft);
+}
+
+.header-more-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: inline-grid;
+  min-width: 16px;
+  height: 16px;
+  place-items: center;
+  padding: 0 4px;
+  border: 1px solid var(--bg);
+  border-radius: 999px;
+  background: var(--pink);
+  color: var(--bg);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 14px;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -380,6 +411,102 @@ h3 {
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 0 12px 12px;
+}
+
+.header-more-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 12px;
+  z-index: 12;
+  width: max-content;
+  min-width: 180px;
+  max-width: min(64vw, 240px);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 98%, transparent);
+  box-shadow: var(--shadow);
+  padding: 6px;
+}
+
+.more-menu {
+  display: grid;
+  gap: 2px;
+}
+
+.more-menu-separator {
+  display: block;
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--border);
+}
+
+.more-menu-item {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  column-gap: 10px;
+  row-gap: 2px;
+  min-height: 50px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.more-menu-item.single-line {
+  grid-template-columns: 24px minmax(0, 1fr);
+  min-height: 42px;
+  row-gap: 0;
+  padding-block: 7px;
+}
+
+.more-menu-item .ui-icon {
+  grid-row: 1 / span 2;
+  align-self: center;
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+}
+
+.more-menu-item.single-line .ui-icon {
+  grid-row: 1;
+  width: 18px;
+  height: 18px;
+}
+
+.more-menu-item strong,
+.more-menu-item span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.more-menu-item strong {
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.more-menu-item span {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.more-menu-item:hover,
+.more-menu-item:focus-visible {
+  background: var(--panel-soft);
+}
+
+.more-menu-item.danger {
+  color: var(--danger);
+}
+
+.more-menu-item.danger .ui-icon {
+  color: currentColor;
 }
 
 .unread-agents-panel {
@@ -471,12 +598,6 @@ h3 {
 .agent-settings-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.agent-settings-actions {
-  display: flex;
-  flex-wrap: wrap;
   gap: 8px;
 }
 
@@ -1438,15 +1559,8 @@ select {
   overflow: hidden;
 }
 
-.server-lifecycle-card {
-  border-color: color-mix(in srgb, var(--danger) 36%, var(--border));
-  background: color-mix(in srgb, var(--danger) 7%, var(--panel));
-}
-
-button.restart-server-button {
-  border-color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 20%, var(--panel));
-  color: color-mix(in srgb, var(--danger) 78%, var(--text));
+#settings-push-notifications {
+  scroll-margin-top: calc(var(--safe-area-top) + 76px);
 }
 
 .detail-card > summary {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -110,6 +110,12 @@ const ICONS = {
       <line x1="12" x2="12.01" y1="17" y2="17"></line>
     </svg>
   `,
+  bell: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M10.268 21a2 2 0 0 0 3.464 0"></path>
+      <path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8a6 6 0 0 0-12 0c0 4.499-1.411 5.956-2.738 7.326"></path>
+    </svg>
+  `,
   calendarCheck2: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="M8 2v4"></path>
@@ -276,6 +282,13 @@ const ICONS = {
       <path d="M2 8v11a2 2 0 0 0 2 2h14"></path>
     </svg>
   `,
+  ellipsis: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="1"></circle>
+      <circle cx="19" cy="12" r="1"></circle>
+      <circle cx="5" cy="12" r="1"></circle>
+    </svg>
+  `,
   hammer: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="m15 12-9.373 9.373a1 1 0 0 1-3.001-3L12 9"></path>
@@ -413,6 +426,11 @@ const state = {
   renderedRouteKey: null,
   renderedViewHtml: "",
   agentSettingsOpen: false,
+  headerMoreOpen: false,
+  headerMoreBadge: "",
+  headerMoreContent: "",
+  headerMoreKey: "none",
+  headerMoreLabel: "More actions",
   unreadPanelOpen: false,
   readMarkTimer: null,
   lastAppBadgeCount: null,
@@ -430,9 +448,9 @@ const els = {
   subtitle: document.getElementById("screen-subtitle"),
   mark: document.getElementById("header-mark"),
   back: document.getElementById("back-button"),
-  projectEdit: document.getElementById("project-edit-button"),
-  agentProject: document.getElementById("agent-project-button"),
-  agentSettings: document.getElementById("agent-settings-button"),
+  headerMore: document.getElementById("header-more-button"),
+  headerMoreBadge: document.getElementById("header-more-badge"),
+  headerMorePanel: document.getElementById("header-more-panel"),
   agentSettingsPanel: document.getElementById("agent-settings-panel"),
   unreadPanel: document.getElementById("unread-agents-panel"),
   authPanel: document.getElementById("auth-panel"),
@@ -559,8 +577,7 @@ async function readJson(response) {
 }
 
 function parseRoute() {
-  const hash = location.hash.replace(/^#/, "");
-  const parts = hash.split("/").filter(Boolean).map(decodeURIComponent);
+  const { parts, params } = parsedHashRoute();
   if (parts[0] === "agent" && parts[1] && parts[2] === "edit") {
     return { type: "agentForm", mode: "edit", key: parts[1] };
   }
@@ -587,12 +604,33 @@ function parseRoute() {
   if (parts[0] === "project" && parts[1] && parts[2] === "action" && parts[3]) {
     return { type: "guard", key: parts[1], action: parts[3] };
   }
-  if (parts[0] === "project" && parts[1]) return { type: "project", key: parts[1] };
+  if (parts[0] === "project" && parts[1]) {
+    const route = { type: "project", key: parts[1] };
+    const backTo = parseBackToRoute(params.get("back_to") || params.get("return_to"));
+    if (backTo) route.backTo = backTo;
+    return route;
+  }
   if ((parts[0] === "settings" || parts[0] === "setup") && parts[1] === "hidden") return { type: "hiddenSettings" };
   if (parts[0] === "setup") return { type: "tab", tab: "settings" };
   if (parts[0] === "search" || parts[0] === "projects") return { type: "tab", tab: "agents" };
   if (TOP_TABS.includes(parts[0])) return { type: "tab", tab: parts[0] };
   return { type: "tab", tab: "now" };
+}
+
+function parsedHashRoute() {
+  const hash = location.hash.replace(/^#/, "");
+  const [path, query = ""] = hash.split("?", 2);
+  return {
+    parts: path.split("/").filter(Boolean).map(decodeURIComponent),
+    params: new URLSearchParams(query),
+  };
+}
+
+function parseBackToRoute(value) {
+  const text = String(value || "").replace(/^#/, "");
+  const parts = text.split("/").filter(Boolean).map(decodeURIComponent);
+  if (parts[0] === "agent" && parts[1]) return { type: "agent", key: parts[1] };
+  return null;
 }
 
 function routeHash(route) {
@@ -613,12 +651,24 @@ function routeHash(route) {
   }
   if (route.type === "attachment") return `#attachment/${encodeURIComponent(route.id)}`;
   if (route.type === "projectForm") return `#project/${encodeURIComponent(route.key)}/edit`;
-  if (route.type === "project") return `#project/${encodeURIComponent(route.key)}`;
+  if (route.type === "project") {
+    return `#project/${encodeURIComponent(route.key)}${routeBackQuery(route)}`;
+  }
   if (route.type === "guard") {
     return `#project/${encodeURIComponent(route.key)}/action/${encodeURIComponent(route.action)}`;
   }
   if (route.type === "hiddenSettings") return "#settings/hidden";
   return `#${route.tab}`;
+}
+
+function routeBackQuery(route) {
+  const value = backRouteValue(route.backTo);
+  return value ? `?back_to=${encodeURIComponent(value)}` : "";
+}
+
+function backRouteValue(route) {
+  if (route?.type === "agent" && route.key) return `agent/${route.key}`;
+  return "";
 }
 
 function navigate(route) {
@@ -905,7 +955,7 @@ function render() {
   els.header.classList.toggle("detail-header", subpage && !onboarding);
   els.header.classList.remove("header-hidden");
   if (!agentShellRoute(route)) setAgentSettings(null);
-  setProjectEditButton(route.type === "project" ? findProject(route.key) : null);
+  syncHeaderMoreRoute(route);
   syncDetailHeaderLayout();
   if (onboarding) {
     setNavHidden(false);
@@ -1486,7 +1536,11 @@ function renderAgents(options = {}) {
   const groups = groupMode ? agentProjectGroups(query) : [];
   const flatAgents = groupMode ? [] : sortedAgentList(query);
   const unread = state.agents.filter((agent) => agent.unread).length;
+  const selectedCount = selectedBulkArchiveKeys().length;
+  const moreLabel = selectedCount ? `Agent list actions, ${selectedCount} selected` : "Agent list actions";
+  const moreBadge = selectedCount ? compactCount(selectedCount) : "";
   setHeader("Agents", `${state.agents.length} managed / ${state.projects.length} projects / ${unread} unread`, "A");
+  setHeaderMore(agentsMoreMenuHtml(), moreLabel, "agents", moreBadge);
 
   replaceView(`
     <div class="top-actions">
@@ -1495,7 +1549,6 @@ function renderAgents(options = {}) {
         <input id="agent-filter" type="search" value="${escapeAttr(state.filters.agents)}" placeholder="Filter agents and projects" aria-label="Filter agents and projects" data-filter="agents">
       </label>
       ${agentSortMenuHtml()}
-      <button class="inline-icon-button" type="button" data-toggle-bulk-archive ${state.agents.length ? "" : "disabled"}>${iconSvg(state.bulkArchiveMode ? "x" : "archive")}<span>${state.bulkArchiveMode ? "Cancel" : "Select"}</span></button>
     </div>
     ${renderBulkArchiveBar()}
     ${groupMode
@@ -1529,6 +1582,67 @@ function agentSortMenuHtml() {
   `;
 }
 
+function agentsMoreMenuHtml() {
+  if (!state.agents.length) return "";
+
+  const selected = selectedBulkArchiveKeys();
+  const toggleLabel = state.bulkArchiveMode ? "Cancel selection" : "Select agents";
+  const toggleIcon = state.bulkArchiveMode ? "x" : "archive";
+  const selectedLabel = selected.length === 1 ? "1 selected" : `${selected.length} selected`;
+
+  return moreMenuHtml([
+    moreMenuButton({
+      label: toggleLabel,
+      icon: toggleIcon,
+      attrs: "data-toggle-bulk-archive",
+    }),
+    state.bulkArchiveMode
+      ? moreMenuButton({
+          label: "Archive selected",
+          sublabel: selectedLabel,
+          icon: "archive",
+          attrs: "data-run-bulk-archive",
+          danger: true,
+          disabled: selected.length === 0,
+        })
+      : "",
+  ]);
+}
+
+function settingsMoreMenuHtml(setup) {
+  const restartable = !!setup?.server?.restartable;
+  const hiddenCount = setup?.counts?.hidden_projects || 0;
+  return moreMenuHtml([
+    moreMenuButton({
+      label: "Push notifications",
+      sublabel: "Jump to browser alerts",
+      icon: "bell",
+      attrs: 'data-scroll-settings-section="settings-push-notifications"',
+    }),
+    moreMenuButton({
+      label: "Hidden projects",
+      sublabel: `${hiddenCount} hidden`,
+      icon: "eyeOff",
+      attrs: "data-open-hidden-settings",
+    }),
+    moreMenuButton({
+      label: "Recheck status",
+      sublabel: "Refresh readiness",
+      icon: "rotateCcw",
+      attrs: "data-refresh",
+    }),
+    moreMenuSeparator(),
+    moreMenuButton({
+      label: "Restart server",
+      sublabel: restartable ? "Reload Remote UI" : "Unavailable",
+      icon: "loaderPinwheel",
+      attrs: "data-restart-server",
+      danger: true,
+      disabled: !restartable,
+    }),
+  ]);
+}
+
 function renderFlatAgentList(agents, query) {
   if (!agents.length) return renderAgentsEmpty(query);
 
@@ -1551,7 +1665,6 @@ function renderBulkArchiveBar() {
       </div>
       <div class="button-row">
         <button type="button" data-clear-bulk-archive ${selected.length ? "" : "disabled"}>Clear</button>
-        <button class="danger inline-icon-button" type="button" data-run-bulk-archive ${selected.length ? "" : "disabled"}>${iconSvg("archive")}<span>Archive selected</span></button>
       </div>
     </section>
   `;
@@ -1612,10 +1725,12 @@ function renderSetup() {
   const setup = state.setup;
   setHeader("Settings", connectionText(), "S");
   if (!setup) {
+    setHeaderMore(null, "Settings actions", "settings");
     replaceView(emptyState("Settings unavailable", "Refresh to load Remote UI readiness."));
     return;
   }
 
+  setHeaderMore(settingsMoreMenuHtml(setup), "Settings actions", "settings");
   const displayUrl = setup.public_ui_url || setup.ui_url || location.href;
   replaceView(`
     <section class="summary-card">
@@ -1631,7 +1746,6 @@ function renderSetup() {
       </div>
       <div class="button-row">
         <button type="button" data-copy="${escapeAttr(displayUrl || "")}">Copy URL</button>
-        <button class="primary" type="button" data-refresh>Recheck</button>
       </div>
     </section>
     ${renderPushSetup(setup)}
@@ -1645,6 +1759,12 @@ function renderSetup() {
             <span class="pill ${item.ready ? "done" : "fail"}">${item.ready ? "Ready" : "Missing"}</span>
           </div>
         `).join("")}
+        <div class="section-label"><strong>Server lifecycle</strong><span>${setup.server?.restartable ? "restartable" : "unavailable"}</span></div>
+        <div class="detail-row">
+          <span class="status-mark ${setup.server?.restartable ? "done" : "fail"}" aria-hidden="true">${statusIcon(setup.server?.restartable)}</span>
+          <div><strong>Remote restart</strong><span>${setup.server?.restartable ? "Restart is available from the Settings menu." : "Start Tycho Remote with a restart command to enable restart."}</span></div>
+          <span class="pill ${setup.server?.restartable ? "done" : "fail"}">${setup.server?.restartable ? "Ready" : "Off"}</span>
+        </div>
         <div class="section-label"><strong>Optional tools</strong><span>${setup.tools?.length || 0} tools</span></div>
         ${(setup.tools || []).map((item) => `
           <div class="detail-row">
@@ -1669,10 +1789,7 @@ function renderSetup() {
           ${copyableKv("Archived", `${setup.counts?.archived_projects || 0} archived`)}
           ${copyableKv("Config", setup.config?.loaded ? "hq.yml loaded" : "not loaded")}
           ${copyableKv("Prompts", `${setup.config?.prompt_template_count || 0} templates`)}
-        </div>
-        <div class="button-row">
-          <button type="button" data-open-hidden-settings>Hidden projects</button>
-          <button type="button" disabled>Open TUI setup</button>
+          ${copyableKv("Tycho build", tychoBuildLabel(setup))}
         </div>
       </div>
     </section>
@@ -1698,15 +1815,14 @@ function renderSetup() {
         ${copyableKv("Auth", setup.auth?.status)}
       </div>
     </details>
-    <section class="detail-card server-lifecycle-card">
-      <div class="detail-card-body" style="padding-top: 12px;">
-        <div class="section-label"><strong>Server lifecycle</strong><span>${setup.server?.restartable ? "restartable" : "unavailable"}</span></div>
-        <div class="button-row">
-          <button class="danger inline-icon-button restart-server-button" type="button" data-restart-server ${setup.server?.restartable ? "" : "disabled"}>${iconSvg("loaderPinwheel")}<span>Restart Remote</span></button>
-        </div>
-      </div>
-    </section>
   `);
+}
+
+function tychoBuildLabel(setup) {
+  const version = String(setup?.build?.version || "").trim();
+  const assetVersion = String(setup?.build?.asset_version || document.documentElement.dataset.assetVersion || "").trim();
+  if (version && assetVersion) return `${version} / UI ${assetVersion}`;
+  return version || assetVersion || "unknown";
 }
 
 function renderHiddenSettings() {
@@ -1818,7 +1934,7 @@ function renderPushSetup(setup) {
     : denied ? "Notification permission is blocked in this browser" : configured ? `${enabledCount} subscription${enabledCount === 1 ? "" : "s"}` : "VAPID keys are unavailable";
 
   return `
-    <section class="detail-card">
+    <section class="detail-card" id="settings-push-notifications">
       <div class="detail-card-body" style="padding-top: 12px;">
         <div class="section-label"><strong>Push notifications</strong><span>browser alerts</span></div>
         <div class="detail-row">
@@ -1864,6 +1980,7 @@ function renderAgent(key, options = {}) {
       : renderAgentConversationView(agent, blocks);
   setHeader(agent.name || agent.key, agentHeaderLabel(agent), "A");
   setAgentSettings(agent);
+  setHeaderMore(agentMoreMenuHtml(agent), "Conversation actions", agentHeaderMoreKey(agent.key));
   replaceView(`
     ${body}
     <section class="agent-dock" data-agent-dock>
@@ -2373,6 +2490,7 @@ function renderProject(key) {
   }
 
   setHeader(project.name || project.key, `${project.group || "ungrouped"} / key ${project.key}`, "folder");
+  setHeaderMore(projectMoreMenuHtml(project), "Project actions", projectHeaderMoreKey(project.key));
   const agents = agentsForProject(project.key);
   replaceView(`
     <div class="chip-row">
@@ -2395,6 +2513,10 @@ function renderProject(key) {
         <span class="status-mark detail" aria-hidden="true">${iconSvg("gitCommit")}</span>
         <div class="row-title"><strong>Revision</strong><span>${escapeHtml([project.commit_hash, project.branch].filter(Boolean).join(" on ") || "not available")}</span></div>
         <button type="button" data-copy="${escapeAttr(project.commit_hash || "")}" ${project.commit_hash ? "" : "disabled"}>Copy</button>
+      </div>
+      <div class="agent-row project-overview-row">
+        <span class="status-mark ${project.dirty ? "need" : "done"}" aria-hidden="true">${iconSvg("code")}</span>
+        <div class="row-title"><strong>Changes</strong><span>${escapeHtml(project.dirty ? `${project.dirty_files} dirty files in this workspace` : "No tracked or untracked changes reported")}</span></div>
       </div>
     </section>
     ${renderProjectAgents(project, agents)}
@@ -3870,6 +3992,32 @@ function projectMatches(project, query) {
   ].some((value) => String(value || "").toLowerCase().includes(query));
 }
 
+function moreMenuHtml(items) {
+  const content = items.filter(Boolean).join("");
+  if (!content) return "";
+  return `<div class="more-menu" role="menu">${content}</div>`;
+}
+
+function moreMenuSeparator() {
+  return `<span class="more-menu-separator" role="separator" aria-hidden="true"></span>`;
+}
+
+function moreMenuButton({ label, sublabel = "", icon = "ellipsis", attrs = "", danger = false, disabled = false }) {
+  const className = [
+    "more-menu-item",
+    sublabel ? "" : "single-line",
+    danger ? "danger" : "",
+  ].filter(Boolean).join(" ");
+  const sublabelHtml = sublabel ? `<span>${escapeHtml(sublabel)}</span>` : "";
+  return `
+    <button class="${className}" type="button" role="menuitem" ${attrs} ${disabled ? "disabled" : ""}>
+      ${iconSvg(icon)}
+      <strong>${escapeHtml(label)}</strong>
+      ${sublabelHtml}
+    </button>
+  `;
+}
+
 function setHeader(title, subtitle, subtitleIcon = "folder") {
   els.title.textContent = title;
   setHeaderSubtitleIcon(subtitleIcon);
@@ -3959,6 +4107,7 @@ function toggleUnreadPanel() {
   state.unreadPanelOpen = !state.unreadPanelOpen;
   if (state.unreadPanelOpen) {
     state.agentSettingsOpen = false;
+    closeHeaderMore();
     const route = parseRoute();
     const currentAgent = agentShellRoute(route) ? findAgent(route.key) : null;
     setAgentSettings(currentAgent);
@@ -3970,6 +4119,78 @@ function closeUnreadPanel() {
   if (!state.unreadPanelOpen) return;
   state.unreadPanelOpen = false;
   syncUnreadAlert();
+}
+
+function syncHeaderMoreRoute(route) {
+  const key = headerMoreKeyForRoute(route);
+  if (state.headerMoreKey !== key) setHeaderMore(null, "More actions", key);
+}
+
+function headerMoreKeyForRoute(route) {
+  if (route.type === "tab" && route.tab === "agents") return "agents";
+  if (route.type === "tab" && route.tab === "settings") return "settings";
+  if (agentShellRoute(route)) return agentHeaderMoreKey(route.key);
+  if (route.type === "project") return projectHeaderMoreKey(route.key);
+  return "none";
+}
+
+function agentHeaderMoreKey(key) {
+  return `agent:${key}`;
+}
+
+function projectHeaderMoreKey(key) {
+  return `project:${key}`;
+}
+
+function setHeaderMore(content, label = "More actions", key = state.headerMoreKey, badge = "") {
+  if (state.headerMoreKey !== key) state.headerMoreOpen = false;
+  state.headerMoreContent = String(content || "").trim();
+  state.headerMoreBadge = String(badge || "").trim();
+  state.headerMoreKey = key || "none";
+  state.headerMoreLabel = label || "More actions";
+  if (!state.headerMoreContent) state.headerMoreOpen = false;
+  renderHeaderMore();
+  syncDetailHeaderLayout();
+}
+
+function renderHeaderMore() {
+  const hasMenu = Boolean(state.headerMoreContent);
+  els.headerMore.classList.toggle("hidden", !hasMenu);
+  els.headerMore.setAttribute("aria-label", state.headerMoreLabel);
+  els.headerMore.setAttribute("title", state.headerMoreLabel);
+  els.headerMore.setAttribute("aria-expanded", hasMenu && state.headerMoreOpen ? "true" : "false");
+  els.headerMoreBadge.textContent = state.headerMoreBadge;
+  els.headerMoreBadge.classList.toggle("hidden", !state.headerMoreBadge);
+  els.headerMorePanel.setAttribute("aria-label", state.headerMoreLabel);
+
+  if (!hasMenu || !state.headerMoreOpen) {
+    els.headerMorePanel.classList.add("hidden");
+    els.headerMorePanel.innerHTML = "";
+    return;
+  }
+
+  els.headerMorePanel.innerHTML = state.headerMoreContent;
+  els.headerMorePanel.classList.remove("hidden");
+}
+
+function toggleHeaderMore() {
+  if (!state.headerMoreContent) return;
+  state.headerMoreOpen = !state.headerMoreOpen;
+  if (state.headerMoreOpen) closeUnreadPanel();
+  renderHeaderMore();
+}
+
+function closeHeaderMore() {
+  if (!state.headerMoreOpen) return;
+  state.headerMoreOpen = false;
+  renderHeaderMore();
+}
+
+function scrollSettingsSection(id) {
+  const section = document.getElementById(id);
+  if (!section) return;
+
+  section.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 function eventPathIncludes(event, element) {
@@ -4039,53 +4260,15 @@ function notificationPermissionLabel() {
 function setAgentSettings(agent) {
   if (!agent) {
     state.agentSettingsOpen = false;
-    setAgentProjectButton(null);
-    els.agentSettings.classList.add("hidden");
-    els.agentSettings.setAttribute("aria-expanded", "false");
     els.agentSettingsPanel.classList.add("hidden");
     els.agentSettingsPanel.innerHTML = "";
     syncDetailHeaderLayout();
     return;
   }
 
-  setAgentProjectButton(agent);
-  els.agentSettings.classList.remove("hidden");
-  els.agentSettings.setAttribute("aria-expanded", state.agentSettingsOpen ? "true" : "false");
   els.agentSettingsPanel.innerHTML = agentSettingsHtml(agent);
   els.agentSettingsPanel.classList.toggle("hidden", !state.agentSettingsOpen);
   syncDetailHeaderLayout();
-}
-
-function setAgentProjectButton(agent) {
-  if (!agent?.project_key) {
-    els.agentProject.classList.add("hidden");
-    delete els.agentProject.dataset.openProject;
-    els.agentProject.setAttribute("aria-label", "Open project");
-    els.agentProject.setAttribute("title", "Open project");
-    return;
-  }
-
-  const label = `Open project ${agentProjectLabel(agent)}`;
-  els.agentProject.classList.remove("hidden");
-  els.agentProject.dataset.openProject = agent.project_key;
-  els.agentProject.setAttribute("aria-label", label);
-  els.agentProject.setAttribute("title", label);
-}
-
-function setProjectEditButton(project) {
-  if (!project?.key) {
-    els.projectEdit.classList.add("hidden");
-    delete els.projectEdit.dataset.editProject;
-    els.projectEdit.setAttribute("aria-label", "Edit project");
-    els.projectEdit.setAttribute("title", "Edit project");
-    return;
-  }
-
-  const label = `Edit project ${project.name || project.key}`;
-  els.projectEdit.classList.remove("hidden");
-  els.projectEdit.dataset.editProject = project.key;
-  els.projectEdit.setAttribute("aria-label", label);
-  els.projectEdit.setAttribute("title", label);
 }
 
 function toggleAgentSettings() {
@@ -4096,10 +4279,60 @@ function toggleAgentSettings() {
   state.agentSettingsOpen = !state.agentSettingsOpen;
   if (state.agentSettingsOpen) closeUnreadPanel();
   setAgentSettings(agent);
+  setHeaderMore(agentMoreMenuHtml(agent), "Conversation actions", agentHeaderMoreKey(agent.key));
+}
+
+function agentMoreMenuHtml(agent) {
+  const running = agentIsRunning(agent);
+  const lifecycleSublabel = running ? "Stop agent first" : agent.name || agent.key;
+  return moreMenuHtml([
+    agent.project_key
+      ? moreMenuButton({
+          label: "Open project",
+          sublabel: agentProjectLabel(agent),
+          icon: "folder",
+          attrs: `data-open-project="${escapeAttr(agent.project_key)}"`,
+        })
+      : "",
+    moreMenuButton({
+      label: state.agentSettingsOpen ? "Hide conversation settings" : "Conversation settings",
+      sublabel: running ? "Agent is running" : agentTemplateLabel(agent),
+      icon: "settings",
+      attrs: "data-toggle-agent-settings",
+    }),
+    moreMenuSeparator(),
+    moreMenuButton({
+      label: "Edit agent",
+      sublabel: lifecycleSublabel,
+      icon: "pencil",
+      attrs: `data-edit-agent="${escapeAttr(agent.key)}"`,
+      disabled: running,
+    }),
+    moreMenuSeparator(),
+    moreMenuButton({
+      label: "Archive agent",
+      sublabel: lifecycleSublabel,
+      icon: "archive",
+      attrs: `data-archive-agent="${escapeAttr(agent.key)}"`,
+      danger: true,
+      disabled: running,
+    }),
+  ]);
+}
+
+function projectMoreMenuHtml(project) {
+  if (!project?.key) return "";
+  return moreMenuHtml([
+    moreMenuButton({
+      label: "Edit project",
+      sublabel: project.name || project.key,
+      icon: "pencil",
+      attrs: `data-edit-project="${escapeAttr(project.key)}"`,
+    }),
+  ]);
 }
 
 function agentSettingsHtml(agent) {
-  const disabled = agentIsRunning(agent) ? "disabled" : "";
   return `
     <div class="agent-settings-grid">
       ${copyableKv("Project", agentProjectLabel(agent))}
@@ -4116,11 +4349,6 @@ function agentSettingsHtml(agent) {
       ${copyableKv("Sandbox", agent.sandbox_mode)}
       ${copyableKv("Raw log", agent.log_path)}
     </div>
-    <div class="agent-settings-actions">
-      <button class="inline-icon-button" type="button" data-edit-agent="${escapeAttr(agent.key)}" ${disabled}>${iconSvg("pencil")}<span>Edit agent</span></button>
-      <button class="danger inline-icon-button" type="button" data-archive-agent="${escapeAttr(agent.key)}" ${disabled}>${iconSvg("archive")}<span>Archive agent</span></button>
-    </div>
-    ${agentIsRunning(agent) ? `<p class="field-hint">Stop the agent before editing or archiving it.</p>` : ""}
   `;
 }
 
@@ -5095,22 +5323,13 @@ els.back.addEventListener("click", () => {
   else if (route.type === "agentForm" && route.mode === "create") navigate({ type: "project", key: route.projectKey });
   else if (route.type === "agentArchive") navigate({ type: "agent", key: route.key });
   else if (route.type === "projectForm") navigate({ type: "project", key: route.key });
+  else if (route.type === "project" && route.backTo) navigate(route.backTo);
   else if (route.type === "project" || route.type === "guard") navigate({ type: "tab", tab: "agents" });
   else if (route.type === "hiddenSettings") navigate({ type: "tab", tab: "settings" });
   else navigate({ type: "tab", tab: "now" });
 });
 
-els.projectEdit.addEventListener("click", () => {
-  const projectKey = els.projectEdit.dataset.editProject;
-  if (projectKey) navigate({ type: "projectForm", key: projectKey });
-});
-
-els.agentProject.addEventListener("click", () => {
-  const projectKey = els.agentProject.dataset.openProject;
-  if (projectKey) navigate({ type: "project", key: projectKey });
-});
-
-els.agentSettings.addEventListener("click", toggleAgentSettings);
+els.headerMore.addEventListener("click", toggleHeaderMore);
 
 els.mark.addEventListener("click", toggleUnreadPanel);
 
@@ -5144,6 +5363,82 @@ els.agentSettingsPanel.addEventListener("click", (event) => {
 
   const agentAction = event.target.closest("[data-agent-action]");
   if (agentAction) runAgentAction(agentAction);
+});
+
+els.headerMorePanel.addEventListener("click", (event) => {
+  const toggleBulk = event.target.closest("[data-toggle-bulk-archive]");
+  if (toggleBulk) {
+    closeHeaderMore();
+    toggleBulkArchiveMode();
+    return;
+  }
+
+  const runBulk = event.target.closest("[data-run-bulk-archive]");
+  if (runBulk) {
+    closeHeaderMore();
+    archiveSelectedAgents();
+    return;
+  }
+
+  const projectButton = event.target.closest("[data-open-project]");
+  if (projectButton) {
+    closeHeaderMore();
+    const route = parseRoute();
+    const backTo = agentShellRoute(route) ? { type: "agent", key: route.key } : null;
+    navigate({ type: "project", key: projectButton.dataset.openProject, backTo });
+    return;
+  }
+
+  const editAgentButton = event.target.closest("[data-edit-agent]");
+  if (editAgentButton) {
+    closeHeaderMore();
+    navigate({ type: "agentForm", mode: "edit", key: editAgentButton.dataset.editAgent });
+    return;
+  }
+
+  const editProjectButton = event.target.closest("[data-edit-project]");
+  if (editProjectButton) {
+    closeHeaderMore();
+    navigate({ type: "projectForm", key: editProjectButton.dataset.editProject });
+    return;
+  }
+
+  const archiveAgentButton = event.target.closest("[data-archive-agent]");
+  if (archiveAgentButton) {
+    closeHeaderMore();
+    navigate({ type: "agentArchive", key: archiveAgentButton.dataset.archiveAgent });
+    return;
+  }
+
+  if (event.target.closest("[data-toggle-agent-settings]")) {
+    closeHeaderMore();
+    toggleAgentSettings();
+    return;
+  }
+
+  const settingsSectionButton = event.target.closest("[data-scroll-settings-section]");
+  if (settingsSectionButton) {
+    closeHeaderMore();
+    scrollSettingsSection(settingsSectionButton.dataset.scrollSettingsSection);
+    return;
+  }
+
+  if (event.target.closest("[data-open-hidden-settings]")) {
+    closeHeaderMore();
+    navigate({ type: "hiddenSettings" });
+    return;
+  }
+
+  if (event.target.closest("[data-refresh]")) {
+    closeHeaderMore();
+    refresh({ force: true });
+    return;
+  }
+
+  if (event.target.closest("[data-restart-server]")) {
+    closeHeaderMore();
+    restartRemoteServer();
+  }
 });
 
 function saveRemoteToken() {
@@ -5398,6 +5693,11 @@ document.addEventListener("click", (event) => {
 document.addEventListener("click", (event) => {
   if (eventPathIncludes(event, els.mark) || eventPathIncludes(event, els.unreadPanel)) return;
   closeUnreadPanel();
+});
+
+document.addEventListener("click", (event) => {
+  if (eventPathIncludes(event, els.headerMore) || eventPathIncludes(event, els.headerMorePanel)) return;
+  closeHeaderMore();
 });
 
 document.addEventListener("click", (event) => {

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -43,25 +43,14 @@
             </div>
           </div>
           <div class="header-actions">
-            <button id="project-edit-button" class="icon-button hidden" type="button" aria-label="Edit project" title="Edit project">
+            <button id="header-more-button" class="icon-button hidden" type="button" aria-label="More actions" title="More actions" aria-expanded="false" aria-controls="header-more-panel">
               <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
-                <path d="M12 20h9"></path>
-                <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
+                <circle cx="12" cy="12" r="1"></circle>
+                <circle cx="19" cy="12" r="1"></circle>
+                <circle cx="5" cy="12" r="1"></circle>
               </svg>
-              <span class="sr-only">Edit project</span>
-            </button>
-            <button id="agent-project-button" class="icon-button hidden" type="button" aria-label="Open project" title="Open project">
-              <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
-                <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9l-.81-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path>
-              </svg>
-              <span class="sr-only">Open project</span>
-            </button>
-            <button id="agent-settings-button" class="icon-button hidden" type="button" aria-label="Agent settings" title="Agent settings" aria-expanded="false">
-              <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
-                <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
-                <circle cx="12" cy="12" r="3"></circle>
-              </svg>
-              <span class="sr-only">Agent settings</span>
+              <span id="header-more-badge" class="header-more-badge hidden" aria-hidden="true"></span>
+              <span class="sr-only">More actions</span>
             </button>
           </div>
         </div>
@@ -74,7 +63,8 @@
           </div>
         </form>
         <section id="unread-agents-panel" class="unread-agents-panel hidden" aria-label="Unread agents"></section>
-        <section id="agent-settings-panel" class="agent-settings-panel hidden" aria-label="Agent settings"></section>
+        <section id="header-more-panel" class="header-more-panel hidden" aria-label="More actions"></section>
+        <section id="agent-settings-panel" class="agent-settings-panel hidden" aria-label="Conversation settings"></section>
       </header>
 
       <section id="growl" class="growl hidden" role="status" aria-live="polite" aria-atomic="true"></section>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1057,6 +1057,8 @@ module RemoteServerTest
       assert(setup.dig(:auth, :required), "expected auth state")
       assert(setup.dig(:auth, :status) == "token required", "expected required auth status")
       assert(setup.dig(:server, :restartable), "expected setup payload to expose Remote restart readiness")
+      assert(setup.dig(:build, :version) == HQ::VERSION, "expected setup payload to expose Tycho version")
+      assert(setup.dig(:build, :asset_version).to_s.length == 12, "expected setup payload to expose Remote UI build")
       assert(setup.dig(:counts, :projects) == 1, "expected active project count")
       assert(setup.dig(:counts, :archived_projects) == 1, "expected archived project count")
       assert(setup[:harnesses].map { |item| item[:name] }.sort == %w[claude claude-wrapper codex],
@@ -1406,10 +1408,10 @@ module RemoteServerTest
            "expected root CSS reference to be asset-versioned")
     assert(response[:body].match?(%r{src="/ui\.js\?v=[0-9a-f]{12}"}),
            "expected root JavaScript reference to be asset-versioned")
-    assert(response[:body].include?("project-edit-button"), "expected root shell to expose Project edit")
-    assert(response[:body].include?('<span class="sr-only">Edit project</span>'),
-           "expected Project edit header control to be icon-only with accessible text")
-    assert(response[:body].include?("agent-settings-button"), "expected root shell to expose Agent settings")
+    assert(!response[:body].include?("project-edit-button"), "expected Project edit to live in the shared More menu")
+    assert(response[:body].include?("header-more-button"), "expected root shell to expose header More actions")
+    assert(response[:body].include?('id="header-more-panel"'), "expected root shell to expose the header More menu panel")
+    assert(response[:body].include?('id="header-more-badge"'), "expected root shell to expose the header More badge")
     assert(response[:body].include?('data-tab="settings"'), "expected root shell to expose Settings navigation")
     assert(response[:body].include?("<span>Settings</span>"), "expected root shell to label setup navigation as Settings")
     assert(!response[:body].include?('data-tab="search"'), "expected root shell to remove Search navigation")
@@ -1466,12 +1468,22 @@ module RemoteServerTest
            "expected Agent detail shortcuts to float above the dock")
     assert(css[:body].include?(".go-recent-fab"), "expected Agent detail to include Go to recent")
     assert(css[:body].include?(".agent-settings-panel"), "expected Agent settings to render in the header")
+    assert(css[:body].include?(".header-more-panel"), "expected header More menus to render as dropdown panels")
+    assert(css[:body].include?(".more-menu-item"), "expected header More menus to style compact menu rows")
+    assert(css[:body].include?(".more-menu-item.single-line"),
+           "expected single-action More menus to use compact rows")
+    assert(css[:body].include?(".more-menu-separator"),
+           "expected Conversation More menu groups to support separators")
+    assert(css[:body].include?(".header-more-badge"),
+           "expected Agents bulk selection count to render on the More button")
+    assert(css[:body].include?("#header-more-button") && css[:body].include?("border: 0;"),
+           "expected the header More button to be borderless")
     assert(css[:body].include?(".growl"), "expected Remote UI to style growl notifications")
     assert(css[:body].include?(".agent-sort-menu"), "expected Remote UI to style agent sort dropdowns")
     assert(css[:body].include?(".agent-sort-trigger"), "expected Remote UI to style icon-only sort triggers")
     assert(css[:body].include?(".agent-sort-option"), "expected Remote UI to style text sort options")
-    assert(css[:body].include?(".agent-settings-actions"),
-           "expected Agent settings to hide edit/archive actions behind the settings panel")
+    assert(!css[:body].include?(".agent-settings-actions"),
+           "expected Agent settings to move edit/archive actions into the More menu")
     assert(css[:body].include?(".agent-form"), "expected Remote UI to style agent lifecycle forms")
     assert(css[:body].include?(".inline-icon-button"), "expected Remote UI action buttons to support SVG icons")
     assert(css[:body].include?(".agent-summary-viewer"), "expected Agent summary to render as a focused page")
@@ -1605,10 +1617,10 @@ module RemoteServerTest
            "expected the skill flyout to stack above the floating Summary shortcut")
     assert(css[:body].include?(".agent-dock:has(.attachment-flyout:not(.hidden))"),
            "expected the attachment flyout to stack above the skill flyout")
-    assert(css[:body].include?(".server-lifecycle-card"),
-           "expected Settings restart lifecycle card to have distinct styling")
-    assert(css[:body].include?(".restart-server-button"),
-           "expected Settings restart action to have distinct button styling")
+    assert(!css[:body].include?(".server-lifecycle-card"),
+           "expected Settings restart readiness to use the normal automation readiness card")
+    assert(css[:body].include?("#settings-push-notifications"),
+           "expected Settings push section to support header menu scrolling")
     assert(css[:body].include?("grid-template-columns: repeat(3, minmax(0, 1fr));"),
            "expected bottom navigation to use the simplified three-tab layout")
     assert(css[:body].include?(".bulk-action-bar"),
@@ -1735,6 +1747,27 @@ module RemoteServerTest
            "expected Remote UI inquiry answers to use the guarded answer endpoint")
     assert(js[:body].include?("normalizeInquiryInputType"),
            "expected Remote UI to normalize inquiry field input types")
+    assert(js[:body].include?("function setHeaderMore"), "expected Remote UI to expose reusable header More menus")
+    assert(js[:body].include?("function headerMoreKeyForRoute"),
+           "expected header More menus to preserve open state across same-route refreshes")
+    assert(js[:body].include?('route.tab === "settings") return "settings"'),
+           "expected Settings More menu to preserve open state across same-route refreshes")
+    assert(js[:body].include?("headerMoreBadge"),
+           "expected header More menus to expose a discoverability badge")
+    assert(js[:body].include?("function parseBackToRoute"),
+           "expected Project routes to parse return crumbs")
+    assert(js[:body].include?("function routeBackQuery"),
+           "expected Project routes to serialize return crumbs")
+    assert(js[:body].include?("function agentsMoreMenuHtml"),
+           "expected Agents tab actions to move into the header More menu")
+    assert(js[:body].include?("function agentMoreMenuHtml"),
+           "expected Conversation actions to move into the header More menu")
+    assert(js[:body].include?("Conversation settings"),
+           "expected Conversation settings to be available from the More menu")
+    assert(js[:body].include?("Open project"),
+           "expected Conversation More menu project navigation to use a verb label")
+    assert(js[:body].include?('back_to=${encodeURIComponent(value)}'),
+           "expected Project links opened from agents to carry a back_to crumb")
     assert(js[:body].include?("function setAgentSettings"), "expected Agent metadata to move into header settings")
     assert(js[:body].include?('id="agent-model" name="model"'),
            "expected Remote UI agent form to expose model input")
@@ -1747,6 +1780,16 @@ module RemoteServerTest
     assert(js[:body].include?("model: String(formData.get(\"model\")"),
            "expected Remote UI agent form payload to include model")
     assert(js[:body].include?("Push notifications"), "expected Settings screen to expose push readiness")
+    assert(js[:body].include?("function settingsMoreMenuHtml"),
+           "expected Settings actions to move into the header More menu")
+    assert(js[:body].include?("Tycho build"),
+           "expected Settings screen to display the Tycho build")
+    assert(js[:body].include?("function tychoBuildLabel"),
+           "expected Settings screen to format Tycho build metadata")
+    assert(js[:body].include?('id="settings-push-notifications"'),
+           "expected Settings push section to expose an in-page menu target")
+    assert(js[:body].include?('data-scroll-settings-section="settings-push-notifications"'),
+           "expected Settings More menu to jump to push notifications")
     assert(js[:body].include?("function renderHiddenSettings"),
            "expected Settings screen to expose a dedicated Hidden settings page")
     assert(js[:body].include?('apiGet("/settings/hidden")'),
@@ -1754,14 +1797,18 @@ module RemoteServerTest
     assert(js[:body].include?('apiPatch("/settings/hidden"'),
            "expected Hidden settings page to update hidden configuration")
     assert(js[:body].include?("data-open-hidden-settings"),
-           "expected Settings screen to link to Hidden settings")
+           "expected Settings More menu to link to Hidden settings")
     assert(js[:body].include?('"eyeOff"') && js[:body].include?('"slash"') && js[:body].include?('"eye"'),
            "expected Hidden settings to use hidden/inherit/visible icon toggle buttons")
-    assert(js[:body].include?("data-restart-server"), "expected Settings screen to expose Remote restart action")
-    assert(js[:body].include?('class="danger inline-icon-button restart-server-button" type="button" data-restart-server'),
-           "expected Remote restart action to use danger button styling")
-    assert(js[:body].index("Refresh and preferences") < js[:body].index("data-restart-server"),
-           "expected Remote restart action to stay at the bottom of the Settings screen")
+    assert(js[:body].include?("Restart server"), "expected Settings More menu to expose Remote restart action")
+    assert(js[:body].include?("data-restart-server"), "expected Settings More menu to expose Remote restart action")
+    assert(js[:body].include?("Remote restart"),
+           "expected Settings readiness to include Remote restart status")
+    assert(js[:body].index("Automation readiness") < js[:body].index("Remote restart"),
+           "expected Remote restart readiness to sit inside Automation readiness")
+    assert(js[:body].index("Remote restart") < js[:body].index("Configuration"),
+           "expected Remote restart readiness to render before Configuration")
+    assert(js[:body].include?("Recheck status"), "expected Settings More menu to expose readiness refresh")
     assert(js[:body].include?("function restartRemoteServer"), "expected Remote UI to handle Remote restarts")
     assert(js[:body].include?('apiPost("/server/restart"'),
            "expected Remote UI restart action to call the restart endpoint")
@@ -1804,10 +1851,10 @@ module RemoteServerTest
            "expected Remote UI agent forms to let the server preserve/default workspace")
     assert(js[:body].include?("data-create-agent"),
            "expected Project detail to expose Add agent navigation")
-    assert(js[:body].include?("function setProjectEditButton"),
-           "expected Project detail to expose edit navigation in the header")
-    assert(js[:body].include?("els.projectEdit.dataset.editProject"),
-           "expected Project edit header button to route to the edit form")
+    assert(js[:body].include?("function projectMoreMenuHtml"),
+           "expected Project detail actions to render from the header More menu")
+    assert(js[:body].include?('label: "Edit project"') && js[:body].include?("data-edit-project"),
+           "expected Project More menu to expose edit navigation")
     assert(js[:body].include?('return { type: "projectForm", key: parts[1] };'),
            "expected Remote UI to parse Project edit routes")
     assert(js[:body].include?("function renderProjectForm"),
@@ -1837,15 +1884,17 @@ module RemoteServerTest
     assert(!js[:body].include?("Project editing opens in the TUI"),
            "expected Project detail to remove the old TUI-only edit notice")
     assert(js[:body].include?("data-edit-agent"),
-           "expected Agent settings to expose edit navigation")
+           "expected Agent More menu to expose edit navigation")
     assert(js[:body].include?("data-archive-agent"),
-           "expected Agent settings to open archive choices")
+           "expected Agent More menu to open archive choices")
     assert(js[:body].include?("Clone instead"),
            "expected archive choices to expose clone instead")
     assert(js[:body].include?("mode === \"clone\""),
            "expected Remote UI agent form to support clone mode")
-    assert(js[:body].include?("els.agentSettingsPanel.addEventListener"),
-           "expected Agent settings actions to work from the fixed header panel")
+    assert(js[:body].include?("els.headerMorePanel.addEventListener"),
+           "expected Agent More menu actions to work from the fixed header panel")
+    assert(js[:body].include?('route.type === "project" && route.backTo'),
+           "expected Project Back to honor agent return crumbs")
     assert(js[:body].include?("apiPatch"),
            "expected Remote UI to update agents through the API")
     assert(js[:body].include?("function toggleSkillFlyout"), "expected Insert Skill to use a floating slash picker")
@@ -2228,9 +2277,9 @@ module RemoteServerTest
     assert(js[:body].include?("renderProjectAgentEmpty()"),
            "expected Agents tab to keep zero-agent projects reachable")
     assert(js[:body].include?("data-toggle-bulk-archive"),
-           "expected Agents tab to expose bulk archive selection mode")
+           "expected Agents tab More menu to expose bulk archive selection mode")
     assert(js[:body].include?("data-run-bulk-archive"),
-           "expected Agents tab to expose bulk archive submission")
+           "expected Agents tab More menu to expose bulk archive submission")
     assert(js[:body].include?('apiPost("/agents/archive", { keys })'),
            "expected Remote UI to call the bulk archive endpoint")
     assert(js[:body].include?("function agentArchiveable"),


### PR DESCRIPTION
## Summary

- Add a shared header More menu for Remote UI actions.
- Move agent list, conversation, settings, and project edit actions into the More menu pattern.
- Expose Remote UI build metadata in setup so Settings can render build information.

## Verification

- `bundle exec ruby -c bin/tycho`
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
