### PR TITLE
Improve remote PR diff readability

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -31,6 +31,8 @@ html.ipad-standalone {
 html {
   min-width: 0;
   overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 body {
@@ -1916,6 +1918,7 @@ select {
   gap: 10px;
   min-width: 0;
   max-width: 100%;
+  overflow-x: auto;
   border-top: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg) 54%, var(--panel));
   padding: 10px 0;
@@ -2022,6 +2025,21 @@ select {
 
   .diff-toolbar > button {
     width: 100%;
+  }
+
+  .diff-hunk-header code,
+  .diff-lines {
+    font-size: 11px;
+  }
+
+  .diff-lines {
+    line-height: 1.4;
+  }
+
+  .diff-line {
+    grid-template-columns: 4.5ch 4.5ch 2ch minmax(36ch, 1fr);
+    min-height: 18px;
+    padding-inline: 10px;
   }
 
   .diff-file > summary {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2774,7 +2774,7 @@ function renderPullRequestDiffDetail(agent, item, diff, options = {}) {
   const snapshot = item.snapshot || null;
   const stale = snapshot?.fresh === false;
   const loading = isPullRequestDiffFetching(agent.key, item.id);
-  const expandAll = state.prDiffExpandAll[agent.key] === true;
+  const expandAll = state.prDiffExpandAll[agent.key] !== false;
   const expandLabel = expandAll ? "Collapse all" : "Open all";
   const expandIcon = expandAll ? "listChevronsDownUp" : "listChevronsUpDown";
   const header = `
@@ -6868,7 +6868,7 @@ els.view.addEventListener("click", (event) => {
   const togglePrDiffExpandAllButton = event.target.closest("[data-toggle-pr-diff-expand-all]");
   if (togglePrDiffExpandAllButton) {
     const key = togglePrDiffExpandAllButton.dataset.togglePrDiffExpandAll;
-    const expand = !state.prDiffExpandAll[key];
+    const expand = state.prDiffExpandAll[key] === false;
     state.prDiffExpandAll[key] = expand;
     // Sync the live DOM so the state snapshot captures the new open/closed
     // state instead of restoring the previous per-file details state.

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3719,21 +3719,8 @@ function renderProjectAgents(project, agents) {
         </div>
         <button class="inline-icon-button agent-group-create" type="button" data-create-agent="${escapeAttr(project.key)}">${iconSvg("plus")}<span>Add agent</span></button>
       </div>
-      ${agents.length ? agents.map(renderAgentRow).join("") : renderProjectAgentEmpty()}
+      ${agents.map(renderAgentRow).join("")}
     </section>
-  `;
-}
-
-function renderProjectAgentEmpty() {
-  return `
-    <div class="agent-row project-agent-empty">
-      <span class="status-mark info" aria-hidden="true">${iconSvg("robot")}</span>
-      <div class="row-title">
-        <strong>No managed agents</strong>
-        <span>Add the first managed agent for this project.</span>
-      </div>
-      <span class="pill detail">None</span>
-    </div>
   `;
 }
 
@@ -3759,7 +3746,7 @@ function renderAgentGroup(projectKey, agents) {
         </div>
         ${project ? `<button class="inline-icon-button agent-group-create" type="button" data-create-agent="${escapeAttr(projectKey)}" aria-label="Create agent for ${escapeAttr(projectName)}">${iconSvg("plus")}<span>Agent</span></button>` : ""}
       </div>
-      ${agents.length ? agents.map(renderAgentRow).join("") : renderProjectAgentEmpty()}
+      ${agents.map(renderAgentRow).join("")}
     </section>
   `;
 }

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2572,8 +2572,10 @@ module RemoteServerTest
            "expected Agents tab to sort agents alphabetically within each project group")
     assert(js[:body].include?("projectMatches(project, query)"),
            "expected Agents tab filtering to match project fields")
-    assert(js[:body].include?("renderProjectAgentEmpty()"),
-           "expected Agents tab to keep zero-agent projects reachable")
+    assert(!js[:body].include?("No managed agents"),
+           "expected Agents tab to omit redundant zero-agent empty rows")
+    assert(js[:body].include?("agent-group-create"),
+           "expected Agents tab to keep zero-agent projects reachable from the group header")
     assert(js[:body].include?("data-toggle-bulk-archive"),
            "expected Agents tab toolbar to expose bulk archive selection mode")
     assert(js[:body].include?("data-run-bulk-archive"),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1904,6 +1904,14 @@ module RemoteServerTest
            "expected Project edit form to style the read-only information title")
     assert(css[:body].include?(".diff-viewer") && css[:body].include?(".diff-line.added"),
            "expected Remote UI to style project Git diff rows")
+    assert(css[:body].include?("overflow-x: auto;"),
+           "expected diff file bodies to expose a horizontal scrollbar for long code lines")
+    assert(css[:body].include?("-webkit-text-size-adjust: 100%;") &&
+           css[:body].include?("text-size-adjust: 100%;"),
+           "expected Remote UI to prevent mobile browser text inflation")
+    assert(css[:body].include?(".diff-hunk-header code,\n  .diff-lines") &&
+           css[:body].include?("font-size: 11px;"),
+           "expected mobile diff code typography to stay compact")
     assert(!css[:body].include?("max-height: min(70dvh, 720px);"),
            "expected diff file bodies to avoid per-file vertical scroll limits")
     assert(!css[:body].include?("max-height: min(58dvh, 680px);"),
@@ -2296,6 +2304,10 @@ module RemoteServerTest
            "expected polling snapshots to preserve prompt textarea scroll offsets")
     assert(js[:body].include?("function restorePageScroll"),
            "expected polling renders to restore PR diff and conversation page scroll")
+    assert(js[:body].include?("state.prDiffExpandAll[agent.key] !== false"),
+           "expected PR diff files to open by default")
+    assert(js[:body].include?("const expand = state.prDiffExpandAll[key] === false"),
+           "expected PR diff collapse-all control to toggle from the open default")
     assert(js[:body].include?("function syncPreservedOpenState"),
            "expected restored floating controls to update related button state")
     assert(js[:body].include?("const discovered = state.skills"),


### PR DESCRIPTION
## Summary

- Remove the redundant zero-agent empty rows from Remote UI project groups.
- Make PR diff files open by default while preserving Collapse all/Open all and individual file toggles.
- Add horizontal scrolling for long diff lines and tighten mobile diff typography to avoid oversized code text.

## Verification

- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- Browser/CDP check against a temp Remote UI instance with synthetic PR diff at mobile width
- `bin/test`
