### PR TITLE
[codex] Use bulk selector as agent actions menu

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1569,8 +1569,7 @@ select {
 }
 
 .agent-sort-trigger,
-.agent-bulk-select-button,
-.agent-bulk-trigger {
+.agent-bulk-select-button {
   display: inline-grid;
   width: 42px;
   min-width: 42px;
@@ -1584,22 +1583,20 @@ select {
 }
 
 .agent-sort-trigger::-webkit-details-marker,
-.agent-bulk-trigger::-webkit-details-marker {
+.agent-bulk-select-button::-webkit-details-marker {
   display: none;
 }
 
 .agent-sort-trigger::marker,
-.agent-bulk-trigger::marker {
+.agent-bulk-select-button::marker {
   content: "";
 }
 
 .agent-sort-menu[open] .agent-sort-trigger,
-.agent-bulk-menu[open] .agent-bulk-trigger,
+.agent-bulk-menu.open .agent-bulk-select-button,
 .agent-bulk-select-button.active,
 .agent-sort-trigger:hover,
 .agent-sort-trigger:focus-visible,
-.agent-bulk-trigger:hover,
-.agent-bulk-trigger:focus-visible,
 .agent-bulk-select-button:hover,
 .agent-bulk-select-button:focus-visible {
   border-color: var(--accent);
@@ -1607,8 +1604,7 @@ select {
 }
 
 .agent-sort-trigger .ui-icon,
-.agent-bulk-select-button .ui-icon,
-.agent-bulk-trigger .ui-icon {
+.agent-bulk-select-button .ui-icon {
   width: 16px;
   height: 16px;
 }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -455,6 +455,7 @@ const state = {
   },
   agentSort: initialAgentSort(),
   bulkArchiveMode: false,
+  bulkArchiveMenuOpen: false,
   bulkArchiveSelection: new Set(),
   failureCount: 0,
   timer: null,
@@ -2112,18 +2113,21 @@ function agentBulkControlsHtml() {
 
   const active = state.bulkArchiveMode;
   return `
-    <button
-      class="agent-bulk-select-button ${active ? "active" : ""}"
-      type="button"
-      data-toggle-bulk-archive
-      aria-label="${active ? "Cancel agent selection" : "Select agents"}"
-      title="${active ? "Cancel selection" : "Select agents"}"
-      aria-pressed="${active ? "true" : "false"}"
-    >
-      ${iconSvg("squareCheckBig")}
-      <span class="sr-only">${active ? "Cancel selection" : "Select agents"}</span>
-    </button>
-    ${active ? agentBulkActionMenuHtml() : ""}
+    <div class="agent-bulk-menu ${active && state.bulkArchiveMenuOpen ? "open" : ""}" data-agent-bulk-menu>
+      <button
+        class="agent-bulk-select-button ${active ? "active" : ""}"
+        type="button"
+        data-toggle-bulk-archive
+        aria-label="${active ? "Bulk agent actions" : "Select agents"}"
+        title="${active ? "Bulk agent actions" : "Select agents"}"
+        aria-expanded="${active && state.bulkArchiveMenuOpen ? "true" : "false"}"
+        aria-pressed="${active ? "true" : "false"}"
+      >
+        ${iconSvg("squareCheckBig")}
+        <span class="sr-only">${active ? "Bulk agent actions" : "Select agents"}</span>
+      </button>
+      ${active && state.bulkArchiveMenuOpen ? agentBulkActionMenuHtml() : ""}
+    </div>
   `;
 }
 
@@ -2132,22 +2136,22 @@ function agentBulkActionMenuHtml() {
   const selectedLabel = selected.length === 1 ? "1 selected" : `${selected.length} selected`;
 
   return `
-    <details class="agent-bulk-menu" data-agent-bulk-menu>
-      <summary class="agent-bulk-trigger" aria-label="Bulk agent actions" title="Bulk agent actions">
-        ${iconSvg("ellipsis")}
-        <span class="sr-only">Bulk agent actions</span>
-      </summary>
-      <div class="agent-bulk-options" role="menu" aria-label="Bulk agent actions">
-        ${moreMenuButton({
-          label: "Archive agents",
-          sublabel: selectedLabel,
-          icon: "archive",
-          attrs: "data-run-bulk-archive",
-          danger: true,
-          disabled: selected.length === 0,
-        })}
-      </div>
-    </details>
+    <div class="agent-bulk-options" role="menu" aria-label="Bulk agent actions">
+      ${moreMenuButton({
+        label: "Archive agents",
+        sublabel: selectedLabel,
+        icon: "archive",
+        attrs: "data-run-bulk-archive",
+        danger: true,
+        disabled: selected.length === 0,
+      })}
+      ${moreMenuButton({
+        label: "Cancel selection",
+        sublabel: "Exit bulk mode",
+        icon: "x",
+        attrs: "data-cancel-bulk-archive",
+      })}
+    </div>
   `;
 }
 
@@ -6556,7 +6560,11 @@ els.view.addEventListener("click", (event) => {
   if (!event.target.closest("[data-agent-sort-menu]")) {
     closeAgentSortMenu();
   }
-  if (!event.target.closest("[data-agent-bulk-menu]")) {
+  if (
+    !event.target.closest("[data-agent-bulk-menu]") &&
+    !event.target.closest("[data-select-agent]") &&
+    !event.target.closest(".selectable-agent-row")
+  ) {
     closeAgentBulkMenu();
   }
 
@@ -6605,6 +6613,7 @@ els.view.addEventListener("click", (event) => {
   }
 
   if (event.target.closest("[data-toggle-bulk-archive]")) {
+    event.preventDefault();
     toggleBulkArchiveMode();
     return;
   }
@@ -6626,7 +6635,13 @@ els.view.addEventListener("click", (event) => {
     return;
   }
 
+  if (event.target.closest("[data-cancel-bulk-archive]")) {
+    cancelBulkArchiveMode();
+    return;
+  }
+
   if (event.target.closest("[data-run-bulk-archive]")) {
+    state.bulkArchiveMenuOpen = false;
     archiveSelectedAgents();
     return;
   }
@@ -7196,8 +7211,19 @@ function runAgentAction(agentAction) {
 }
 
 function toggleBulkArchiveMode() {
-  state.bulkArchiveMode = !state.bulkArchiveMode;
-  if (!state.bulkArchiveMode) state.bulkArchiveSelection.clear();
+  if (!state.bulkArchiveMode) {
+    state.bulkArchiveMode = true;
+    state.bulkArchiveMenuOpen = true;
+  } else {
+    state.bulkArchiveMenuOpen = !state.bulkArchiveMenuOpen;
+  }
+  render();
+}
+
+function cancelBulkArchiveMode() {
+  state.bulkArchiveMode = false;
+  state.bulkArchiveMenuOpen = false;
+  state.bulkArchiveSelection.clear();
   render();
 }
 
@@ -7214,6 +7240,7 @@ function archiveSelectedAgents() {
     archivedKeys.forEach(removeAgent);
     state.bulkArchiveSelection.clear();
     state.bulkArchiveMode = false;
+    state.bulkArchiveMenuOpen = false;
 
     const skipped = result.skipped?.length || 0;
     const failed = result.failed?.length || 0;
@@ -7681,7 +7708,14 @@ function closeAgentSortMenu() {
 }
 
 function closeAgentBulkMenu() {
-  document.querySelector("[data-agent-bulk-menu]")?.removeAttribute("open");
+  if (!state.bulkArchiveMenuOpen) return;
+  state.bulkArchiveMenuOpen = false;
+  const route = parseRoute();
+  if (state.bulkArchiveMode && route.type === "tab" && route.tab === "agents") {
+    renderAgents({ focusFilter: false });
+  } else {
+    document.querySelector("[data-agent-bulk-menu]")?.classList.remove("open");
+  }
 }
 
 function closeBlockMenu() {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1857,6 +1857,8 @@ module RemoteServerTest
            "expected Agents tab to style the icon-only bulk selection control")
     assert(css[:body].include?(".agent-bulk-menu"),
            "expected Agents tab to style bulk action dropdowns")
+    assert(!css[:body].include?(".agent-bulk-trigger"),
+           "expected the bulk selector itself to anchor the bulk action dropdown")
     assert(css[:body].include?(".selectable-agent-row"),
            "expected Agents tab to style selectable bulk archive rows")
     assert(css[:body].include?(".compact-actions"),
@@ -2560,6 +2562,10 @@ module RemoteServerTest
            "expected Agents tab toolbar to expose bulk archive selection mode")
     assert(js[:body].include?("data-run-bulk-archive"),
            "expected Agents tab bulk menu to expose bulk archive submission")
+    assert(js[:body].include?("data-cancel-bulk-archive"),
+           "expected Agents tab bulk menu to expose selection cancellation")
+    assert(!js[:body].include?("agent-bulk-trigger"),
+           "expected Agents tab bulk actions to avoid a separate ellipsis trigger")
     assert(js[:body].include?('apiPost("/agents/archive", { keys })'),
            "expected Remote UI to call the bulk archive endpoint")
     assert(js[:body].include?("function agentArchiveable"),


### PR DESCRIPTION
## Summary
- Make the Agents square-check bulk selector anchor the bulk actions menu directly.
- Remove the separate ellipsis bulk trigger and keep Archive agents in the selector menu.
- Keep checkbox selection mode active while the menu opens/closes, with a Cancel selection action for exiting bulk mode.

## Validation
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- Browser verification against an isolated `bin/tycho serve` fixture using local Chrome/CDP: selector opens the menu, no separate ellipsis trigger is present, checkbox selection keeps the menu open, outside click closes only the menu, and the selector reopens it.
