### PR TITLE
[codex] Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.5.0 - 2026-06-13
+
+### Notable Releases
+
+- Add Remote UI project Git diff inspection and agent-attached GitHub PR diff
+  snapshots, so operators can review worktree/staged/all changes and referenced
+  PR changes in-app. (#24, #32)
+- Add Remote UI schedule management for schedule create/edit/delete, manual
+  run/pause/resume, daemon controls, and file-backed schedule message editing.
+  (#25)
+- Add Quick Agent creation in the Remote UI, with project/template defaults and
+  advanced harness, model, effort, and sandbox options. (#29)
+- Expand managed-agent control from the CLI and Remote UI, including new
+  `tycho agent` subcommands plus clone/archive/run/stop/send and bulk archive
+  flows. (#28, #30)
+
+### Others
+
+- Add shared Remote UI More menus and expose build metadata in setup. (#23)
+- Add Tycho Claude skill documentation for the current CLI surface. (#26)
+- Add the direct `erb` runtime dependency and make Git diff parsing stable when
+  user Git config enables mnemonic prefixes. (#27)
+- Improve PR diff loading, attachment download UX, expand/collapse behavior,
+  diff detail headers, long-line scrolling, and mobile diff readability.
+- Preserve Remote UI scroll positions, form values, composer state, and selected
+  detail state across polling refreshes. (#31)
+- Add conversation message copy menus and relative timestamps.
+- Fix wide attachment viewer navigation and stale schedule state when archived
+  scheduled-agent targets disappear.
+
 ## 0.4.0 - 2026-06-06
 
 ### Notable Releases

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-06-06
+2026-06-13
 
 ## Strategic Direction
 
@@ -65,12 +65,11 @@ Key references:
 
 ## Current Focus
 
-**v0.4.0 release**: Tycho's current release focus is Remote UI project editing,
-agent operator ergonomics, managed-agent model/effort controls, schedule
-resilience, simplified schedule statuses, and grouped web push badges. After
-release, the next focus is completing schedule management surfaces and
-stabilizing install/update paths through Homebrew checks and browser/TUI smoke
-verification.
+**v0.5.0 release**: Tycho's current release focus is Remote UI schedule
+management, in-app project and PR diff review, Quick Agent creation,
+managed-agent CLI controls, and Remote UI polling/readability refinements. After
+release, the next focus is stabilizing install/update paths through Homebrew
+checks and continuing browser/TUI smoke verification.
 
 ## Roadmap
 

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
## Summary

- Bump `HQ::VERSION` to `0.5.0`.
- Move post-`v0.4.0` work into a dated `CHANGELOG.md` section for `0.5.0`.
- Refresh `docs/PROJECT_STATUS.md` for the v0.5.0 release focus.

## Validation

- `bundle exec ruby -c bin/tycho`
- `node --check lib/hq/remote_ui/assets/app.js`
- `bin/test`

## Follow-up after merge

- Tag and publish `v0.5.0` from `main`.
- Update `firewalker06/homebrew-tycho` with the `v0.5.0` tarball URL and SHA after the GitHub release exists.
- Keep the Homebrew tap PR open until bottle/test-bot checks pass, then apply the `pr-pull` label to publish bottles.
