### PR TITLE
Expand tycho agent CLI with 8 new subcommands

### DIFF
--- a/.claude/skills/tycho/SKILL.md
+++ b/.claude/skills/tycho/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tycho
-description: Manages Tycho-monitored projects and managed agents. Use when the user asks to deploy, check status, manage maintenance mode, create agents, or control schedules for any project.
+description: Manages Tycho-monitored projects and managed agents. Use when the user asks to deploy, check status, manage maintenance mode, create/list/run/stop/send/archive/clone agents, or control schedules for any project.
 ---
 
 # Tycho CLI Skill
@@ -18,6 +18,14 @@ Manage Kamal-deployed projects, managed agents, and scheduled runs via the `tych
 | | `app live <project-key>` | Resume live traffic |
 | **project** | `project update <project-key> --pr-url <url>` | Set / clear open PR URL |
 | **agent** | `agent create <project-key> <prompt>` | Create (and optionally run) a managed agent |
+| | `agent list [<project-key>]` | List agents, optionally filtered by project |
+| | `agent status <agent-key>` | Show full status and metadata |
+| | `agent run <agent-key>` | Start or re-run an existing agent |
+| | `agent stop <agent-key>` | Stop a running agent |
+| | `agent logs <agent-key>` | Print agent log |
+| | `agent send <agent-key> <message>` | Append a message and re-run the agent |
+| | `agent archive <agent-key>` | Archive an agent and move its logs |
+| | `agent clone <agent-key>` | Clone an existing agent |
 | **schedule** | `schedule list` | List all schedules and daemon status |
 | | `schedule validate` | Validate schedule config |
 | | `schedule run <schedule-key>` | Trigger a schedule immediately |
@@ -29,18 +37,11 @@ Manage Kamal-deployed projects, managed agents, and scheduled runs via the `tych
 
 ## `tycho agent create`
 
-Create a new managed agent for a project. This is the primary command for programmatically launching coding agents.
+Create a new managed agent for a project.
 
 ```
 tycho agent create <project-key> <prompt> [options]
 ```
-
-### Arguments
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `project-key` | Yes | Key of the target project (see `app list` or `hq.yml`) |
-| `prompt` | Yes | Initial system prompt / task description for the agent |
 
 ### Options
 
@@ -49,60 +50,124 @@ tycho agent create <project-key> <prompt> [options]
 | `--model MODEL` | Model override, e.g. `claude-opus-4-5`, `o4-mini` |
 | `--harness HARNESS` | Agent harness, e.g. `claude`, `codex` (defaults to project default) |
 | `--name NAME` | Override auto-generated agent name |
