### PR TITLE
Add Remote UI git diff viewer

### DIFF
--- a/docs/research/git-diff-viewer-study.md
+++ b/docs/research/git-diff-viewer-study.md
@@ -1,0 +1,277 @@
+# Temporary Study: Git Diff Viewer for Tycho
+
+Date: 2026-06-06
+
+References were verified active on 2026-06-06. The implementation notes lean on the Git manuals for diff/status/apply behavior and GNU diffutils for the unified hunk shape.
+
+## Why This Matters
+
+Tycho already knows which project or agent workspace a user is operating in, but it currently exposes only a shallow Git summary: commit, branch, and dirty file count. That is enough to warn that something changed, but not enough to understand what changed, decide whether an agent touched the right files, or carry precise code context into an agent conversation.
+
+A first-class diff viewer would make Tycho much more useful as an operator console. The highest-leverage version is not just "show `git diff`"; it is "let the user inspect a change, select a file, hunk, or line range, and bring that exact context into the agent conversation."
+
+## Current State in the Codebase
+
+Current Git metadata is collected in `HQ::AppProject#parse_git_status`:
+
+- `git rev-parse --short HEAD`
+- `git branch --show-current`
+- `git status --porcelain`
+- `dirty_files = porcelain.lines.count`
+
+That data flows into:
+
+- TUI project and agent chips/detail rows as `branch`, `commit_hash`, and `dirty_files`.
+- Remote API project payloads as `branch`, `commit_hash`, `dirty`, and `dirty_files`.
+- Web UI project chips and revision rows.
+
+There is no current file-level status, diff endpoint, hunk parser, or line-level model. The current implementation tells the user that a project is dirty, but it cannot answer "what changed?"
+
+## Product Shape
+
+The feature should support two modes:
+
+1. Read-only inspection: understand the current worktree quickly.
+2. Context crafting: select diff ranges and use them as conversation material for an agent.
+
+Patch application or staging should be a later step. The first implementation should avoid changing Git state.
+
+## TUI Concept
+
+Add a `D` or `ctrl+d` project action that opens a diff view for the selected project.
+
+Useful TUI layout:
+
+- Left column: changed files, status, additions/deletions, staged/unstaged badge.
+- Right column: unified hunk viewer with old/new line numbers.
+- Header controls: scope toggle for `worktree`, `staged`, and `all`.
+- Footer controls: next/previous file, next/previous hunk, copy selected hunk, send selection to current/new agent chat, close.
+
+Interaction targets:
+
+- File selection for broad review.
+- Hunk selection for agent context.
+- Line range selection as a later enhancement once the hunk model is stable.
+
+The TUI should use the existing viewport/detail patterns instead of introducing a separate navigation system. Diff rendering must stay width-aware and avoid horizontal layout churn.
+
+## Web UI Concept
+
+Add a project-level diff panel or route, for example `/#project/:key/diff`.
+
+Useful Web UI layout:
+
+- Sticky toolbar with scope, refresh, collapse/expand files, and "Send to agent".
+- File list with status and counts.
+- Unified diff view as the initial default.
+- Split diff can be a later enhancement.
+- Mobile layout should put the file list behind a drawer or top segmented list.
+
+Line and hunk actions can be richer on the Web UI:
+
+- Click hunk gutter to select a hunk.
+- Drag or shift-click line ranges in a hunk.
+- Button to attach selection to an existing agent conversation.
+- Button to start a new agent using selected diff context.
+
+Polling should preserve open files, selected hunks, and compose form state.
+
+## Backend Model
+
+Add a small Git domain object, for example `HQ::GitRepository` or `HQ::GitDiff`.
+
+Responsibilities:
+
+- Validate that the configured project path is a Git worktree.
+- Collect status using a parseable format such as `git status --porcelain=v1 -z` or `--porcelain=v2 -z`.
+- Collect diffs with shell-safe argument arrays through `Open3.capture3`.
+- Disable pagers and colors.
+- Limit max bytes, max files, and max lines.
+- Detect binary files and huge diffs.
+- Return structured data, not raw terminal text only.
+
+Suggested scopes:
+
+- `worktree`: unstaged changes, equivalent to `git diff`.
+- `staged`: index changes, equivalent to `git diff --cached`.
+- `all`: combined view against `HEAD`, equivalent to `git diff HEAD`.
+- `untracked`: synthetic additions for untracked files, guarded by size and binary checks.
+
+Suggested structured shape:
+
+```json
+{
+  "project_key": "example",
+  "head": "abc1234",
+  "branch": "feature/diff-viewer",
+  "scope": "worktree",
+  "files": [
+    {
+      "path": "lib/example.rb",
+      "old_path": null,
+      "status": "modified",
+      "binary": false,
+      "additions": 12,
+      "deletions": 4,
+      "hunks": [
+        {
+          "header": "@@ -10,7 +10,9 @@",
+          "old_start": 10,
+          "old_lines": 7,
+          "new_start": 10,
+          "new_lines": 9,
+          "lines": [
+            { "kind": "context", "old": 10, "new": 10, "text": "  def call" },
+            { "kind": "removed", "old": 11, "new": null, "text": "- old_code" },
+            { "kind": "added", "old": null, "new": 11, "text": "+ new_code" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Remote API Sketch
+
+Add project-scoped routes:
+
+- `GET /projects/:key/git/status`
+- `GET /projects/:key/git/diff?scope=worktree`
+- `GET /projects/:key/git/diff?scope=staged`
+- `GET /projects/:key/git/diff?scope=all`
+
+For agent handoff:
+
+- Reuse `POST /agents/:key/messages`.
+- Include diff selection metadata in the message payload.
+- Store selected diff context in memory as a normal user message plus metadata so it appears in both TUI and Web conversations.
+
+Example agent message body:
+
+```json
+{
+  "message": "Review this hunk and suggest the smallest safe fix.",
+  "diff_selection": {
+    "project_key": "example",
+    "scope": "worktree",
+    "file": "lib/example.rb",
+    "hunk_index": 0,
+    "line_range": [11, 18]
+  }
+}
+```
+
+For the first version, the server can expand `diff_selection` into bounded text before appending to agent memory. Later, it can persist references and rehydrate them from snapshots.
+
+## Custom Diff Crafting
+
+"Craft our own git diff" should be treated as a patch draft workspace, not as immediate mutation of the Git index.
+
+Initial safe version:
+
+- User selects whole files or hunks.
+- Tycho builds a bounded patch bundle from those selections.
+- The patch bundle can be copied, attached, or sent to an agent.
+- Nothing is applied to disk.
+
+More advanced version:
+
+- User selects individual added/removed/context lines.
+- Tycho recalculates hunk ranges and preserves enough context for `git apply`.
+- Tycho validates with `git apply --check`.
+- Applying the patch requires explicit confirmation.
+
+Line-level custom patching is useful, but it is also where complexity spikes. Hunk-level selection should come first because it gives most of the agent-conversation benefit with far less parser and correctness risk.
+
+## Implementation Phases
+
+Phase 1: backend and read-only viewer
+
+- Add a Git diff domain object with command timeouts and size limits.
+- Add remote API endpoints for status and diff.
+- Add tests with temp Git repos for modified, added, deleted, renamed, staged, unstaged, untracked, binary, and path-with-spaces cases.
+- Add a Web UI project diff view.
+- Add a TUI read-only diff view from the Projects screen.
+
+Web-first implementation note:
+
+- Start with `GET /projects/:key/git/status` and `GET /projects/:key/git/diff?scope=worktree|staged|all`.
+- Render a project-level `#project/:key/diff` Web route with scope toggles and hunk-level read-only inspection.
+- Preserve the TUI work for the next slice so the backend shape can settle against browser-visible behavior first.
+
+Phase 2: agent conversation integration
+
+- Add hunk selection.
+- Add "send selected diff to agent" from both TUI and Web UI.
+- Store selected context in agent memory with metadata.
+- Render selected diff context clearly in chat logs.
+
+Phase 3: patch bundle crafting
+
+- Add file/hunk selection basket.
+- Generate a patch bundle from selected hunks.
+- Allow copy, download, or agent handoff.
+- Keep this read-only by default.
+
+Phase 4: guarded mutation
+
+- Add `git apply --check`.
+- Add explicit apply confirmation.
+- Consider staged/unstaged patch workflows only after read-only and agent handoff are stable.
+
+## Testing Notes
+
+Backend tests should use temp repos and real Git commands. Important cases:
+
+- Modified tracked file.
+- Newly added tracked file.
+- Deleted file.
+- Rename detection.
+- Staged-only change.
+- Mixed staged and unstaged changes in one file.
+- Untracked text file.
+- Untracked or changed binary file.
+- File path with spaces.
+- Large diff truncation.
+- Repository unavailable or not a Git worktree.
+
+TUI tests should cover:
+
+- Empty diff state.
+- Dirty project with file list.
+- Hunk rendering width behavior.
+- Selection state across refresh.
+- Agent handoff prompt text.
+
+Web tests should cover:
+
+- Diff route rendering.
+- Scope toggles.
+- File and hunk expansion.
+- Selection surviving polling refresh.
+- Mobile layout.
+- Sending selected diff to an agent conversation.
+
+## Risks and Guardrails
+
+- Large diffs can make the TUI slow and the browser heavy; enforce byte and file limits.
+- Diffs may contain secrets; do not automatically attach full project diffs to agents.
+- Untracked files need special handling because plain `git diff` does not include them.
+- Binary files should show metadata only.
+- Shell interpolation should be avoided for Git commands.
+- Submodules, worktrees, symlinks, and merge conflicts need explicit status labels.
+- Diff parsing must preserve enough context to avoid misleading line references.
+
+## Recommendation
+
+This is a strong feature direction. The current "dirty file count" is a useful warning, but a diff viewer would turn Tycho into a real workspace inspection tool.
+
+The best next step is a read-only diff viewer plus hunk-level agent handoff. That gets most of the productivity benefit without taking on the risk of applying or staging patches. Once hunk selection is stable, custom patch crafting can build on the same parsed diff model.
+
+## Source References
+
+- Git `diff` manual: https://git-scm.com/docs/git-diff. Verified active on 2026-06-06. Used for the three initial scopes: unstaged worktree diff, staged/index diff through `--cached`/`--staged`, and working tree against `HEAD`.
+- Git `status` manual: https://git-scm.com/docs/git-status. Verified active on 2026-06-06. Used for the recommendation to parse `--porcelain` output because Git documents it as stable for scripts and independent of user configuration.
+- Git `apply` manual: https://git-scm.com/docs/git-apply. Verified active on 2026-06-06. Used for the later patch-crafting guardrail around validating generated patches with `git apply --check` before any explicit mutation.
+- GNU diffutils unified format manual: https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html. Verified active on 2026-06-06. Used for hunk parsing concepts: file headers, `@@` hunk ranges, context lines, added lines, and removed lines.

