### PR TITLE
[codex] Add quick agent remote UI

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -648,6 +648,13 @@ h3 {
   flex: 0 0 auto;
 }
 
+.agent-toolbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
 .compact-actions button {
   padding: 7px 9px;
 }
@@ -1559,10 +1566,11 @@ select {
 .agent-sort-menu {
   position: relative;
   flex: 0 0 auto;
-  margin-left: auto;
 }
 
-.agent-sort-trigger {
+.agent-sort-trigger,
+.agent-bulk-select-button,
+.agent-bulk-trigger {
   display: inline-grid;
   width: 42px;
   min-width: 42px;
@@ -1575,27 +1583,43 @@ select {
   cursor: pointer;
 }
 
-.agent-sort-trigger::-webkit-details-marker {
+.agent-sort-trigger::-webkit-details-marker,
+.agent-bulk-trigger::-webkit-details-marker {
   display: none;
 }
 
-.agent-sort-trigger::marker {
+.agent-sort-trigger::marker,
+.agent-bulk-trigger::marker {
   content: "";
 }
 
 .agent-sort-menu[open] .agent-sort-trigger,
+.agent-bulk-menu[open] .agent-bulk-trigger,
+.agent-bulk-select-button.active,
 .agent-sort-trigger:hover,
-.agent-sort-trigger:focus-visible {
+.agent-sort-trigger:focus-visible,
+.agent-bulk-trigger:hover,
+.agent-bulk-trigger:focus-visible,
+.agent-bulk-select-button:hover,
+.agent-bulk-select-button:focus-visible {
   border-color: var(--accent);
   background: var(--panel-soft);
 }
 
-.agent-sort-trigger .ui-icon {
+.agent-sort-trigger .ui-icon,
+.agent-bulk-select-button .ui-icon,
+.agent-bulk-trigger .ui-icon {
   width: 16px;
   height: 16px;
 }
 
-.agent-sort-options {
+.agent-bulk-menu {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.agent-sort-options,
+.agent-bulk-options {
   position: absolute;
   z-index: 18;
   top: calc(100% + 6px);
@@ -1608,6 +1632,10 @@ select {
   background: var(--panel);
   box-shadow: var(--shadow);
   padding: 4px;
+}
+
+.agent-bulk-options {
+  width: min(72vw, 240px);
 }
 
 .agent-sort-option {
@@ -3545,4 +3573,174 @@ select {
 
 @keyframes poll-refresh-hourglass {
   to { transform: rotate(.5turn); }
+}
+
+/* ---- Quick Agent ---- */
+
+.quick-agent-fab {
+  position: fixed;
+  right: 20px;
+  bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent, #ff79c6);
+  color: var(--text-inverse, #0a0a0a);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, .35);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.quick-agent-fab:hover { transform: translateY(-1px); box-shadow: 0 8px 22px rgba(0, 0, 0, .45); }
+.quick-agent-fab:active { transform: translateY(0); }
+.quick-agent-fab.hidden { display: none; }
+.quick-agent-fab .ui-icon { width: 24px; height: 24px; stroke-width: 2.5; }
+
+.quick-agent-dialog {
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  max-width: none;
+  max-height: none;
+}
+.quick-agent-dialog::backdrop {
+  background: rgba(0, 0, 0, .55);
+  backdrop-filter: blur(2px);
+}
+
+.quick-agent-form {
+  width: min(560px, calc(100vw - 32px));
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 12px;
+  background: var(--panel, #282a36);
+  color: var(--text, #f8f8f2);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, .55);
+}
+
+.quick-agent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.quick-agent-header strong { font-size: 1rem; }
+
+.quick-agent-project-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: .875rem;
+  color: var(--text-muted, #6272a4);
+}
+.quick-agent-project-row select {
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-2, #1f2029);
+  color: var(--text, #f8f8f2);
+}
+.quick-agent-project-static { color: var(--text, #f8f8f2); font-weight: 600; }
+
+.quick-agent-prompt {
+  width: 100%;
+  resize: vertical;
+  min-height: 96px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2, #1f2029);
+  color: var(--text, #f8f8f2);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.quick-agent-options-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.quick-agent-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text, #f8f8f2);
+  cursor: pointer;
+  font-size: .875rem;
+}
+.quick-agent-toggle-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  font-weight: 700;
+}
+
+.quick-agent-pill {
+  font-size: .75rem;
+  color: var(--text-muted, #6272a4);
+}
+
+.quick-agent-advanced {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+.quick-agent-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: .75rem;
+  color: var(--text-muted, #6272a4);
+}
+.quick-agent-field select {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-2, #1f2029);
+  color: var(--text, #f8f8f2);
+}
+
+/* Mobile: bottom sheet */
+@media (max-width: 640px) {
+  .quick-agent-dialog {
+    margin: 0;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    max-height: 100%;
+  }
+  .quick-agent-dialog[open] {
+    position: fixed;
+    inset: auto 0 0 0;
+  }
+  .quick-agent-form {
+    width: 100%;
+    max-height: 90vh;
+    border-radius: 16px 16px 0 0;
+    padding: 16px 16px calc(16px + env(safe-area-inset-bottom, 0px));
+  }
+  .quick-agent-advanced {
+    grid-template-columns: 1fr;
+  }
 }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -399,6 +399,12 @@ const ICONS = {
       <path d="m9 15 6-6"></path>
     </svg>
   `,
+  squareCheckBig: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M21 10.656V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h12.344"></path>
+      <path d="m9 11 3 3L22 4"></path>
+    </svg>
+  `,
   squareUserRound: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="M18 21a6 6 0 0 0-12 0"></path>
@@ -503,6 +509,8 @@ const els = {
   saveToken: document.getElementById("save-token-button"),
   view: document.getElementById("view"),
   nav: document.getElementById("bottom-nav"),
+  quickAgentFab: document.getElementById("quick-agent-fab"),
+  quickAgentDialog: document.getElementById("quick-agent-dialog"),
 };
 
 syncPlatformClasses();
@@ -1225,6 +1233,7 @@ function render() {
   els.back.classList.toggle("hidden", !subpage);
   els.header.classList.toggle("hidden", onboarding);
   els.nav.classList.toggle("hidden", subpage || onboarding);
+  syncQuickAgentFab(route, onboarding);
   els.view.classList.toggle("no-nav", subpage || onboarding);
   els.view.classList.toggle("onboarding-content", onboarding);
   els.view.classList.toggle("detail-page", subpage && !onboarding);
@@ -1716,6 +1725,7 @@ function renderNow() {
   const unread = state.agents.filter((agent) => agent.unread && !agent.awaiting_input && !agent.blocked && !agent.running);
   const scheduleSection = renderScheduleNowSection();
   setHeader("Needs attention", connectionText(), "HQ");
+  setMainHeaderMore("now");
 
   if (waiting.length === 0 && blocked.length === 0 && running.length === 0 && unread.length === 0 && !scheduleSection) {
     replaceView(`
@@ -2051,11 +2061,8 @@ function renderAgents(options = {}) {
   const groups = groupMode ? agentProjectGroups(query) : [];
   const flatAgents = groupMode ? [] : sortedAgentList(query);
   const unread = state.agents.filter((agent) => agent.unread).length;
-  const selectedCount = selectedBulkArchiveKeys().length;
-  const moreLabel = selectedCount ? `Agent list actions, ${selectedCount} selected` : "Agent list actions";
-  const moreBadge = selectedCount ? compactCount(selectedCount) : "";
   setHeader("Agents", `${state.agents.length} managed / ${state.projects.length} projects / ${unread} unread`, "A");
-  setHeaderMore(agentsMoreMenuHtml(), moreLabel, "agents", moreBadge);
+  setMainHeaderMore("agents");
 
   replaceView(`
     <div class="top-actions">
@@ -2063,7 +2070,10 @@ function renderAgents(options = {}) {
         <span class="nav-mark" aria-hidden="true">${iconSvg("search")}</span>
         <input id="agent-filter" type="search" value="${escapeAttr(state.filters.agents)}" placeholder="Filter agents and projects" aria-label="Filter agents and projects" data-filter="agents">
       </label>
-      ${agentSortMenuHtml()}
+      <div class="agent-toolbar-actions">
+        ${agentSortMenuHtml()}
+        ${agentBulkControlsHtml()}
+      </div>
     </div>
     ${renderBulkArchiveBar()}
     ${groupMode
@@ -2097,31 +2107,48 @@ function agentSortMenuHtml() {
   `;
 }
 
-function agentsMoreMenuHtml() {
+function agentBulkControlsHtml() {
   if (!state.agents.length) return "";
 
+  const active = state.bulkArchiveMode;
+  return `
+    <button
+      class="agent-bulk-select-button ${active ? "active" : ""}"
+      type="button"
+      data-toggle-bulk-archive
+      aria-label="${active ? "Cancel agent selection" : "Select agents"}"
+      title="${active ? "Cancel selection" : "Select agents"}"
+      aria-pressed="${active ? "true" : "false"}"
+    >
+      ${iconSvg("squareCheckBig")}
+      <span class="sr-only">${active ? "Cancel selection" : "Select agents"}</span>
+    </button>
+    ${active ? agentBulkActionMenuHtml() : ""}
+  `;
+}
+
+function agentBulkActionMenuHtml() {
   const selected = selectedBulkArchiveKeys();
-  const toggleLabel = state.bulkArchiveMode ? "Cancel selection" : "Select agents";
-  const toggleIcon = state.bulkArchiveMode ? "x" : "archive";
   const selectedLabel = selected.length === 1 ? "1 selected" : `${selected.length} selected`;
 
-  return moreMenuHtml([
-    moreMenuButton({
-      label: toggleLabel,
-      icon: toggleIcon,
-      attrs: "data-toggle-bulk-archive",
-    }),
-    state.bulkArchiveMode
-      ? moreMenuButton({
-          label: "Archive selected",
+  return `
+    <details class="agent-bulk-menu" data-agent-bulk-menu>
+      <summary class="agent-bulk-trigger" aria-label="Bulk agent actions" title="Bulk agent actions">
+        ${iconSvg("ellipsis")}
+        <span class="sr-only">Bulk agent actions</span>
+      </summary>
+      <div class="agent-bulk-options" role="menu" aria-label="Bulk agent actions">
+        ${moreMenuButton({
+          label: "Archive agents",
           sublabel: selectedLabel,
           icon: "archive",
           attrs: "data-run-bulk-archive",
           danger: true,
           disabled: selected.length === 0,
-        })
-      : "",
-  ]);
+        })}
+      </div>
+    </details>
+  `;
 }
 
 function settingsMoreMenuHtml(setup) {
@@ -2245,7 +2272,7 @@ function renderSetup() {
     return;
   }
 
-  setHeaderMore(settingsMoreMenuHtml(setup), "Settings actions", "settings");
+  setMainHeaderMore("settings");
   const displayUrl = setup.public_ui_url || setup.ui_url || location.href;
   replaceView(`
     <section class="summary-card">
@@ -5172,6 +5199,15 @@ function setHeaderMore(content, label = "More actions", key = state.headerMoreKe
   syncDetailHeaderLayout();
 }
 
+function setMainHeaderMore(key) {
+  if (!state.setup) {
+    setHeaderMore(null, "Settings actions", key);
+    return;
+  }
+
+  setHeaderMore(settingsMoreMenuHtml(state.setup), "Settings actions", key);
+}
+
 function renderHeaderMore() {
   const hasMenu = Boolean(state.headerMoreContent);
   els.headerMore.classList.toggle("hidden", !hasMenu);
@@ -6520,6 +6556,9 @@ els.view.addEventListener("click", (event) => {
   if (!event.target.closest("[data-agent-sort-menu]")) {
     closeAgentSortMenu();
   }
+  if (!event.target.closest("[data-agent-bulk-menu]")) {
+    closeAgentBulkMenu();
+  }
 
   if (!event.target.closest("[data-toggle-block-menu]") && !event.target.closest(".block-menu-popover")) {
     closeBlockMenu();
@@ -7641,6 +7680,10 @@ function closeAgentSortMenu() {
   document.querySelector("[data-agent-sort-menu]")?.removeAttribute("open");
 }
 
+function closeAgentBulkMenu() {
+  document.querySelector("[data-agent-bulk-menu]")?.removeAttribute("open");
+}
+
 function closeBlockMenu() {
   if (state.openBlockMenu === null) return;
   state.openBlockMenu = null;
@@ -7848,3 +7891,354 @@ refresh({ force: true });
     pulling = false;
   }, { passive: true });
 })();
+
+// ---- Quick Agent ----
+
+function syncQuickAgentFab(route, onboarding) {
+  if (!els.quickAgentFab) return;
+  const hide = onboarding ||
+    !state.projects.length ||
+    route?.type === "agent" ||
+    route?.type === "agentSummary" ||
+    route?.type === "agentAttachment" ||
+    route?.type === "agentPullRequests" ||
+    route?.type === "attachment" ||
+    route?.type === "agentForm" ||
+    route?.type === "agentArchive";
+  els.quickAgentFab.classList.toggle("hidden", hide);
+}
+
+function quickAgentEligibleProjects() {
+  // The /projects list payload doesn't carry agent_template_summaries —
+  // only the per-project detail does. Treat any visible project as eligible
+  // and let the per-project detail (or server fallback) supply the template.
+  return state.projects.slice();
+}
+
+function isTextEntryFocused() {
+  const el = document.activeElement;
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  if (tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (tag === "INPUT") {
+    const type = (el.type || "text").toLowerCase();
+    return !["button", "submit", "checkbox", "radio", "range", "color", "file", "reset"].includes(type);
+  }
+  return false;
+}
+
+function quickAgentInitialProject(route) {
+  const eligible = quickAgentEligibleProjects();
+  if (!eligible.length) return null;
+  if (route?.type === "project" && route.key) {
+    const match = eligible.find((p) => p.key === route.key);
+    if (match) return match;
+  }
+  if (route?.type === "agent" && route.key) {
+    const agent = findAgent(route.key);
+    if (agent?.project_key) {
+      const match = eligible.find((p) => p.key === agent.project_key);
+      if (match) return match;
+    }
+  }
+  return eligible[0];
+}
+
+async function openQuickAgent() {
+  if (!els.quickAgentDialog || !els.quickAgentDialog.showModal) return;
+  const route = parseRoute();
+  const initial = quickAgentInitialProject(route);
+  if (!initial) {
+    showGrowl("Add a project before spawning a quick agent.", "warning");
+    return;
+  }
+  try {
+    await ensureProject(initial.key);
+  } catch (error) {
+    showGrowl(`Project defaults unavailable: ${error.message}`, "warning");
+  }
+  renderQuickAgentDialog(initial.key);
+  if (els.quickAgentDialog.open) els.quickAgentDialog.close();
+  els.quickAgentDialog.showModal();
+  const prompt = els.quickAgentDialog.querySelector("#quick-agent-prompt");
+  if (prompt) prompt.focus();
+}
+
+function closeQuickAgent() {
+  if (!els.quickAgentDialog) return;
+  if (els.quickAgentDialog.open) els.quickAgentDialog.close();
+  els.quickAgentDialog.innerHTML = "";
+}
+
+function renderQuickAgentDialog(projectKey, options = {}) {
+  if (!els.quickAgentDialog) return;
+  const eligible = quickAgentEligibleProjects();
+  const listProject = eligible.find((p) => p.key === projectKey) || eligible[0];
+  const project = findProject(listProject?.key) || listProject;
+  if (!project) return;
+
+  const defaults = quickAgentProjectDefaults(project, options.templateKey || null);
+  const harness = normalizeAgentHarness(options.harness || defaults.harness);
+  const model = options.model !== undefined ? options.model : defaults.model;
+  const effort = options.effort !== undefined ? options.effort : defaults.effort;
+  const advancedOpen = Boolean(options.advancedOpen);
+  const promptValue = options.promptValue || "";
+
+  const projectOptions = eligible.length > 1
+    ? `<select id="quick-agent-project" data-quick-agent-project>
+         ${eligible.map((p) => `<option value="${escapeAttr(p.key)}" ${p.key === project.key ? "selected" : ""}>${escapeHtml(p.name || p.key)}</option>`).join("")}
+       </select>`
+    : `<span class="quick-agent-project-static">${escapeHtml(project.name || project.key)}</span>`;
+
+  const advancedHtml = advancedOpen ? `
+    <section class="quick-agent-advanced">
+      <label class="quick-agent-field">
+        <span>Harness</span>
+        <select id="quick-agent-harness" data-quick-agent-harness>
+          ${agentHarnessOptions().map((h) => `<option value="${escapeAttr(h)}" ${h === harness ? "selected" : ""}>${escapeHtml(h)}</option>`).join("")}
+        </select>
+      </label>
+      <label class="quick-agent-field">
+        <span>Model</span>
+        <select id="quick-agent-model" data-quick-agent-model>
+          ${modelChoiceOptions(harness, model)}
+        </select>
+      </label>
+      <label class="quick-agent-field">
+        <span>Effort</span>
+        <select id="quick-agent-effort" data-quick-agent-effort>
+          ${reasoningEffortChoiceOptions(harness, model, effort)}
+        </select>
+      </label>
+    </section>
+  ` : "";
+
+  const pillModel = model || "default";
+  const pillParts = [harness, pillModel];
+  if (effort) pillParts.push(effort);
+  const pill = pillParts.join(" · ");
+
+  els.quickAgentDialog.innerHTML = `
+    <form id="quick-agent-form" class="quick-agent-form" method="dialog" data-project-key="${escapeAttr(project.key)}">
+      <header class="quick-agent-header">
+        <strong>Quick Agent</strong>
+        <button type="button" class="icon-button" data-quick-agent-close aria-label="Close">
+          <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>
+        </button>
+      </header>
+      <label class="quick-agent-project-row">
+        <span>Project</span>
+        ${projectOptions}
+      </label>
+      <textarea id="quick-agent-prompt" class="quick-agent-prompt" rows="4" placeholder="Describe what the agent should do…" required>${escapeHtml(promptValue)}</textarea>
+      <div class="quick-agent-options-row">
+        <button type="button" class="quick-agent-toggle" data-quick-agent-toggle aria-expanded="${advancedOpen ? "true" : "false"}">
+          <span class="quick-agent-toggle-mark" aria-hidden="true">${advancedOpen ? "−" : "+"}</span>
+          <span>Options</span>
+        </button>
+        <span class="quick-agent-pill">${escapeHtml(pill)}</span>
+      </div>
+      ${advancedHtml}
+    </form>
+  `;
+}
+
+function quickAgentProjectDefaults(project, templateKey = null) {
+  const template = agentTemplateFor(project, templateKey);
+  return {
+    template,
+    harness: template?.agent || project?.agent || "",
+    model: template?.model || project?.model || "",
+    effort: template?.reasoning_effort || project?.reasoning_effort || "",
+    sandboxMode: template?.sandbox_mode || "",
+  };
+}
+
+function quickAgentReadState() {
+  const dialog = els.quickAgentDialog;
+  if (!dialog) return null;
+  const harnessControl = dialog.querySelector("[data-quick-agent-harness]");
+  const modelControl = dialog.querySelector("[data-quick-agent-model]");
+  const effortControl = dialog.querySelector("[data-quick-agent-effort]");
+  return {
+    projectKey: dialog.querySelector("[data-quick-agent-project]")?.value
+      || dialog.querySelector("#quick-agent-form")?.dataset.projectKey
+      || quickAgentEligibleProjects()[0]?.key
+      || "",
+    harness: harnessControl ? harnessControl.value : undefined,
+    model: modelControl ? modelControl.value : undefined,
+    effort: effortControl ? effortControl.value : undefined,
+    promptValue: dialog.querySelector("#quick-agent-prompt")?.value || "",
+    advancedOpen: dialog.querySelector("[data-quick-agent-toggle]")?.getAttribute("aria-expanded") === "true",
+  };
+}
+
+function quickAgentRerender(overrides = {}) {
+  const current = quickAgentReadState();
+  if (!current) return;
+  const next = { ...current, ...overrides };
+  renderQuickAgentDialog(next.projectKey, {
+    harness: next.harness,
+    model: next.model,
+    effort: next.effort,
+    promptValue: next.promptValue,
+    advancedOpen: next.advancedOpen,
+  });
+  const prompt = els.quickAgentDialog.querySelector("#quick-agent-prompt");
+  if (prompt) {
+    prompt.focus();
+    prompt.selectionStart = prompt.selectionEnd = prompt.value.length;
+  }
+}
+
+function deriveQuickAgentName(project, prompt) {
+  const words = String(prompt || "").trim().split(/\s+/).filter(Boolean).slice(0, 6).join(" ");
+  const base = words || "quick agent";
+  const fullName = project ? `${project.name || project.key} ${base}` : base;
+  return fullName.length > 60 ? `${fullName.slice(0, 57)}…` : fullName;
+}
+
+async function submitQuickAgent() {
+  const dialog = els.quickAgentDialog;
+  if (!dialog) return;
+  const promptInput = dialog.querySelector("#quick-agent-prompt");
+  const prompt = String(promptInput?.value || "").trim();
+  if (!prompt) {
+    promptInput?.focus();
+    return;
+  }
+  const projectKey = dialog.querySelector("[data-quick-agent-project]")?.value
+    || quickAgentEligibleProjects()[0]?.key;
+  const project = findProject(projectKey);
+  if (!project) return;
+  const defaults = quickAgentProjectDefaults(project);
+  const harness = normalizeAgentHarness(
+    dialog.querySelector("[data-quick-agent-harness]")?.value || defaults.harness
+  );
+  const model = (dialog.querySelector("[data-quick-agent-model]")?.value || "").trim();
+  const effort = (dialog.querySelector("[data-quick-agent-effort]")?.value || "").trim().toLowerCase();
+  const payload = {
+    project_key: project.key,
+    name: deriveQuickAgentName(project, prompt),
+    prompt,
+    agent: harness,
+    start: true,
+  };
+  if (defaults.template?.key) payload.template_key = defaults.template.key;
+  if (defaults.sandboxMode) payload.sandbox_mode = defaults.sandboxMode;
+  if (model) payload.model = model;
+  if (effort) payload.reasoning_effort = effort;
+
+  closeQuickAgent();
+  mutate(async () => {
+    const data = await apiPost("/agents", payload);
+    const nextAgent = data.agent;
+    if (nextAgent?.key) {
+      upsertAgent(nextAgent);
+      navigate({ type: "agent", key: nextAgent.key });
+    }
+  });
+}
+
+if (els.quickAgentFab) {
+  els.quickAgentFab.addEventListener("click", openQuickAgent);
+}
+
+if (els.quickAgentDialog) {
+  els.quickAgentDialog.addEventListener("click", (event) => {
+    if (event.target === els.quickAgentDialog) {
+      closeQuickAgent();
+      return;
+    }
+    if (event.target.closest("[data-quick-agent-close]")) {
+      event.preventDefault();
+      closeQuickAgent();
+      return;
+    }
+    if (event.target.closest("[data-quick-agent-toggle]")) {
+      event.preventDefault();
+      const current = quickAgentReadState();
+      if (current) quickAgentRerender({ advancedOpen: !current.advancedOpen });
+    }
+  });
+
+  els.quickAgentDialog.addEventListener("change", async (event) => {
+    const projectSelect = event.target.closest("[data-quick-agent-project]");
+    if (projectSelect) {
+      const newKey = projectSelect.value;
+      try {
+        await ensureProject(newKey);
+      } catch (error) {
+        showGrowl(`Project defaults unavailable: ${error.message}`, "warning");
+      }
+      const project = findProject(newKey);
+      const defaults = quickAgentProjectDefaults(project || {});
+      quickAgentRerender({
+        projectKey: newKey,
+        harness: normalizeAgentHarness(defaults.harness),
+        model: defaults.model,
+        effort: defaults.effort,
+      });
+      return;
+    }
+    const harnessSelect = event.target.closest("[data-quick-agent-harness]");
+    if (harnessSelect) {
+      const harness = normalizeAgentHarness(harnessSelect.value);
+      const dialog = els.quickAgentDialog;
+      const modelSelect = dialog.querySelector("[data-quick-agent-model]");
+      const effortSelect = dialog.querySelector("[data-quick-agent-effort]");
+      if (modelSelect) modelSelect.innerHTML = modelChoiceOptions(harness, modelSelect.value || "");
+      if (effortSelect) effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, modelSelect?.value || "", effortSelect.value || "");
+      return;
+    }
+    const modelSelect = event.target.closest("[data-quick-agent-model]");
+    if (modelSelect) {
+      const harnessSelect = els.quickAgentDialog.querySelector("[data-quick-agent-harness]");
+      const harness = normalizeAgentHarness(harnessSelect?.value);
+      const effortSelect = els.quickAgentDialog.querySelector("[data-quick-agent-effort]");
+      if (effortSelect) {
+        const defaultEffort = defaultReasoningEffortForModel(harness, modelSelect.value);
+        if (defaultEffort) effortSelect.value = defaultEffort;
+        effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, modelSelect.value, effortSelect.value || "");
+      }
+      // Live-update the pill
+      const pillEl = els.quickAgentDialog.querySelector(".quick-agent-pill");
+      if (pillEl) {
+        const parts = [harness, modelSelect.value || "default"];
+        if (effortSelect?.value) parts.push(effortSelect.value);
+        pillEl.textContent = parts.join(" · ");
+      }
+    }
+  });
+
+  els.quickAgentDialog.addEventListener("keydown", (event) => {
+    const inPrompt = event.target.id === "quick-agent-prompt";
+    if (event.key === "Enter" && inPrompt && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      submitQuickAgent();
+      return;
+    }
+    if (event.key === "Escape") {
+      // Native <dialog> already handles Escape, but ensure our close-up runs.
+      setTimeout(() => closeQuickAgent(), 0);
+    }
+  });
+
+  // Click outside the form (on dialog backdrop) to close.
+  els.quickAgentDialog.addEventListener("close", () => {
+    els.quickAgentDialog.innerHTML = "";
+  });
+}
+
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "c") return;
+  if (event.altKey || event.ctrlKey || event.metaKey) return;
+  if (isTextEntryFocused()) return;
+  if (els.quickAgentDialog?.open) return;
+  const route = parseRoute();
+  if (onboardingActive()) return;
+  if (route?.type === "agent" || route?.type === "agentForm" || route?.type === "agentArchive") return;
+  event.preventDefault();
+  openQuickAgent();
+});

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -71,6 +71,14 @@
 
       <main id="view" class="content" aria-live="polite"></main>
 
+      <button id="quick-agent-fab" class="quick-agent-fab hidden" type="button" aria-label="Quick agent" title="Quick agent (c)">
+        <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M12 5v14"></path>
+          <path d="M5 12h14"></path>
+        </svg>
+      </button>
+      <dialog id="quick-agent-dialog" class="quick-agent-dialog" aria-label="Quick agent"></dialog>
+
       <nav id="bottom-nav" class="bottom-nav" aria-label="Primary navigation">
         <button type="button" data-tab="now">
           <span class="nav-mark" aria-hidden="true">

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1630,6 +1630,8 @@ module RemoteServerTest
     assert(response[:body].include?("header-more-button"), "expected root shell to expose header More actions")
     assert(response[:body].include?('id="header-more-panel"'), "expected root shell to expose the header More menu panel")
     assert(response[:body].include?('id="header-more-badge"'), "expected root shell to expose the header More badge")
+    assert(response[:body].include?('id="quick-agent-fab"'), "expected root shell to expose Quick Agent launch")
+    assert(response[:body].include?('id="quick-agent-dialog"'), "expected root shell to expose Quick Agent modal")
     assert(response[:body].include?('data-tab="settings"'), "expected root shell to expose Settings navigation")
     assert(response[:body].include?("<span>Settings</span>"), "expected root shell to label setup navigation as Settings")
     assert(!response[:body].include?('data-tab="search"'), "expected root shell to remove Search navigation")
@@ -1693,7 +1695,7 @@ module RemoteServerTest
     assert(css[:body].include?(".more-menu-separator"),
            "expected Conversation More menu groups to support separators")
     assert(css[:body].include?(".header-more-badge"),
-           "expected Agents bulk selection count to render on the More button")
+           "expected header More menus to expose badge styling")
     assert(css[:body].include?("#header-more-button") && css[:body].include?("border: 0;"),
            "expected the header More button to be borderless")
     assert(css[:body].include?(".growl"), "expected Remote UI to style growl notifications")
@@ -1843,12 +1845,18 @@ module RemoteServerTest
            "expected bottom navigation to use the simplified three-tab layout")
     assert(css[:body].include?(".bulk-action-bar"),
            "expected Agents tab to style bulk archive controls")
+    assert(css[:body].include?(".quick-agent-fab"),
+           "expected Remote UI to style the Quick Agent floating action button")
+    assert(css[:body].include?(".quick-agent-dialog"),
+           "expected Remote UI to style the Quick Agent modal")
     assert(css[:body].include?(".top-actions .search-box"),
            "expected Agents tab search to flex inside the action row")
-    assert(css[:body].include?(".top-actions > button"),
-           "expected Agents tab actions to align independently from the search width")
-    assert(css[:body].include?("margin-left: auto;"),
-           "expected Agents tab action button to stay right aligned")
+    assert(css[:body].include?(".agent-toolbar-actions"),
+           "expected Agents tab toolbar actions to align independently from the search width")
+    assert(css[:body].include?(".agent-bulk-select-button"),
+           "expected Agents tab to style the icon-only bulk selection control")
+    assert(css[:body].include?(".agent-bulk-menu"),
+           "expected Agents tab to style bulk action dropdowns")
     assert(css[:body].include?(".selectable-agent-row"),
            "expected Agents tab to style selectable bulk archive rows")
     assert(css[:body].include?(".compact-actions"),
@@ -1992,8 +2000,8 @@ module RemoteServerTest
            "expected Remote UI to call the project Git diff endpoint")
     assert(js[:body].include?("data-open-project-diff"),
            "expected Project detail to expose Git diff navigation")
-    assert(js[:body].include?("function agentsMoreMenuHtml"),
-           "expected Agents tab actions to move into the header More menu")
+    assert(js[:body].include?("function agentBulkControlsHtml"),
+           "expected Agents tab bulk selection to render beside the sort control")
     assert(js[:body].include?("function agentMoreMenuHtml"),
            "expected Conversation actions to move into the header More menu")
     assert(js[:body].include?("Conversation settings"),
@@ -2016,6 +2024,14 @@ module RemoteServerTest
     assert(js[:body].include?("Push notifications"), "expected Settings screen to expose push readiness")
     assert(js[:body].include?("function settingsMoreMenuHtml"),
            "expected Settings actions to move into the header More menu")
+    assert(js[:body].include?("function setMainHeaderMore"),
+           "expected main tabs to share the Settings More menu")
+    assert(js[:body].include?("function openQuickAgent"),
+           "expected Remote UI to expose Quick Agent creation")
+    assert(js[:body].include?("function quickAgentProjectDefaults"),
+           "expected Quick Agent to derive project-specific defaults")
+    assert(js[:body].include?("await ensureProject(newKey)"),
+           "expected Quick Agent project changes to load project detail defaults")
     assert(js[:body].include?("Tycho build"),
            "expected Settings screen to display the Tycho build")
     assert(js[:body].include?("function tychoBuildLabel"),
@@ -2541,9 +2557,9 @@ module RemoteServerTest
     assert(js[:body].include?("renderProjectAgentEmpty()"),
            "expected Agents tab to keep zero-agent projects reachable")
     assert(js[:body].include?("data-toggle-bulk-archive"),
-           "expected Agents tab More menu to expose bulk archive selection mode")
+           "expected Agents tab toolbar to expose bulk archive selection mode")
     assert(js[:body].include?("data-run-bulk-archive"),
-           "expected Agents tab More menu to expose bulk archive submission")
+           "expected Agents tab bulk menu to expose bulk archive submission")
     assert(js[:body].include?('apiPost("/agents/archive", { keys })'),
            "expected Remote UI to call the bulk archive endpoint")
     assert(js[:body].include?("function agentArchiveable"),


### PR DESCRIPTION
## Summary
- Add a floating Quick Agent launcher and simplified modal for creating agents from the Remote UI.
- Load project detail when opening/changing projects so the modal follows each project/template defaults for harness, model, reasoning effort, and sandbox mode.
- Reuse the Settings-style header More menu on the main tabs, and move Agents bulk selection beside the sort control with an icon-only square-check-big button plus a bulk archive menu.

## Verification
- `node --check lib/hq/remote_ui/assets/app.js`
- `bin/test`
- Browser verification against a temp `bin/tycho serve` instance with isolated config/log/schedule paths: checked Now/Agents shared header menu, Quick Agent project-default switching, advanced option defaults, and Agents bulk archive menu state.