-| `--template KEY` | Template key to use (defaults to project's first template) |
+| `--template KEY` | Template key (defaults to project's first template) |
 | `--run` | Start the agent immediately after creation |
 
-### Examples
-
 ```bash
-# Create an agent (does not start it)
+# Create only
 tycho agent create my-project "Refactor the auth module to use JWT"
 
 # Create and start immediately
 tycho agent create my-project "Fix failing tests in spec/models" --run
 
-# Use a specific model and harness
-tycho agent create global-web "Review open PRs and summarise findings" \
-  --harness claude --model claude-opus-4-5 --run
-
-# Use a specific template
-tycho agent create fizzy "Write release notes for this sprint" \
-  --template release --run
+# Specify harness and model
+tycho agent create global-web "Review open PRs" --harness claude --model claude-opus-4-5 --run
 ```
 
-### Output
+---
 
-```
-Created agent my-project-agent-7
-  Name:    My Project custom 7
-  Project: my-project
-  Harness: claude
-  Model:   claude-opus-4-5
-  Prompt:  Refactor the auth module to use JWT
-  Status:  running (pid 12345)          # only shown with --run
-  Log:     ~/.tycho/logs/agents/...     # only shown with --run
+## `tycho agent list`
+
+List all managed agents, or filter to one project.
+
+```bash
+tycho agent list                  # all agents
+tycho agent list my-project       # only agents for my-project
 ```
 
-The agent key (`my-project-agent-7`) can be used to locate logs under `~/.tycho/logs/agents/`.
+Output columns: Key, Project, Name, Harness, Status, Runs.
+
+---
+
+## `tycho agent status`
+
+Full status table for a single agent — pid, model, harness, run count, start/finish times, exit code, workspace, log path.
+
+```bash
+tycho agent status my-project-agent-3
+```
+
+---
+
+## `tycho agent run`
+
+Start or re-run an existing agent (same as `create --run` but for agents that already exist).
+
+```bash
+tycho agent run my-project-agent-3
+```
+
+Prints the pid and log path on success.
+
+---
+
+## `tycho agent stop`
+
+Send SIGTERM to a running agent's process group.
+
+```bash
+tycho agent stop my-project-agent-3
+```
+
+Errors if the agent is not currently running.
+
+---
+
+## `tycho agent logs`
+
+Print the agent's log file. Three log types are available.
+
+```bash
+tycho agent logs my-project-agent-3                        # raw stream (default)
+tycho agent logs my-project-agent-3 --type conversation    # user/assistant turns
+tycho agent logs my-project-agent-3 --type system         # tool calls and events
+tycho agent logs my-project-agent-3 --follow              # tail -f the raw log
+```
+
+---
+
+## `tycho agent send`
+
+Append a user message to the agent's conversation and start it. This is the primary command for multi-turn agent interactions from the CLI.
+
+```bash
+tycho agent send my-project-agent-3 "The tests still fail on line 42 — try a different approach"
+```
+
+Errors if the agent is already running. Prints pid and log path on success.
+
+---
+
+## `tycho agent archive`
+
+Archive a stopped agent — moves all its log files to the archive directory and removes it from the active agents list.
+
+```bash
+tycho agent archive my-project-agent-3
+```
+
+Errors if the agent is currently running.
+
+---
+
+## `tycho agent clone`
+
+Clone an existing agent (copies prompt, harness, model, template). The clone gets a new key and a fresh run history.
+
+```bash
+tycho agent clone my-project-agent-3          # clone only
+tycho agent clone my-project-agent-3 --run    # clone and start immediately
+```
 
 ---
 
 ## `tycho app` — Deployment Commands
 
 ```bash
-# List all Kamal-enabled projects
 tycho app list
-
-# Check health, last action, and metadata
 tycho app status my-project
-
-# Trigger a deploy (detached, logs to ~/.tycho/logs/projects/my-project/action.log)
 tycho app deploy my-project
-
-# Enable maintenance mode
 tycho app maintenance my-project
-
-# Resume live traffic
 tycho app live my-project
 ```
 
@@ -113,20 +178,11 @@ Actions run as detached background processes. Check progress via `app status` or
 ## `tycho schedule` — Schedule Management
 
 ```bash
-# Show all schedules and daemon status
 tycho schedule list
-
-# Validate config without running
 tycho schedule validate
-
-# Fire a schedule right now (ignores cron timing)
 tycho schedule run weekly-review
-
-# Pause / resume
 tycho schedule pause weekly-review
 tycho schedule resume weekly-review
-
-# Signal the daemon to reload config on next tick
 tycho schedule reload
 ```
 
@@ -135,21 +191,17 @@ tycho schedule reload
 ## `tycho project update`
 
 ```bash
-# Set the open PR URL shown in the TUI
 tycho project update my-project --pr-url https://github.com/org/repo/pull/123
-
-# Clear the PR URL
-tycho project update my-project --pr-url ""
+tycho project update my-project --pr-url ""   # clear
 ```
 
 ---
 
 ## Project Keys
 
-Project keys are defined in `~/.tycho/config/hq.yml`. Use `tycho app list` to see keys for Kamal-enabled projects. Agent-only projects (no Kamal) do not appear in `app list` — read the config directly if needed:
-
 ```bash
-grep "^- key:" ~/.tycho/config/hq.yml
+tycho app list                              # Kamal-enabled projects
+grep "^- key:" ~/.tycho/config/hq.yml      # all projects (including agent-only)
 ```
 
 ---
@@ -171,5 +223,8 @@ grep "^- key:" ~/.tycho/config/hq.yml
 
 1. **Find the project key** — `tycho app list` or `grep "^- key:" ~/.tycho/config/hq.yml`
 2. **Create the agent** — `tycho agent create <key> "<task>" [--harness claude] [--run]`
-3. **Monitor** — tail `~/.tycho/logs/agents/<key>.raw.log`, or open the TUI (`tycho`)
-4. **Deploy / maintenance** — `tycho app deploy <key>` / `tycho app maintenance <key>`
+3. **Check status** — `tycho agent status <agent-key>` or `tycho agent list <project-key>`
+4. **Read output** — `tycho agent logs <agent-key> --type conversation`
+5. **Continue the conversation** — `tycho agent send <agent-key> "<follow-up>"`
+6. **Stop if needed** — `tycho agent stop <agent-key>`
+7. **Clean up** — `tycho agent archive <agent-key>`

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -152,8 +152,116 @@ module HQ
         end
       end
 
+      class AgentList < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "List managed agents"
+        argument :project_key, required: false, desc: "Filter by project key"
+        usage_template "agent list [%{project_key}]"
+
+        def call(**opts)
+          exit CLICommand.list_agents(opts[:project_key], out: out, err: err)
+        end
+      end
+
+      class AgentStatus < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Show status and metadata for an agent"
+        argument :agent_key, required: true, desc: "Agent key"
+        usage_template "agent status %{agent_key}"
+
+        def call(agent_key:, **)
+          exit CLICommand.agent_status(agent_key, out: out, err: err)
+        end
+      end
+
+      class AgentRun < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Start (or re-run) an existing agent"
+        argument :agent_key, required: true, desc: "Agent key"
+        usage_template "agent run %{agent_key}"
+
+        def call(agent_key:, **)
+          exit CLICommand.run_agent(agent_key, out: out, err: err)
+        end
+      end
+
+      class AgentStop < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Stop a running agent"
+        argument :agent_key, required: true, desc: "Agent key"
+        usage_template "agent stop %{agent_key}"
+
+        def call(agent_key:, **)
+          exit CLICommand.stop_agent(agent_key, out: out, err: err)
+        end
+      end
+
+      class AgentLogs < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Print agent log (raw stream by default)"
+        argument :agent_key, required: true, desc: "Agent key"
+        option :type, default: "raw", desc: "Log type: raw, conversation, system"
+        option :follow, type: :boolean, default: false, desc: "Follow the log (like tail -f)"
+        usage_template "agent logs %{agent_key}"
+
+        def call(agent_key:, **opts)
+          exit CLICommand.agent_logs(agent_key, opts, out: out, err: err)
+        end
+      end
+
+      class AgentSend < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Send a message to an agent and re-run it"
+        argument :agent_key, required: true, desc: "Agent key"
+        argument :message, required: true, desc: "Message to send"
+        usage_template "agent send %{agent_key} %{message}"
+
+        def call(agent_key:, message:, **)
+          exit CLICommand.send_agent_message(agent_key, message, out: out, err: err)
+        end
+      end
+
+      class AgentArchive < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Archive an agent and move its logs"
+        argument :agent_key, required: true, desc: "Agent key"
+        usage_template "agent archive %{agent_key}"
+
+        def call(agent_key:, **)
+          exit CLICommand.archive_agent(agent_key, out: out, err: err)
+        end
+      end
+
+      class AgentClone < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Clone an existing agent"
+        argument :agent_key, required: true, desc: "Agent key to clone"
+        option :run, type: :boolean, default: false, desc: "Start the cloned agent immediately"
+        usage_template "agent clone %{agent_key}"
+
+        def call(agent_key:, **opts)
+          exit CLICommand.clone_agent(agent_key, opts, out: out, err: err)
+        end
+      end
+
       register "agent", Agent do |prefix|
         prefix.register "create", AgentCreate
+        prefix.register "list", AgentList
+        prefix.register "status", AgentStatus
+        prefix.register "run", AgentRun
+        prefix.register "stop", AgentStop
+        prefix.register "logs", AgentLogs
+        prefix.register "send", AgentSend
+        prefix.register "archive", AgentArchive
+        prefix.register "clone", AgentClone
       end
 
       class Schedule < Dry::CLI::Command
@@ -255,7 +363,15 @@ module HQ
       Commands::ProjectUpdate
     ].freeze
     AGENT_COMMANDS = [
-      Commands::AgentCreate
+      Commands::AgentCreate,
+      Commands::AgentList,
+      Commands::AgentStatus,
+      Commands::AgentRun,
+      Commands::AgentStop,
+      Commands::AgentLogs,
+      Commands::AgentSend,
+      Commands::AgentArchive,
+      Commands::AgentClone,
     ].freeze
     SCHEDULE_COMMANDS = [
       Commands::ScheduleValidate,
@@ -278,7 +394,10 @@ module HQ
       *RUNTIME_COMMANDS,
       *APP_COMMANDS.map { |command| "  #{COMMAND_NAME} #{format(command.usage_template, project_key: "<project-key>")}" },
       *PROJECT_COMMANDS.map { |command| "  #{COMMAND_NAME} #{format(command.usage_template, project_key: "<project-key>")}" },
-      *AGENT_COMMANDS.map { |command| "  #{COMMAND_NAME} #{format(command.usage_template, project_key: "<project-key>", prompt: "<prompt>")}" },
+      *AGENT_COMMANDS.map { |command|
+        template = command.usage_template
+        "  #{COMMAND_NAME} #{format(template, project_key: "<project-key>", agent_key: "<agent-key>", prompt: "<prompt>", message: "<message>")}"
+      },
       *SCHEDULE_COMMANDS.map { |command| "  #{COMMAND_NAME} #{format(command.usage_template, schedule_key: "<schedule-key>")}" },
       "",
       "Run without a command to open the interactive Tycho TUI."
@@ -577,6 +696,184 @@ module HQ
       failure("Failed to create agent: #{e.message}", err: err)
     end
 
+    def list_agents(project_key, out: $stdout, err: $stderr)
+      agents = load_all_agents
+      agents = agents.select { |a| a.project_key == project_key.to_s } if project_key
+      if agents.empty?
+        out.puts project_key ? "No agents for project: #{project_key}" : "No agents found."
+        return 0
+      end
+      headers = %w[Key Project Name Harness Status Runs]
+      rows = agents.map do |a|
+        [a.key, a.project_key, a.name, a.agent, a.status, a.run_count.to_s]
+      end
+      out.puts agent_table(headers, rows)
+      0
+    rescue StandardError => e
+      failure("Failed to list agents: #{e.message}", err: err)
+    end
+
+    def agent_status(agent_key, out: $stdout, err: $stderr)
+      agent = load_all_agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless agent
+
+      last = agent.last_run
+      rows = [
+        ["Key", agent.key],
+        ["Name", agent.name],
+        ["Project", agent.project_key],
+        ["Harness", agent.agent],
+        ["Model", agent.model || "(project default)"],
+        ["Status", agent.status],
+        ["PID", agent.pid ? agent.pid.to_s : "n/a"],
+        ["Runs", agent.run_count.to_s],
+        ["Started", agent.started_at ? agent.started_at.strftime("%Y-%m-%d %H:%M:%S") : "n/a"],
+        ["Finished", agent.finished_at ? agent.finished_at.strftime("%Y-%m-%d %H:%M:%S") : "n/a"],
+        ["Exit code", agent.last_exit_code ? agent.last_exit_code.to_s : "n/a"],
+        ["Last run", last ? last.started_at&.strftime("%Y-%m-%d %H:%M:%S") || "n/a" : "n/a"],
+        ["Workspace", agent.workspace],
+        ["Log", agent.raw_log_path || "n/a"],
+      ]
+      table = Lipgloss::Table.new
+        .rows(rows)
+        .border_style(Lipgloss::Style.new.foreground(COLORS[:accent_alt]))
+        .style_func(rows: rows.length, columns: 2) { |_row, column|
+          column.zero? ? Lipgloss::Style.new.bold(true).foreground(COLORS[:notice]) : Lipgloss::Style.new.foreground(COLORS[:text])
+        }
+      out.puts table.render
+      0
+    rescue StandardError => e
+      failure("Failed to get agent status: #{e.message}", err: err)
+    end
+
+    def run_agent(agent_key, out: $stdout, err: $stderr)
+      agent = load_all_agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless agent
+      return failure("Agent #{agent_key} is already running", err: err) if agent.running?
+
+      agent.start!
+      save_agent_in_store(agent)
+      if agent.running?
+        out.puts "Started #{agent.key} (pid #{agent.pid})"
+        out.puts "Log: #{agent.raw_log_path}"
+      else
+        out.puts "Failed to start #{agent.key}"
+        return 1
+      end
+      0
+    rescue StandardError => e
+      failure("Failed to run agent: #{e.message}", err: err)
+    end
+
+    def stop_agent(agent_key, out: $stdout, err: $stderr)
+      agent = load_all_agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless agent
+      return failure("Agent #{agent_key} is not running", err: err) unless agent.running?
+
+      agent.stop!
+      save_agent_in_store(agent)
+      out.puts "Stopped #{agent.key}"
+      0
+    rescue StandardError => e
+      failure("Failed to stop agent: #{e.message}", err: err)
+    end
+
+    def agent_logs(agent_key, opts, out: $stdout, err: $stderr)
+      agent = load_all_agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless agent
+
+      log_path = case opts[:type].to_s
+                 when "conversation" then agent.conversation_log_path
+                 when "system" then agent.system_log_path
+                 else agent.raw_log_path
+                 end
+
+      return failure("Log file not found: #{log_path}", err: err) unless log_path && File.exist?(log_path)
+
+      if opts[:follow]
+        exec("tail", "-f", log_path)
+      else
+        out.puts File.read(log_path)
+      end
+      0
+    rescue StandardError => e
+      failure("Failed to read agent logs: #{e.message}", err: err)
+    end
+
+    def send_agent_message(agent_key, message, out: $stdout, err: $stderr)
+      agent = load_all_agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless agent
+      return failure("Agent #{agent_key} is already running", err: err) if agent.running?
+
+      agent.add_user_message!(message)
+      agent.start!
+      save_agent_in_store(agent)
+      if agent.running?
+        out.puts "Message sent and agent started (pid #{agent.pid})"
+        out.puts "Log: #{agent.raw_log_path}"
+      else
+        out.puts "Message saved but agent failed to start"
+        return 1
+      end
+      0
+    rescue StandardError => e
+      failure("Failed to send message: #{e.message}", err: err)
+    end
+
+    def archive_agent(agent_key, out: $stdout, err: $stderr)
+      agents = load_all_agents
+      agent = agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless agent
+      return failure("Agent #{agent_key} is running — stop it first", err: err) if agent.running?
+
+      archive_path = agent.archive_logs!
+      remaining = agents.reject { |a| a.key == agent_key.to_s }
+      agent_store_for_all.save(remaining)
+      out.puts "Archived #{agent.key}"
+      out.puts "Archive: #{archive_path}" if archive_path
+      0
+    rescue StandardError => e
+      failure("Failed to archive agent: #{e.message}", err: err)
+    end
+
+    def clone_agent(agent_key, opts, out: $stdout, err: $stderr)
+      require_relative "registry"
+
+      registry = Registry.new
+      agents = load_all_agents
+      source = agents.find { |a| a.key == agent_key.to_s }
+      return failure("Unknown agent: #{agent_key}", err: err) unless source
+
+      store = AgentStore.new(registry.projects)
+      clone = store.clone_agent(source, existing_agents: agents)
+
+      project = registry.projects.find { |p| p.key == clone.project_key }
+      store.ensure_project_context_prompt!(clone, project) if project
+
+      agents.unshift(clone)
+      store.save(agents)
+
+      out.puts "Cloned #{source.key} → #{clone.key}"
+      out.puts "  Name:    #{clone.name}"
+      out.puts "  Harness: #{clone.agent}"
+      out.puts "  Model:   #{clone.model || "(project default)"}"
+
+      if opts[:run]
+        clone.start!
+        store.save(store.load.map { |a| a.key == clone.key ? clone : a })
+        if clone.running?
+          out.puts "  Status:  running (pid #{clone.pid})"
+          out.puts "  Log:     #{clone.raw_log_path}"
+        else
+          out.puts "  Status:  start failed"
+          return 1
+        end
+      end
+      0
+    rescue StandardError => e
+      failure("Failed to clone agent: #{e.message}", err: err)
+    end
+
     def validate_schedules(out: $stdout, err: $stderr)
       scheduler.validate!
       out.puts "Schedules valid."
@@ -705,6 +1002,47 @@ module HQ
 
     def native_lipgloss_features
       $LOADED_FEATURES.grep(%r{/lipgloss/\d+\.\d+/lipgloss\.(?:bundle|so)\z})
+    end
+
+    def load_all_agents
+      return [] unless File.exist?(AGENTS_FILE)
+
+      JSON.parse(File.read(AGENTS_FILE)).map { |hash| ManagedAgent.from_hash(hash) }
+    rescue StandardError
+      []
+    end
+
+    def agent_store_for_all
+      require_relative "registry"
+
+      AgentStore.new(Registry.new.projects)
+    end
+
+    def save_agent_in_store(agent)
+      agents = load_all_agents
+      idx = agents.index { |a| a.key == agent.key }
+      if idx
+        agents[idx] = agent
+      else
+        agents.unshift(agent)
+      end
+      agent_store_for_all.save(agents)
+    end
+
+    def agent_table(headers, rows)
+      Lipgloss::Table.new
+        .headers(headers)
+        .rows(rows)
+        .border_style(Lipgloss::Style.new.foreground(COLORS[:accent_alt]))
+        .style_func(rows: rows.length, columns: headers.length) do |row, column|
+          if row == Lipgloss::Table::HEADER_ROW
+            Lipgloss::Style.new.bold(true).foreground(COLORS[:accent])
+          elsif column.zero?
+            Lipgloss::Style.new.bold(true).foreground(COLORS[:notice])
+          else
+            Lipgloss::Style.new.foreground(COLORS[:text])
+          end
+        end.render
     end
 
     def find_app_project(project_key)


### PR DESCRIPTION
## Summary

- Adds 8 new `tycho agent` subcommands: `list`, `status`, `run`, `stop`, `logs`, `send`, `archive`, `clone`
- Together with the existing `agent create --run`, this gives a complete observability and control loop for managed agents entirely from the CLI
- Updates `.claude/skills/tycho/SKILL.md` with the full new surface (also synced to `~/.claude/skills/tycho/`)

## New commands

| Command | Description |
|---------|-------------|
| `agent list [project-key]` | Table of all agents, filterable by project |
| `agent status <key>` | Full metadata: pid, model, runs, times, exit code, log path |
| `agent run <key>` | Start or re-run an existing agent |
| `agent stop <key>` | SIGTERM a running agent's process group |
| `agent logs <key> [--type raw\|conversation\|system] [--follow]` | Read agent logs |
| `agent send <key> <message>` | Append a user message and re-run (multi-turn CLI driver) |
| `agent archive <key>` | Move logs to archive dir and remove from store |
| `agent clone <key> [--run]` | Clone an existing agent with a fresh run history |

## Test plan

- [x] `bin/test` passes
- [x] `tycho --help` shows all 9 agent subcommands
- [x] `tycho agent list secondbrain` — table renders correctly
- [x] `tycho agent status secondbrain-agent-25` — full metadata table renders correctly
- [x] Syntax check: `bundle exec ruby -c lib/hq/cli_command.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)