--- a/lib/hq/domain/app_project.rb
+++ b/lib/hq/domain/app_project.rb
@@ -309,8 +309,8 @@ module HQ
       return unless File.exist?(lockfile)
 
       content = File.read(lockfile)
-      @kamal_version = content[/^    kamal \((.+)\)/, 1]
-      @rails_version = content[/^    rails \((.+)\)/, 1]
+      @kamal_version = content[/^\s*kamal \((.+)\)/, 1]
+      @rails_version = content[/^\s*rails \((.+)\)/, 1]
     end
 
     def parse_git_status

--- a/lib/hq/domain/git_diff.rb
+++ b/lib/hq/domain/git_diff.rb
@@ -1,0 +1,375 @@
+# frozen_string_literal: true
+
+require "open3"
+require "time"
+require "timeout"
+
+module HQ
+  class GitDiff
+    DEFAULT_SCOPE = "worktree"
+    SCOPES = %w[worktree staged all].freeze
+    COMMAND_TIMEOUT = 5
+    MAX_DIFF_BYTES = 512 * 1024
+    MAX_UNTRACKED_BYTES = 64 * 1024
+
+    class Error < StandardError
+      attr_reader :status
+
+      def initialize(message, status: 400)
+        super(message)
+        @status = status
+      end
+    end
+
+    def initialize(path)
+      @path = File.expand_path(path.to_s)
+    end
+
+    def status_payload(project_key: nil)
+      ensure_worktree!
+      status_entries = parse_status_entries(git_output("status", "--porcelain=v1", "-z"))
+      {
+        project_key: project_key,
+        root: worktree_root,
+        head: git_value("rev-parse", "--short", "HEAD"),
+        branch: git_value("branch", "--show-current"),
+        dirty: status_entries.any?,
+        dirty_files: status_entries.length,
+        files: status_entries
+      }.compact
+    end
+
+    def diff_payload(scope: DEFAULT_SCOPE, project_key: nil)
+      ensure_worktree!
+      normalized_scope = normalize_scope(scope)
+      status = status_payload(project_key:)
+      output, truncated = diff_output(normalized_scope)
+      files = parse_patch(output)
+      files.concat(untracked_files(status.fetch(:files, []))) if %w[worktree all].include?(normalized_scope)
+
+      {
+        project_key: project_key,
+        root: status[:root],
+        head: status[:head],
+        branch: status[:branch],
+        scope: normalized_scope,
+        generated_at: Time.now.iso8601,
+        dirty: status[:dirty],
+        dirty_files: status[:dirty_files],
+        files: files,
+        file_count: files.length,
+        additions: files.sum { |file| file[:additions].to_i },
+        deletions: files.sum { |file| file[:deletions].to_i },
+        truncated: truncated
+      }.compact
+    end
+
+    private
+
+    def normalize_scope(value)
+      scope = value.to_s.strip
+      scope = DEFAULT_SCOPE if scope.empty?
+      return scope if SCOPES.include?(scope)
+
+      raise Error.new("Unsupported git diff scope: #{value.inspect}. Supported scopes: #{SCOPES.join(", ")}")
+    end
+
+    def ensure_worktree!
+      raise Error.new("Project path is not a directory: #{@path}", status: 404) unless Dir.exist?(@path)
+
+      inside = git_value("rev-parse", "--is-inside-work-tree")
+      raise Error.new("Project path is not a Git worktree: #{@path}", status: 409) unless inside == "true"
+    end
+
+    def worktree_root
+      git_value("rev-parse", "--show-toplevel")
+    end
+
+    def diff_output(scope)
+      args = ["diff", "--no-color", "--no-ext-diff", "--find-renames", "--patch", "--unified=3"]
+      case scope
+      when "staged"
+        args << "--cached"
+      when "all"
+        args << "HEAD"
+      end
+      args << "--"
+
+      output = git_output(*args)
+      truncated = output.bytesize > MAX_DIFF_BYTES
+      output = output.byteslice(0, MAX_DIFF_BYTES).to_s if truncated
+      [output.scrub, truncated]
+    end
+
+    def git_value(*args)
+      git_output(*args).strip.then { |value| value.empty? ? nil : value }
+    rescue Error
+      nil
+    end
+
+    def git_output(*args)
+      stdout = +""
+      stderr = +""
+      status = nil
+      command = ["git", "-C", @path, "-c", "core.quotepath=false", *args]
+      Timeout.timeout(COMMAND_TIMEOUT) do
+        stdout, stderr, status = Open3.capture3(
+          { "GIT_PAGER" => "cat", "GIT_EXTERNAL_DIFF" => "" },
+          *command
+        )
+      end
+      raise Error.new(stderr.to_s.strip.empty? ? "Git command failed" : stderr.to_s.strip, status: 409) unless status.success?
+
+      stdout.to_s
+    rescue Timeout::Error
+      raise Error.new("Git command timed out", status: 409)
+    rescue SystemCallError => e
+      raise Error.new(e.message, status: 409)
+    end
+
+    def parse_status_entries(output)
+      fields = output.to_s.split("\0")
+      entries = []
+      index = 0
+      while index < fields.length
+        field = fields[index].to_s
+        index += 1
+        next if field.empty?
+
+        code = field[0, 2].to_s
+        path = field[3..].to_s
+        old_path = nil
+        if code.include?("R") || code.include?("C")
+          old_path = fields[index].to_s
+          index += 1
+        end
+        entries << {
+          path: path,
+          old_path: empty_to_nil(old_path),
+          index_status: code[0],
+          worktree_status: code[1],
+          status: status_label(code)
+        }.compact
+      end
+      entries
+    end
+
+    def status_label(code)
+      return "untracked" if code == "??"
+      return "renamed" if code.include?("R")
+      return "copied" if code.include?("C")
+      return "added" if code.include?("A")
+      return "deleted" if code.include?("D")
+      return "modified" if code.include?("M")
+      return "conflicted" if code.match?(/[U]/)
+
+      "changed"
+    end
+
+    def parse_patch(output)
+      files = []
+      current_file = nil
+      current_hunk = nil
+      old_line = nil
+      new_line = nil
+
+      output.to_s.each_line(chomp: true) do |line|
+        if line.start_with?("diff --git ")
+          current_file = new_file_entry
+          files << current_file
+          current_hunk = nil
+          old_line = nil
+          new_line = nil
+          next
+        end
+        next unless current_file
+
+        case line
+        when /\Anew file mode /
+          current_file[:status] = "added"
+        when /\Adeleted file mode /
+          current_file[:status] = "deleted"
+        when /\Arename from (.+)\z/
+          current_file[:status] = "renamed"
+          current_file[:old_path] = unquote_path(Regexp.last_match(1))
+        when /\Arename to (.+)\z/
+          current_file[:status] = "renamed"
+          current_file[:path] = unquote_path(Regexp.last_match(1))
+        when /\A--- (.+)\z/
+          current_file[:old_path] = diff_path(Regexp.last_match(1), "a/")
+          current_file[:status] = "deleted" if Regexp.last_match(1) == "/dev/null"
+        when /\A\+\+\+ (.+)\z/
+          current_file[:path] = diff_path(Regexp.last_match(1), "b/")
+          current_file[:status] = "added" if current_file[:old_path].nil?
+        when /\ABinary files /
+          current_file[:binary] = true
+        when /\AGIT binary patch\z/
+          current_file[:binary] = true
+        when /\A@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)\z/
+          old_line = Regexp.last_match(1).to_i
+          new_line = Regexp.last_match(3).to_i
+          current_hunk = {
+            header: line,
+            old_start: old_line,
+            old_lines: (Regexp.last_match(2) || "1").to_i,
+            new_start: new_line,
+            new_lines: (Regexp.last_match(4) || "1").to_i,
+            section: empty_to_nil(Regexp.last_match(5).to_s.strip),
+            lines: []
+          }.compact
+          current_file[:hunks] << current_hunk
+        else
+          next unless current_hunk
+
+          parsed = parse_hunk_line(line, old_line, new_line)
+          current_hunk[:lines] << parsed.fetch(:line)
+          current_file[:additions] += 1 if parsed.fetch(:line)[:kind] == "added"
+          current_file[:deletions] += 1 if parsed.fetch(:line)[:kind] == "removed"
+          old_line = parsed.fetch(:old_line)
+          new_line = parsed.fetch(:new_line)
+        end
+      end
+
+      files.each do |file|
+        file[:path] ||= file[:old_path]
+        file[:old_path] = nil if file[:old_path] == file[:path]
+      end
+      files
+    end
+
+    def new_file_entry
+      {
+        path: nil,
+        old_path: nil,
+        status: "modified",
+        binary: false,
+        additions: 0,
+        deletions: 0,
+        hunks: []
+      }
+    end
+
+    def parse_hunk_line(line, old_line, new_line)
+      case line[0]
+      when "+"
+        parsed_line = {
+          kind: "added",
+          old_number: nil,
+          new_number: new_line,
+          content: line[1..].to_s
+        }
+        new_line += 1
+      when "-"
+        parsed_line = {
+          kind: "removed",
+          old_number: old_line,
+          new_number: nil,
+          content: line[1..].to_s
+        }
+        old_line += 1
+      when " "
+        parsed_line = {
+          kind: "context",
+          old_number: old_line,
+          new_number: new_line,
+          content: line[1..].to_s
+        }
+        old_line += 1
+        new_line += 1
+      else
+        parsed_line = {
+          kind: "meta",
+          old_number: nil,
+          new_number: nil,
+          content: line
+        }
+      end
+
+      { line: parsed_line, old_line: old_line, new_line: new_line }
+    end
+
+    def untracked_files(status_entries)
+      status_entries.select { |entry| entry[:status] == "untracked" }.map { |entry| untracked_file(entry[:path]) }
+    end
+
+    def untracked_file(path)
+      safe_path = safe_relative_path(path)
+      full_path = File.join(worktree_root, safe_path)
+      entry = {
+        path: safe_path,
+        old_path: nil,
+        status: "untracked",
+        binary: false,
+        additions: 0,
+        deletions: 0,
+        hunks: []
+      }
+      unless File.file?(full_path)
+        entry[:message] = "Untracked directory or special file is not expanded."
+        return entry
+      end
+
+      size = File.size(full_path)
+      content = File.binread(full_path, [size, MAX_UNTRACKED_BYTES].min)
+      if content.include?("\0")
+        entry[:binary] = true
+        entry[:message] = "Untracked binary file is not expanded."
+        return entry
+      end
+
+      lines = content.scrub.lines(chomp: true)
+      entry[:truncated] = size > MAX_UNTRACKED_BYTES
+      entry[:additions] = lines.length
+      entry[:hunks] << {
+        header: "@@ -0,0 +1,#{lines.length} @@",
+        old_start: 0,
+        old_lines: 0,
+        new_start: 1,
+        new_lines: lines.length,
+        lines: lines.each_with_index.map do |text, index|
+          {
+            kind: "added",
+            old_number: nil,
+            new_number: index + 1,
+            content: text
+          }
+        end
+      }
+      entry
+    rescue SystemCallError => e
+      entry[:message] = e.message
+      entry
+    end
+
+    def safe_relative_path(path)
+      expanded = File.expand_path(path.to_s, worktree_root)
+      root = "#{worktree_root}#{File::SEPARATOR}"
+      unless expanded == worktree_root || expanded.start_with?(root)
+        raise Error.new("Git path escapes worktree: #{path.inspect}", status: 409)
+      end
+
+      expanded.delete_prefix(root)
+    end
+
+    def diff_path(value, prefix)
+      raw = unquote_path(value)
+      return nil if raw == "/dev/null"
+
+      raw.start_with?(prefix) ? raw.delete_prefix(prefix) : raw
+    end
+
+    def unquote_path(value)
+      text = value.to_s
+      return text.undump if text.start_with?("\"") && text.end_with?("\"")
+
+      text
+    rescue ArgumentError
+      text
+    end
+
+    def empty_to_nil(value)
+      text = value.to_s
+      text.empty? ? nil : text
+    end
+  end
+end

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -17,6 +17,7 @@ require_relative "domain/agent_attachment_store"
 require_relative "domain/agent_chat_log"
 require_relative "domain/agent_store"
 require_relative "domain/executable_resolver"
