### PR TITLE
Add Remote UI form control names

### DIFF
--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2810,7 +2810,7 @@ function renderAgentPullRequestsToggle(agent) {
 function renderAgentComposer(agent, skills, options = {}) {
   return `
     <form id="composer" class="composer" data-agent-key="${escapeAttr(agent.key)}">
-      <textarea id="prompt-input" rows="2" placeholder="Send a prompt" aria-label="Prompt" enterkeyhint="enter"></textarea>
+      <textarea id="prompt-input" name="prompt" rows="2" placeholder="Send a prompt" aria-label="Prompt" enterkeyhint="enter"></textarea>
       <div class="composer-drop-overlay" data-composer-drop-overlay aria-hidden="true">
         <span>Drop files to attach</span>
       </div>
@@ -3609,7 +3609,7 @@ function renderGuardedAction(projectKey, action) {
     </details>
     <form id="guard-form" class="field-card">
       <label class="check-label">
-        <input id="confirm-action" type="checkbox" ${preflight.can_start ? "" : "disabled"}>
+        <input id="confirm-action" name="confirm_action" type="checkbox" ${preflight.can_start ? "" : "disabled"}>
         I understand this starts a detached Kamal ${escapeHtml(action)} command.
       </label>
       <button class="primary" type="submit" data-project-key="${escapeAttr(project.key)}" data-action="${escapeAttr(action)}" disabled>Start ${escapeHtml(preflight.label)}</button>
@@ -8094,7 +8094,7 @@ function renderQuickAgentDialog(projectKey, options = {}) {
   const promptValue = options.promptValue || "";
 
   const projectOptions = eligible.length > 1
-    ? `<select id="quick-agent-project" data-quick-agent-project>
+    ? `<select id="quick-agent-project" name="project_key" aria-label="Project" data-quick-agent-project>
          ${eligible.map((p) => `<option value="${escapeAttr(p.key)}" ${p.key === project.key ? "selected" : ""}>${escapeHtml(p.name || p.key)}</option>`).join("")}
        </select>`
     : `<span class="quick-agent-project-static">${escapeHtml(project.name || project.key)}</span>`;
@@ -8103,19 +8103,19 @@ function renderQuickAgentDialog(projectKey, options = {}) {
     <section class="quick-agent-advanced">
       <label class="quick-agent-field">
         <span>Harness</span>
-        <select id="quick-agent-harness" data-quick-agent-harness>
+        <select id="quick-agent-harness" name="agent" data-quick-agent-harness>
           ${agentHarnessOptions().map((h) => `<option value="${escapeAttr(h)}" ${h === harness ? "selected" : ""}>${escapeHtml(h)}</option>`).join("")}
         </select>
       </label>
       <label class="quick-agent-field">
         <span>Model</span>
-        <select id="quick-agent-model" data-quick-agent-model>
+        <select id="quick-agent-model" name="model" data-quick-agent-model>
           ${modelChoiceOptions(harness, model)}
         </select>
       </label>
       <label class="quick-agent-field">
         <span>Effort</span>
-        <select id="quick-agent-effort" data-quick-agent-effort>
+        <select id="quick-agent-effort" name="reasoning_effort" data-quick-agent-effort>
           ${reasoningEffortChoiceOptions(harness, model, effort)}
         </select>
       </label>
@@ -8139,7 +8139,7 @@ function renderQuickAgentDialog(projectKey, options = {}) {
         <span>Project</span>
         ${projectOptions}
       </label>
-      <textarea id="quick-agent-prompt" class="quick-agent-prompt" rows="4" placeholder="Describe what the agent should do…" required>${escapeHtml(promptValue)}</textarea>
+      <textarea id="quick-agent-prompt" class="quick-agent-prompt" name="prompt" rows="4" placeholder="Describe what the agent should do…" aria-label="Prompt" required>${escapeHtml(promptValue)}</textarea>
       <div class="quick-agent-options-row">
         <button type="button" class="quick-agent-toggle" data-quick-agent-toggle aria-expanded="${advancedOpen ? "true" : "false"}">
           <span class="quick-agent-toggle-mark" aria-hidden="true">${advancedOpen ? "−" : "+"}</span>

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -58,7 +58,7 @@
           <label for="token-input">Remote token</label>
           <div class="token-row">
             <input class="sr-only" type="text" autocomplete="username" value="hq-remote" tabindex="-1" aria-hidden="true">
-            <input id="token-input" type="password" autocomplete="current-password" placeholder="Bearer token">
+            <input id="token-input" name="token" type="password" autocomplete="current-password" placeholder="Bearer token">
             <button id="save-token-button" type="button">Save</button>
           </div>
         </form>


### PR DESCRIPTION
## Summary

- Add semantic `name` attributes to Remote UI form controls found during the UI audit.
- Keep existing labels/ARIA behavior intact for auth, agent composer, guarded project actions, and Quick Agent controls.
- Add an explicit `aria-label` for the Quick Agent prompt textarea and project select where the dynamic markup needs it.

## Testing

Automated checks run locally:

- [x] Static Remote UI form-control audit for:
  - `<button>` elements missing explicit `type`
  - likely `<input>`, `<select>`, and `<textarea>` controls missing `name`
- [x] `bundle exec ruby test/remote_server_test.rb`
  - Passed: `remote_server_test: ok`
  - Note: Ruby emitted transient `Open3.capture3` thread warnings while the test still exited successfully.
- [x] `bin/test`
  - Passed: `bin/test: ok`

Manual/browser verification steps for reviewers:

1. Start Remote UI from this branch:
   ```sh
   bundle exec bin/tycho serve --host 127.0.0.1 --port 7373
   ```
2. Open `http://127.0.0.1:7373/` and hard refresh:
   - Chrome/Chromium: `Ctrl+Shift+R`
   - Mobile/PWA: close and reopen, or force reload if available
3. Verify auth token control semantics when auth is required:
   - Open the token panel.
   - Save a token and confirm connection still works.
   - In DevTools, confirm:
     ```js
     document.querySelector("#token-input")?.name
     // "token"
     ```
4. Verify the Agent composer still works:
   - Open an existing agent.
   - Type a prompt in the composer.
   - Send it, or stop before sending if using a live agent you do not want to modify.
   - In DevTools, confirm:
     ```js
     document.querySelector("#prompt-input")?.name
     // "prompt"
     ```
5. Verify guarded project action confirmation still works:
   - Open a project guarded action such as deploy, maintenance, or live.
   - Tick the confirmation checkbox.
   - Confirm the Start button enables as before.
   - In DevTools, confirm:
     ```js
     document.querySelector("#confirm-action")?.name
     // "confirm_action"
     ```
6. Verify Quick Agent still works:
   - Open the Quick Agent floating action.
   - Select a project if multiple projects are available.
   - Enter a prompt.
   - Expand Options and change Harness/Model/Effort.
   - Create/run only if safe for your environment.
   - In DevTools, confirm the available controls expose names:
     ```js
     document.querySelector("#quick-agent-project")?.name
     document.querySelector("#quick-agent-harness")?.name
     document.querySelector("#quick-agent-model")?.name
     document.querySelector("#quick-agent-effort")?.name
     document.querySelector("#quick-agent-prompt")?.name
     // "project_key", "agent", "model", "reasoning_effort", "prompt"
     ```
7. Regression spot-check:
   - Polling/refresh should not erase typed composer or Quick Agent prompt text while focused.
   - Existing click handlers should still work because the change only adds form semantics and does not rename IDs/data attributes.
