### PR TITLE
Load source checkout bundle in tycho executable

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -11,7 +11,8 @@ end
 
 commands = [
   ["bundle", "exec", "ruby", "-c", "bin/tycho"],
-  ["bundle", "exec", "ruby", "-c", "bin/schedule"]
+  ["bundle", "exec", "ruby", "-c", "bin/schedule"],
+  ["ruby", "bin/tycho", "doctor"]
 ] +
            test_files.map { |path| ["bundle", "exec", "ruby", path] }
 

--- a/bin/tycho
+++ b/bin/tycho
@@ -43,6 +43,12 @@ end
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
+source_gemfile = File.expand_path("../Gemfile", __dir__)
+if File.file?(source_gemfile)
+  ENV["BUNDLE_GEMFILE"] = source_gemfile
+  require "bundler/setup"
+end
+
 require "hq/dotenv_loader"
 
 HQ::DotenvLoader.load(File.expand_path("../.env", __dir__))


### PR DESCRIPTION
## Summary

Make direct source-checkout execution work after `bin/setup` installs gems under `vendor/bundle`.

`bin/tycho` now detects the repository `Gemfile`, sets `BUNDLE_GEMFILE`, and loads `bundler/setup` before requiring Tycho application code. This keeps the documented source flow working:

```bash
bin/setup
bin/tycho doctor
```

The regression is covered by adding a direct `ruby bin/tycho doctor` smoke to `bin/test`, outside `bundle exec`.

## Reproduction fixed by this PR

With local Bundler config:

```yaml
BUNDLE_PATH: "vendor/bundle"
```

Before the fix:

```bash
bin/tycho doctor
# LoadError: cannot load such file -- dry/cli
```

But this worked because it explicitly activated Bundler:

```bash
bundle exec bin/tycho doctor
```

After the fix, direct source execution works:

```bash
bin/tycho doctor
ruby bin/tycho doctor
```

## Verification

- `bin/setup`
- `bin/tycho doctor`
- `ruby bin/tycho doctor`
- `bin/test`