+require_relative "domain/git_diff"
 require_relative "domain/harness_catalog"
 require_relative "domain/kamal_action"
 require_relative "domain/push_notification_store"
@@ -110,9 +111,13 @@ module HQ
 
     private
 
-    Request = Struct.new(:method, :path, :headers, :body, keyword_init: true) do
+    Request = Struct.new(:method, :path, :query, :headers, :body, keyword_init: true) do
       def [](key)
         headers[key.to_s.downcase]
+      end
+
+      def query_params
+        @query_params ||= URI.decode_www_form(query.to_s).to_h
       end
     end
 
@@ -242,6 +247,10 @@ module HQ
         tail = parts.drop(2)
         return ok(project: service.project(key)) if method == "GET" && tail.empty?
         return ok(project: service.update_project(key, body)) if %w[PATCH PUT].include?(method) && tail.empty?
+        return ok(git: service.project_git_status(key)) if method == "GET" && tail == ["git", "status"]
+        if method == "GET" && tail[0, 2] == ["git", "diff"] && tail.length <= 3
+          return ok(diff: service.project_git_diff(key, scope: tail[2] || request&.query_params&.fetch("scope", nil)))
+        end
         return ok(actions: service.project_action_preflights(key)) if method == "GET" && tail == ["actions"]
         return ok(service.start_project_action(key, body["action"], body)) if method == "POST" && tail == ["actions"]
         if tail.length == 2 && tail.first == "actions"
