### PR TITLE
[codex] Preserve remote scroll positions

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -641,7 +641,11 @@ h3 {
 }
 
 .top-actions .search-box {
-  flex: 1 1 260px;
+  flex: 1 1 auto;
+}
+
+.top-actions {
+  flex-wrap: nowrap;
 }
 
 .top-actions > button {
@@ -650,6 +654,7 @@ h3 {
 
 .agent-toolbar-actions {
   display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 8px;
   margin-left: auto;
@@ -1911,8 +1916,6 @@ select {
   gap: 10px;
   min-width: 0;
   max-width: 100%;
-  max-height: min(70dvh, 720px);
-  overflow: auto;
   border-top: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg) 54%, var(--panel));
   padding: 10px 0;
@@ -3087,10 +3090,6 @@ select {
     overflow-y: auto;
     overscroll-behavior: contain;
     padding-right: 4px;
-  }
-
-  .agent-workspace.has-detail .diff-file-body {
-    max-height: min(58dvh, 680px);
   }
 
   .agent-workspace-pull-requests.has-detail .agent-detail-pane {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1381,6 +1381,10 @@ function captureViewState() {
     controls: {},
     details: {},
     openElements: {},
+    pageScroll: {
+      top: Math.max(0, window.scrollY || document.documentElement.scrollTop || 0),
+      left: Math.max(0, window.scrollX || document.documentElement.scrollLeft || 0),
+    },
     scrollContainers: {},
   };
 
@@ -1449,6 +1453,8 @@ function restoreViewState(snapshot) {
     element.scrollTop = stored.top || 0;
     element.scrollLeft = stored.left || 0;
   });
+
+  restorePageScroll(snapshot.pageScroll);
 }
 
 function syncPreservedOpenState(element, open) {
@@ -1653,6 +1659,7 @@ function controlState(control) {
   return {
     value: control.value,
     selection: textSelectionFor(control),
+    scroll: controlScrollFor(control),
   };
 }
 
@@ -1662,7 +1669,22 @@ function restoreControlState(control, stored) {
   } else if (Object.prototype.hasOwnProperty.call(stored, "value")) {
     control.value = stored.value;
     restoreTextSelection(control, stored.selection);
+    restoreControlScroll(control, stored.scroll);
   }
+}
+
+function controlScrollFor(control) {
+  return {
+    top: Math.max(0, control.scrollTop || 0),
+    left: Math.max(0, control.scrollLeft || 0),
+  };
+}
+
+function restoreControlScroll(control, scroll) {
+  if (!scroll) return;
+
+  control.scrollTop = scroll.top || 0;
+  control.scrollLeft = scroll.left || 0;
 }
 
 function textSelectionFor(control) {
@@ -1679,6 +1701,20 @@ function restoreTextSelection(control, selection) {
   const start = Math.min(selection.start, control.value.length);
   const end = Math.min(selection.end, control.value.length);
   control.setSelectionRange(start, end);
+}
+
+function restorePageScroll(scroll) {
+  if (!scroll) return;
+
+  const top = Math.max(0, scroll.top || 0);
+  const left = Math.max(0, scroll.left || 0);
+  window.scrollTo({ top, left, behavior: "auto" });
+  state.lastScrollY = top;
+  window.requestAnimationFrame(() => {
+    window.scrollTo({ top, left, behavior: "auto" });
+    state.lastScrollY = Math.max(0, window.scrollY || top);
+    updateGoRecentVisibility();
+  });
 }
 
 function syncViewControls() {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1851,8 +1851,14 @@ module RemoteServerTest
            "expected Remote UI to style the Quick Agent modal")
     assert(css[:body].include?(".top-actions .search-box"),
            "expected Agents tab search to flex inside the action row")
+    assert(css[:body].include?(".top-actions {\n  flex-wrap: nowrap;"),
+           "expected Agents tab search and toolbar controls to stay on one row")
+    assert(css[:body].include?("flex: 1 1 auto;"),
+           "expected Agents tab search to shrink instead of forcing toolbar wrapping")
     assert(css[:body].include?(".agent-toolbar-actions"),
            "expected Agents tab toolbar actions to align independently from the search width")
+    assert(css[:body].include?(".agent-toolbar-actions {\n  display: inline-flex;\n  flex: 0 0 auto;"),
+           "expected Agents tab toolbar actions to keep fixed width beside search")
     assert(css[:body].include?(".agent-bulk-select-button"),
            "expected Agents tab to style the icon-only bulk selection control")
     assert(css[:body].include?(".agent-bulk-menu"),
@@ -1898,6 +1904,10 @@ module RemoteServerTest
            "expected Project edit form to style the read-only information title")
     assert(css[:body].include?(".diff-viewer") && css[:body].include?(".diff-line.added"),
            "expected Remote UI to style project Git diff rows")
+    assert(!css[:body].include?("max-height: min(70dvh, 720px);"),
+           "expected diff file bodies to avoid per-file vertical scroll limits")
+    assert(!css[:body].include?("max-height: min(58dvh, 680px);"),
+           "expected split diff file bodies to avoid per-file vertical scroll limits")
     assert(css[:body].include?(".diff-scope-switch"),
            "expected Remote UI to style Git diff scope toggles")
     js = server.send(:route_ui, "/ui.js")
@@ -2280,6 +2290,12 @@ module RemoteServerTest
            "expected polling renders to skip unchanged Remote UI view HTML")
     assert(js[:body].include?("scrollContainers"),
            "expected polling snapshots to preserve scroll positions for restored controls")
+    assert(js[:body].include?("pageScroll"),
+           "expected polling snapshots to preserve page scroll on same-route renders")
+    assert(js[:body].include?("function controlScrollFor"),
+           "expected polling snapshots to preserve prompt textarea scroll offsets")
+    assert(js[:body].include?("function restorePageScroll"),
+           "expected polling renders to restore PR diff and conversation page scroll")
     assert(js[:body].include?("function syncPreservedOpenState"),
            "expected restored floating controls to update related button state")
     assert(js[:body].include?("const discovered = state.skills"),


### PR DESCRIPTION
## Summary
- Remove per-file vertical height limits from Remote UI diff file bodies so a PR diff can be browsed through one diff-detail scrollbar.
- Preserve page scroll and form-control internal scroll offsets across same-route polling renders.
- Keep the Agents search, sort, and bulk action controls on one row by allowing the search to shrink and keeping toolbar actions fixed-width.

## Validation
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- Browser verification against an isolated `bin/tycho serve` fixture using local Chrome/CDP:
  - long PR diff file body has no per-file max-height and overflow is visible
  - PR detail pane scroll remains at `scrollTop=900` after forced refresh
  - Conversation page scroll and prompt textarea scroll/value survive forced refresh
  - Agents toolbar search and sort/bulk controls remain on one row at the provided screenshot width

## Note
Leaving this unmerged until behavior is confirmed.