@@ -395,8 +404,8 @@ module HQ
         headers[name.to_s.downcase] = value.to_s.strip unless name.to_s.empty?
       end
       body = client.read(headers["content-length"].to_i).to_s
-      path = raw_path.to_s.split("?", 2).first
-      Request.new(method: method.to_s.upcase, path: path, headers: headers, body: body)
+      path, query = raw_path.to_s.split("?", 2)
+      Request.new(method: method.to_s.upcase, path: path, query: query.to_s, headers: headers, body: body)
     end
 
     def write_http(client, status, body = nil, content_type: "application/json", headers: {}, **payload)
@@ -666,6 +675,20 @@ module HQ
       refresh_project!(target)
       agents = load_agents.select { |agent| agent.project_key == target.key }
       project_detail_payload(target, agents:, active_action: active_actions[target.key])
+    end
+
+    def project_git_status(key)
+      project = find_project!(key)
+      GitDiff.new(project.path).status_payload(project_key: project.key)
+    rescue GitDiff::Error => e
+      raise Error.new(e.message, status: e.status)
+    end
+
+    def project_git_diff(key, scope: nil)
+      project = find_project!(key)
+      GitDiff.new(project.path).diff_payload(scope:, project_key: project.key)
+    rescue GitDiff::Error => e
+      raise Error.new(e.message, status: e.status)
     end
 
     def update_project(key, attrs)

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1576,6 +1576,202 @@ select {
   padding: 0 12px 12px;
 }
 
+.diff-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.diff-scope-switch {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.diff-scope-switch button {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 38px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.diff-scope-switch button + button {
+  border-left: 1px solid var(--border);
+}
+
+.diff-scope-switch button.active {
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.diff-summary-card .card-title {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.diff-viewer {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.diff-file > summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.diff-file {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.diff-file-title {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.diff-file-title span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.diff-file-body {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  max-width: 100%;
+  max-height: min(70dvh, 720px);
+  overflow: auto;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 54%, var(--panel));
+  padding: 10px 0;
+}
+
+.diff-file-message {
+  margin: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--muted);
+  padding: 10px;
+}
+
+.diff-hunk {
+  display: grid;
+  width: max-content;
+  min-width: 100%;
+}
+
+.diff-hunk-header {
+  position: sticky;
+  top: -10px;
+  z-index: 1;
+  border-block: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel-soft) 78%, var(--panel));
+  padding: 6px 12px;
+}
+
+.diff-hunk-header code {
+  color: var(--info);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+}
+
+.diff-lines {
+  display: grid;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.diff-line {
+  display: grid;
+  grid-template-columns: 5ch 5ch 2ch minmax(40ch, 1fr);
+  min-height: 20px;
+  padding: 0 12px;
+}
+
+.diff-line.added {
+  background: color-mix(in srgb, var(--ok) 14%, transparent);
+}
+
+.diff-line.removed {
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+}
+
+.diff-line.meta {
+  color: var(--muted);
+}
+
+.diff-line-no {
+  color: var(--muted);
+  user-select: none;
+}
+
+.diff-marker {
+  color: var(--muted);
+  user-select: none;
+}
+
+.diff-line.added .diff-marker {
+  color: var(--ok);
+}
+
+.diff-line.removed .diff-marker {
+  color: var(--danger);
+}
+
+.diff-line code {
+  color: var(--text);
+  font: inherit;
+  white-space: pre;
+}
+
+@media (max-width: 560px) {
+  .diff-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .diff-scope-switch {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .diff-scope-switch button {
+    padding-inline: 6px;
+  }
+
+  .diff-scope-switch button + button {
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+
+  .diff-toolbar > button {
+    width: 100%;
+  }
+
+  .diff-file > summary {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .diff-file > summary .pill {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
 .kv-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -395,6 +395,7 @@ const state = {
   schedules: [],
   scheduleDaemon: null,
   projectDetails: {},
+  projectDiffs: {},
   hiddenSettings: null,
   setup: null,
   conversations: {},
@@ -595,6 +596,12 @@ function parseRoute() {
   }
   if (parts[0] === "agent" && parts[1]) return { type: "agent", key: parts[1] };
   if (parts[0] === "attachment" && parts[1]) return { type: "attachment", id: parts[1] };
+  if (parts[0] === "project" && parts[1] && parts[2] === "diff") {
+    const route = { type: "projectDiff", key: parts[1], scope: normalizeDiffScope(params.get("scope") || parts[3]) };
+    const backTo = parseBackToRoute(params.get("back_to") || params.get("return_to"));
+    if (backTo) route.backTo = backTo;
+    return route;
+  }
   if (parts[0] === "project" && parts[1] && parts[2] === "agent" && parts[3] === "new") {
     return { type: "agentForm", mode: "create", projectKey: parts[1] };
   }
@@ -633,6 +640,11 @@ function parseBackToRoute(value) {
   return null;
 }
 
+function normalizeDiffScope(value) {
+  const scope = String(value || "").trim();
+  return ["worktree", "staged", "all"].includes(scope) ? scope : "worktree";
+}
+
 function routeHash(route) {
   if (route.type === "agent") return `#agent/${encodeURIComponent(route.key)}`;
   if (route.type === "agentSummary") return `#agent/${encodeURIComponent(route.key)}/summary`;
@@ -650,6 +662,13 @@ function routeHash(route) {
     return `#agent/${encodeURIComponent(route.key)}/attachment/${encodeURIComponent(route.attachmentId)}`;
   }
   if (route.type === "attachment") return `#attachment/${encodeURIComponent(route.id)}`;
+  if (route.type === "projectDiff") {
+    const params = new URLSearchParams();
+    params.set("scope", normalizeDiffScope(route.scope));
+    const backTo = backRouteValue(route.backTo);
+    if (backTo) params.set("back_to", backTo);
+    return `#project/${encodeURIComponent(route.key)}/diff?${params.toString()}`;
+  }
   if (route.type === "projectForm") return `#project/${encodeURIComponent(route.key)}/edit`;
   if (route.type === "project") {
     return `#project/${encodeURIComponent(route.key)}${routeBackQuery(route)}`;
@@ -680,6 +699,19 @@ function navigate(route) {
   }
 }
 
+function navigateProjectDiff(button) {
+  const route = parseRoute();
+  const backTo = agentShellRoute(route)
+    ? { type: "agent", key: route.key }
+    : route.type === "projectDiff" ? route.backTo : null;
+  navigate({
+    type: "projectDiff",
+    key: button.dataset.openProjectDiff,
+    scope: button.dataset.diffScope || "worktree",
+    backTo,
+  });
+}
+
 function activateNavTab(tab) {
   const route = parseRoute();
   if (route.type === "tab" && route.tab === tab) {
@@ -701,7 +733,7 @@ function scrollPageToTop() {
 
 function currentTopTab(route) {
   if (route.type === "tab") return route.tab;
-  if (route.type === "project" || route.type === "projectForm" || route.type === "guard") return "agents";
+  if (route.type === "project" || route.type === "projectDiff" || route.type === "projectForm" || route.type === "guard") return "agents";
   if (route.type === "agentForm") return "agents";
   if (route.type === "agent" || route.type === "agentSummary" || route.type === "agentAttachment" || route.type === "agentArchive" || route.type === "attachment") return "agents";
   if (route.type === "hiddenSettings") return "settings";
@@ -834,8 +866,11 @@ async function ensureRouteData(options = {}) {
     }
     await ensureAttachmentPreview(route.id, options.forceAttachment);
   }
-  if (route.type === "project" || route.type === "guard") {
+  if (route.type === "project" || route.type === "projectDiff" || route.type === "guard") {
     await ensureProject(route.key, true);
+  }
+  if (route.type === "projectDiff") {
+    await ensureProjectDiff(route.key, route.scope, true);
   }
   if (route.type === "guard") {
     await ensurePreflight(route.key, route.action, options.forcePreflight);
@@ -858,6 +893,25 @@ async function ensureProject(projectKey, force = false) {
   if (!force && state.projectDetails[projectKey]) return;
   const data = await apiGet(`/projects/${encodeURIComponent(projectKey)}`);
   if (data.project) state.projectDetails[projectKey] = data.project;
+}
+
+async function ensureProjectDiff(projectKey, scope = "worktree", force = false) {
+  const normalizedScope = normalizeDiffScope(scope);
+  const key = projectDiffKey(projectKey, normalizedScope);
+  if (!force && state.projectDiffs[key] && !state.projectDiffs[key].loading) return;
+
+  state.projectDiffs[key] = { project_key: projectKey, scope: normalizedScope, loading: true };
+  try {
+    const data = await apiGet(`/projects/${encodeURIComponent(projectKey)}/git/diff?scope=${encodeURIComponent(normalizedScope)}`);
+    state.projectDiffs[key] = data.diff || { project_key: projectKey, scope: normalizedScope, files: [] };
+  } catch (error) {
+    state.projectDiffs[key] = {
+      project_key: projectKey,
+      scope: normalizedScope,
+      error: error.message,
+      files: [],
+    };
+  }
 }
 
 async function ensureConversation(agent, force = false) {
@@ -987,6 +1041,8 @@ function render() {
     }
   } else if (route.type === "project") {
     renderProject(route.key);
+  } else if (route.type === "projectDiff") {
+    renderProjectDiff(route.key, route.scope);
   } else if (route.type === "projectForm") {
     renderProjectForm(route.key);
   } else if (route.type === "agentForm") {
@@ -1037,6 +1093,7 @@ function routeStateKey(route) {
   if (route.type === "agentArchive") return `agent-archive:${route.key}`;
   if (route.type === "projectForm") return `project-form:${route.key}`;
   if (route.type === "project") return `project:${route.key}`;
+  if (route.type === "projectDiff") return `project-diff:${route.key}:${normalizeDiffScope(route.scope)}`;
   if (route.type === "guard") return `guard:${route.key}:${route.action}`;
   if (route.type === "hiddenSettings") return "settings:hidden";
   return `tab:${route.tab}`;
@@ -2547,6 +2604,174 @@ function renderProject(key) {
       </div>
     </section>
   `);
+}
+
+function renderProjectDiff(key, scope = "worktree") {
+  const normalizedScope = normalizeDiffScope(scope);
+  const project = findProject(key);
+  const diff = state.projectDiffs[projectDiffKey(key, normalizedScope)];
+  if (!project && initialDataPending()) {
+    setHeader("Loading project", "Fetching remote state", "gitCommit");
+    replaceView(emptyState("Loading project", "Fetching project state before rendering changes."));
+    return;
+  }
+
+  if (!project) {
+    setHeader("Project not found", "It may have been removed from config.", "gitCommit");
+    replaceView(emptyState("Project not found", "Return to the Agents tab and choose an active project."));
+    return;
+  }
+
+  setHeader(`${project.name || project.key} changes`, `${diffScopeLabel(normalizedScope)} / ${project.branch || "branch n/a"}`, "gitCommit");
+  if (!diff || diff.loading) {
+    replaceView(`
+      ${renderProjectDiffScopeSwitch(project, normalizedScope)}
+      ${emptyState("Loading diff", "Reading Git changes for this project.")}
+    `);
+    return;
+  }
+
+  if (diff.error) {
+    replaceView(`
+      ${renderProjectDiffScopeSwitch(project, normalizedScope)}
+      <section class="notice">
+        <strong>Diff unavailable</strong>
+        <p>${escapeHtml(diff.error)}</p>
+      </section>
+    `);
+    return;
+  }
+
+  const files = Array.isArray(diff.files) ? diff.files : [];
+  const summary = `${files.length} ${files.length === 1 ? "file" : "files"} / +${diff.additions || 0} -${diff.deletions || 0}`;
+  replaceView(`
+    ${renderProjectDiffScopeSwitch(project, normalizedScope)}
+    <section class="summary-card diff-summary-card">
+      <div class="card-title">
+        <strong>${escapeHtml(summary)}</strong>
+        <span>${escapeHtml([diff.head, diff.branch].filter(Boolean).join(" on ") || "Git revision unavailable")}</span>
+      </div>
+      <div class="chip-row">
+        <span class="chip ${diff.dirty ? "need" : "done"}">${diff.dirty ? `${diff.dirty_files || 0} dirty` : "clean"}</span>
+        <span class="chip detail">${escapeHtml(diffScopeLabel(normalizedScope))}</span>
+        ${diff.truncated ? `<span class="chip need">truncated</span>` : ""}
+      </div>
+    </section>
+    <section class="diff-viewer" aria-label="Git diff">
+      ${files.length ? files.map(renderProjectDiffFile).join("") : emptyState("No changes", "This diff scope has no file changes.")}
+    </section>
+  `);
+}
+
+function renderProjectDiffScopeSwitch(project, currentScope) {
+  const scopes = [
+    ["worktree", "Worktree"],
+    ["staged", "Staged"],
+    ["all", "All"],
+  ];
+  return `
+    <section class="diff-toolbar" aria-label="Diff scope">
+      <div class="diff-scope-switch" role="group" aria-label="Diff scope">
+        ${scopes.map(([scope, label]) => `
+          <button class="${scope === currentScope ? "active" : ""}" type="button" data-open-project-diff="${escapeAttr(project.key)}" data-diff-scope="${escapeAttr(scope)}" aria-pressed="${scope === currentScope ? "true" : "false"}">${escapeHtml(label)}</button>
+        `).join("")}
+      </div>
+      <button class="inline-icon-button" type="button" data-refresh>${iconSvg("rotateCcw")}<span>Refresh</span></button>
+    </section>
+  `;
+}
+
+function renderProjectDiffFile(file, index) {
+  const path = file.path || file.old_path || "unknown path";
+  const status = diffStatusLabel(file.status);
+  const className = diffStatusClass(file.status);
+  const meta = diffFileMeta(file);
+  const hunks = Array.isArray(file.hunks) ? file.hunks : [];
+  const body = file.binary
+    ? `<div class="diff-file-message">Binary file is not expanded.</div>`
+    : hunks.length
+      ? hunks.map(renderDiffHunk).join("")
+      : `<div class="diff-file-message">${escapeHtml(file.message || "No textual hunks for this file.")}</div>`;
+
+  return `
+    <details class="diff-file detail-card" ${index === 0 ? "open" : ""} data-state-key="diff-file:${escapeAttr(path)}">
+      <summary>
+        <span class="status-mark ${className}" aria-hidden="true">${iconSvg(file.binary ? "fileText" : "code")}</span>
+        <span class="diff-file-title">
+          <strong class="wrap-anywhere">${escapeHtml(path)}</strong>
+          <span>${escapeHtml(meta)}</span>
+        </span>
+        <span class="pill ${className}">${escapeHtml(status)}</span>
+      </summary>
+      <div class="diff-file-body" data-preserve-scroll data-state-key="diff-scroll:${escapeAttr(path)}">
+        ${body}
+      </div>
+    </details>
+  `;
+}
+
+function renderDiffHunk(hunk, index) {
+  const lines = Array.isArray(hunk.lines) ? hunk.lines : [];
+  return `
+    <section class="diff-hunk" aria-label="Hunk ${index + 1}">
+      <div class="diff-hunk-header"><code>${escapeHtml(hunk.header || "@@")}</code></div>
+      <div class="diff-lines">
+        ${lines.map(renderDiffLine).join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderDiffLine(line) {
+  const kind = String(line.kind || "context");
+  const marker = kind === "added" ? "+" : kind === "removed" ? "-" : kind === "meta" ? "\\" : " ";
+  return `
+    <div class="diff-line ${escapeAttr(kind)}">
+      <span class="diff-line-no">${diffLineNumber(line.old_number)}</span>
+      <span class="diff-line-no">${diffLineNumber(line.new_number)}</span>
+      <span class="diff-marker">${escapeHtml(marker)}</span>
+      <code>${escapeHtml(line.content || "")}</code>
+    </div>
+  `;
+}
+
+function diffLineNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? escapeHtml(String(number)) : "";
+}
+
+function projectDiffKey(projectKey, scope) {
+  return `${projectKey || ""}:${normalizeDiffScope(scope)}`;
+}
+
+function diffScopeLabel(scope) {
+  return {
+    worktree: "Worktree",
+    staged: "Staged",
+    all: "All changes",
+  }[normalizeDiffScope(scope)];
+}
+
+function diffStatusLabel(status) {
+  return capitalize(String(status || "modified"));
+}
+
+function diffStatusClass(status) {
+  const value = String(status || "");
+  if (["added", "untracked", "copied"].includes(value)) return "done";
+  if (["deleted"].includes(value)) return "fail";
+  if (["renamed"].includes(value)) return "info";
+  return "need";
+}
+
+function diffFileMeta(file) {
+  const counts = [];
+  if (file.additions) counts.push(`+${file.additions}`);
+  if (file.deletions) counts.push(`-${file.deletions}`);
+  if (file.binary) counts.push("binary");
+  if (file.truncated) counts.push("truncated");
+  if (file.old_path && file.old_path !== file.path) counts.push(`from ${file.old_path}`);
+  return counts.join(" / ") || "metadata only";
 }
 
 function renderProjectForm(key) {
@@ -4285,6 +4510,7 @@ function toggleAgentSettings() {
 function agentMoreMenuHtml(agent) {
   const running = agentIsRunning(agent);
   const lifecycleSublabel = running ? "Stop agent first" : agent.name || agent.key;
+  const project = agent.project_key ? findProject(agent.project_key) : null;
   return moreMenuHtml([
     agent.project_key
       ? moreMenuButton({
@@ -4292,6 +4518,14 @@ function agentMoreMenuHtml(agent) {
           sublabel: agentProjectLabel(agent),
           icon: "folder",
           attrs: `data-open-project="${escapeAttr(agent.project_key)}"`,
+        })
+      : "",
+    agent.project_key
+      ? moreMenuButton({
+          label: "See diff",
+          sublabel: projectDiffSublabel(project, agentProjectLabel(agent)),
+          icon: "fileText",
+          attrs: `data-open-project-diff="${escapeAttr(agent.project_key)}" data-diff-scope="worktree"`,
         })
       : "",
     moreMenuButton({
@@ -4329,7 +4563,22 @@ function projectMoreMenuHtml(project) {
       icon: "pencil",
       attrs: `data-edit-project="${escapeAttr(project.key)}"`,
     }),
+    moreMenuButton({
+      label: "See diff",
+      sublabel: projectDiffSublabel(project),
+      icon: "fileText",
+      attrs: `data-open-project-diff="${escapeAttr(project.key)}" data-diff-scope="worktree"`,
+    }),
   ]);
+}
+
+function projectDiffSublabel(project, fallback = "Workspace changes") {
+  if (!project) return fallback;
+  if (project.dirty) {
+    const count = Number(project.dirty_files) || 0;
+    return `${count} dirty ${count === 1 ? "file" : "files"}`;
+  }
+  return "Workspace clean";
 }
 
 function agentSettingsHtml(agent) {
@@ -5323,6 +5572,7 @@ els.back.addEventListener("click", () => {
   else if (route.type === "agentForm" && route.mode === "create") navigate({ type: "project", key: route.projectKey });
   else if (route.type === "agentArchive") navigate({ type: "agent", key: route.key });
   else if (route.type === "projectForm") navigate({ type: "project", key: route.key });
+  else if (route.type === "projectDiff") navigate(route.backTo || { type: "project", key: route.key });
   else if (route.type === "project" && route.backTo) navigate(route.backTo);
   else if (route.type === "project" || route.type === "guard") navigate({ type: "tab", tab: "agents" });
   else if (route.type === "hiddenSettings") navigate({ type: "tab", tab: "settings" });
@@ -5413,6 +5663,13 @@ els.headerMorePanel.addEventListener("click", (event) => {
   if (event.target.closest("[data-toggle-agent-settings]")) {
     closeHeaderMore();
     toggleAgentSettings();
+    return;
+  }
+
+  const projectDiffButton = event.target.closest("[data-open-project-diff]");
+  if (projectDiffButton) {
+    closeHeaderMore();
+    navigateProjectDiff(projectDiffButton);
     return;
   }
 
@@ -5529,6 +5786,12 @@ els.view.addEventListener("click", (event) => {
   const projectButton = event.target.closest("[data-open-project]");
   if (projectButton) {
     navigate({ type: "project", key: projectButton.dataset.openProject });
+    return;
+  }
+
+  const projectDiffButton = event.target.closest("[data-open-project-diff]");
+  if (projectDiffButton) {
+    navigateProjectDiff(projectDiffButton);
     return;
   }
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -23,6 +23,7 @@ module RemoteServerTest
     assert_remote_prompt_start_accepts_dash_prefixed_message
     assert_remote_agent_conversation_hides_run_summary
     assert_remote_project_payloads_include_status_and_detail
+    assert_remote_project_git_diff_payload
     assert_remote_project_update_route_edits_metadata
     assert_remote_agent_model_and_effort_payloads
     assert_remote_hidden_settings_filter_projects_and_agents
@@ -774,6 +775,48 @@ module RemoteServerTest
       assert(detail[:agent_template_summaries].first[:prompt] == "Default prompt for web.",
              "expected Remote UI project detail to expose full template prompt for agent creation")
       assert(detail.dig(:recent_agent_summary, :key) == agent[:key], "expected recent agent summary")
+    end
+  end
+
+  def assert_remote_project_git_diff_payload
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      File.write(File.join(workspace, "tracked.txt"), "one\n")
+      git!(workspace, "init")
+      git!(workspace, "config", "user.email", "tycho@example.test")
+      git!(workspace, "config", "user.name", "Tycho Test")
+      git!(workspace, "add", ".")
+      git!(workspace, "commit", "-m", "initial")
+      File.write(File.join(workspace, "tracked.txt"), "one\ntwo\n")
+      File.write(File.join(workspace, "notes draft.txt"), "draft\n")
+
+      registry = registry_for_project(dir, workspace, apps: false)
+      service = HQ::RemoteService.new(registry: registry)
+      diff = service.project_git_diff("web", scope: "worktree")
+      tracked = diff[:files].find { |file| file[:path] == "tracked.txt" }
+      untracked = diff[:files].find { |file| file[:path] == "notes draft.txt" }
+      assert(diff[:scope] == "worktree", "expected worktree diff scope")
+      assert(tracked, "expected tracked file diff")
+      assert(tracked[:hunks].first[:lines].any? { |line| line[:kind] == "added" && line[:content] == "two" },
+             "expected tracked additions to be parsed")
+      assert(untracked && untracked[:status] == "untracked", "expected untracked files to be represented")
+      assert(untracked[:additions] == 1, "expected untracked text additions to be counted")
+
+      server = HQ::RemoteServer.new
+      request = HQ::RemoteServer.const_get(:Request).new(
+        method: "GET",
+        path: "/projects/web/git/diff",
+        query: "scope=all",
+        headers: {},
+        body: ""
+      )
+      response = server.send(:route, service, "GET", "/projects/web/git/diff", {}, request)
+      assert(response.dig(:body, :diff, :scope) == "all", "expected git diff route to honor query scope")
+
+      status = server.send(:route, service, "GET", "/projects/web/git/status", {}, nil)
+      assert(status.dig(:body, :git, :dirty), "expected git status route to report dirty workspace")
+      assert(status.dig(:body, :git, :dirty_files).to_i >= 2, "expected git status route to count dirty files")
     end
   end
 
@@ -1666,6 +1709,10 @@ module RemoteServerTest
            "expected Hidden settings toggle segments to stay horizontal")
     assert(css[:body].include?(".project-info-title"),
            "expected Project edit form to style the read-only information title")
+    assert(css[:body].include?(".diff-viewer") && css[:body].include?(".diff-line.added"),
+           "expected Remote UI to style project Git diff rows")
+    assert(css[:body].include?(".diff-scope-switch"),
+           "expected Remote UI to style Git diff scope toggles")
     js = server.send(:route_ui, "/ui.js")
     assert(js[:content_type].include?("javascript"), "expected /ui.js to return JavaScript")
     assert(js[:body].include?("DEFAULT_REFRESH_INTERVALS"), "expected UI JavaScript to define refresh defaults")
@@ -1758,6 +1805,16 @@ module RemoteServerTest
            "expected Project routes to parse return crumbs")
     assert(js[:body].include?("function routeBackQuery"),
            "expected Project routes to serialize return crumbs")
+    assert(js[:body].include?('const route = { type: "projectDiff"'),
+           "expected Project diff routes to be parsed")
+    assert(js[:body].include?("function ensureProjectDiff"),
+           "expected Remote UI to load project Git diffs from the API")
+    assert(js[:body].include?("function renderProjectDiff"),
+           "expected Remote UI to render project Git diffs")
+    assert(js[:body].include?('/git/diff?scope='),
+           "expected Remote UI to call the project Git diff endpoint")
+    assert(js[:body].include?("data-open-project-diff"),
+           "expected Project detail to expose Git diff navigation")
     assert(js[:body].include?("function agentsMoreMenuHtml"),
            "expected Agents tab actions to move into the header More menu")
     assert(js[:body].include?("function agentMoreMenuHtml"),
@@ -1855,6 +1912,8 @@ module RemoteServerTest
            "expected Project detail actions to render from the header More menu")
     assert(js[:body].include?('label: "Edit project"') && js[:body].include?("data-edit-project"),
            "expected Project More menu to expose edit navigation")
+    assert(js[:body].include?('label: "See diff"') && js[:body].include?("function navigateProjectDiff"),
+           "expected More menus to expose Project diff navigation")
     assert(js[:body].include?('return { type: "projectForm", key: parts[1] };'),
            "expected Remote UI to parse Project edit routes")
     assert(js[:body].include?("function renderProjectForm"),
@@ -2579,8 +2638,14 @@ module RemoteServerTest
       GEM
         specs:
           kamal (2.6.1)
-          rails (7.2.2)
+      rails (7.2.2)
     LOCK
+  end
+
+  def git!(workspace, *args)
+    return if system("git", "-C", workspace, *args, out: File::NULL, err: File::NULL)
+
+    raise "git #{args.join(" ")} failed"
   end
 
   def write_test_executable(path)


### PR DESCRIPTION
## Summary

- Add a structured `HQ::GitDiff` backend for project Git status and diff payloads.
- Expose Remote API endpoints for project Git status and diff scopes.
- Add a Remote UI project diff view with worktree/staged/all scopes and See diff actions in the project and agent More menus.
- Add the Git diff viewer study note with verified references.

## Verification

- `bundle exec ruby -c bin/tycho`
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- Headless Chrome fixture: verified project More menu, agent More menu, agent-originated diff back crumb, and rendered `README.md` diff content.
