### PR TITLE
[codex] Add Remote UI skill autocomplete

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -41,6 +41,14 @@ def write_fixture(dir)
   YAML
   File.write(prompts_path, "---\ncustom: \"Check the app.\"\n")
   File.write(schedules_path, "---\nschedules: []\n")
+  skill_dir = File.join(workspace, ".agents", "skills", "review")
+  FileUtils.mkdir_p(skill_dir)
+  File.write(File.join(skill_dir, "SKILL.md"), "# Review\n")
+  12.times do |index|
+    dir = File.join(workspace, ".agents", "skills", "alpha-#{index.to_s.rjust(2, "0")}")
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, "SKILL.md"), "# Alpha #{index}\n")
+  end
 
   {
     config_path: config_path,
@@ -161,9 +169,59 @@ def write_smoke_script(path)
         const value = await page.locator("#prompt-input").inputValue();
         if (value !== draft) throw new Error(`Composer draft was not preserved: ${JSON.stringify(value)}`);
 
+        await page.fill("#prompt-input", "$rev");
+        await page.waitForSelector("[data-skill-autocomplete]:not(.hidden)", { state: "visible", timeout: 10_000 });
+        if (!(await page.locator("[data-skill-autocomplete-rescan]").isVisible())) {
+          throw new Error("Skill autocomplete re-scan command was not visible");
+        }
+        await page.evaluate(async () => {
+          if (typeof refresh !== "function") throw new Error("refresh function is unavailable");
+          await refresh({ force: true, forceConversation: true });
+        });
+        await page.waitForSelector("[data-skill-autocomplete]:not(.hidden)", { state: "visible", timeout: 10_000 });
+        const stillAutocompleting = await page.locator("#prompt-input").inputValue();
+        if (stillAutocompleting !== "$rev") {
+          throw new Error(`Autocomplete draft did not survive refresh: ${JSON.stringify(stillAutocompleting)}`);
+        }
+        await page.keyboard.press("Tab");
+        const autocompletedPrompt = await page.locator("#prompt-input").inputValue();
+        if (autocompletedPrompt !== "$review ") {
+          throw new Error(`Composer skill autocomplete failed: ${JSON.stringify(autocompletedPrompt)}`);
+        }
+
+        await page.fill("#prompt-input", "$");
+        await page.waitForSelector("[data-skill-autocomplete]:not(.hidden)", { state: "visible", timeout: 10_000 });
+        for (let index = 0; index < 10; index += 1) await page.keyboard.press("ArrowDown");
+        const menuScrollTop = await page.locator("[data-skill-autocomplete]").evaluate((element) => element.scrollTop);
+        if (menuScrollTop <= 0) {
+          throw new Error(`Skill autocomplete did not scroll to highlighted item: ${menuScrollTop}`);
+        }
+
         const dockBox = await page.locator("[data-agent-dock]").boundingBox();
         if (!dockBox || dockBox.y + dockBox.height > 844) {
           throw new Error(`Agent dock is outside mobile viewport: ${JSON.stringify(dockBox)}`);
+        }
+
+        await page.goto(`${baseUrl}/ui#project/web/agent/new`, { waitUntil: "networkidle" });
+        await page.waitForSelector("#agent-prompt", { state: "visible", timeout: 10_000 });
+        await page.fill("#agent-prompt", "$rev");
+        await page.waitForSelector("[data-skill-autocomplete]:not(.hidden)", { state: "visible", timeout: 10_000 });
+        await page.keyboard.press("Tab");
+        const agentPrompt = await page.locator("#agent-prompt").inputValue();
+        if (agentPrompt !== "$review ") {
+          throw new Error(`Agent form skill autocomplete failed: ${JSON.stringify(agentPrompt)}`);
+        }
+
+        await page.goto(`${baseUrl}/ui`, { waitUntil: "networkidle" });
+        await page.waitForSelector("#quick-agent-fab:not(.hidden)", { state: "visible", timeout: 10_000 });
+        await page.click("#quick-agent-fab");
+        await page.waitForSelector("#quick-agent-prompt", { state: "visible", timeout: 10_000 });
+        await page.fill("#quick-agent-prompt", "$rev");
+        await page.waitForSelector("[data-skill-autocomplete]:not(.hidden)", { state: "visible", timeout: 10_000 });
+        await page.keyboard.press("Tab");
+        const quickPrompt = await page.locator("#quick-agent-prompt").inputValue();
+        if (quickPrompt !== "$review ") {
+          throw new Error(`Quick Agent skill autocomplete failed: ${JSON.stringify(quickPrompt)}`);
         }
 
         if (errors.length) throw new Error(`Browser console errors: ${errors.join(" | ")}`);

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -3491,6 +3491,51 @@ select {
   text-align: left;
 }
 
+.skill-autocomplete {
+  position: fixed;
+  z-index: 80;
+  display: grid;
+  align-content: start;
+  gap: 4px;
+  max-height: min(180px, 42dvh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px;
+  background: var(--panel);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38);
+}
+
+.skill-autocomplete button {
+  justify-content: start;
+  width: 100%;
+  min-height: 34px;
+  border-color: transparent;
+  background: transparent;
+  color: var(--text);
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+.skill-autocomplete button.active,
+.skill-autocomplete button:hover {
+  border-color: var(--accent);
+  background: rgba(139, 233, 253, 0.12);
+}
+
+.skill-autocomplete-action {
+  margin-top: 4px;
+  border-top-color: var(--border) !important;
+  color: var(--muted) !important;
+}
+
+.skill-autocomplete-empty {
+  padding: 8px 10px;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
 .send-row {
   justify-content: space-between;
 }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -488,6 +488,20 @@ const state = {
   lastAppBadgeCount: null,
   growlTimer: null,
   pendingSummaryScrollId: null,
+  skillAutocomplete: {
+    control: null,
+    controlId: "",
+    projectKey: "",
+    harness: "",
+    trigger: "$",
+    tokenStart: 0,
+    tokenEnd: 0,
+    query: "",
+    items: [],
+    highlightIndex: 0,
+    requestId: 0,
+    composing: false,
+  },
 };
 
 const markdownParser = {
@@ -1047,9 +1061,13 @@ async function markAgentReading(agent) {
 }
 
 async function ensureSkills(agent) {
-  const key = skillKey(agent.project_key, agent.agent);
-  if (state.skills[key]) return;
-  const data = await apiGet(`/projects/${encodeURIComponent(agent.project_key)}/skills/${encodeURIComponent(agent.agent)}`);
+  await ensureSkillsForProject(agent.project_key, agent.agent);
+}
+
+async function ensureSkillsForProject(projectKey, harness, options = {}) {
+  const key = skillKey(projectKey, harness);
+  if (!options.force && state.skills[key]) return;
+  const data = await apiGet(`/projects/${encodeURIComponent(projectKey)}/skills/${encodeURIComponent(harness)}`);
   state.skills[key] = data.skills || [];
 }
 
@@ -1327,6 +1345,7 @@ function restoreViewState(snapshot) {
 
   restorePageScroll(snapshot.pageScroll);
   repositionOpenSummaryAttachmentMenus();
+  restoreSkillAutocompleteAfterRender();
 }
 
 function syncPreservedOpenState(element, open) {
@@ -5592,6 +5611,17 @@ function normalizeAgentHarness(value) {
   return options.includes(normalized) ? normalized : options[0];
 }
 
+function harnessAdapter(name) {
+  const normalized = String(name || "").trim().toLowerCase();
+  const configured = harnessSetupItem(normalized);
+  if (configured?.adapter) return String(configured.adapter).trim().toLowerCase();
+  return normalized === "claude" ? "claude" : "codex";
+}
+
+function skillTriggerForHarness(harness) {
+  return harnessAdapter(harness) === "claude" ? "/" : "$";
+}
+
 function skillsForAgent(agent) {
   const discovered = state.skills[skillKey(agent.project_key, agent.agent)] || [];
   if (discovered.length) return discovered;
@@ -6569,6 +6599,7 @@ els.saveToken.addEventListener("click", saveRemoteToken);
 
 els.view.addEventListener("click", (event) => {
   showNav();
+  if (!event.target.closest("[data-skill-autocomplete]")) closeSkillAutocomplete();
   if (!event.target.closest("[data-attachment-flyout]") && !event.target.closest("[data-toggle-attachments]")) {
     closeAttachmentFlyout();
   }
@@ -6837,6 +6868,12 @@ els.view.addEventListener("click", (event) => {
     return;
   }
 
+  const autocompleteSkill = event.target.closest("[data-skill-autocomplete-index]");
+  if (autocompleteSkill) {
+    insertSkillAutocomplete(Number.parseInt(autocompleteSkill.dataset.skillAutocompleteIndex, 10));
+    return;
+  }
+
   const addPromptAttachment = event.target.closest("[data-add-prompt-attachment]");
   if (addPromptAttachment) {
     closeSkillFlyout();
@@ -6966,6 +7003,25 @@ document.addEventListener("click", (event) => {
   handleDocumentCopyClick(event);
 });
 
+document.addEventListener("mousedown", (event) => {
+  if (event.target.closest("[data-skill-autocomplete]")) event.preventDefault();
+});
+
+document.addEventListener("click", (event) => {
+  const autocompleteSkill = event.target.closest("[data-skill-autocomplete-index]");
+  if (autocompleteSkill) {
+    event.preventDefault();
+    insertSkillAutocomplete(Number.parseInt(autocompleteSkill.dataset.skillAutocompleteIndex, 10));
+    return;
+  }
+  if (event.target.closest("[data-skill-autocomplete]")) return;
+  if (event.target === state.skillAutocomplete.control) return;
+  closeSkillAutocomplete();
+});
+
+window.addEventListener("resize", positionSkillAutocomplete);
+window.addEventListener("scroll", positionSkillAutocomplete, true);
+
 document.addEventListener("click", (event) => {
   if (eventPathIncludes(event, els.mark) || eventPathIncludes(event, els.unreadPanel)) return;
   closeUnreadPanel();
@@ -6991,6 +7047,8 @@ document.addEventListener("click", (event) => {
 });
 
 els.view.addEventListener("keydown", (event) => {
+  if (handleSkillAutocompleteKeydown(event)) return;
+
   if (event.key !== "Enter") return;
   if (event.target?.id === "prompt-input") {
     if (event.shiftKey || event.isComposing) return;
@@ -7024,6 +7082,10 @@ document.addEventListener("dragend", clearComposerDropTargets);
 document.addEventListener("drop", clearComposerDropTargets);
 
 els.view.addEventListener("input", (event) => {
+  if (event.target?.tagName === "TEXTAREA") {
+    refreshSkillAutocomplete(event.target);
+  }
+
   const filter = event.target.closest("[data-filter]");
   if (filter) {
     state.filters[filter.dataset.filter] = filter.value;
@@ -7052,10 +7114,26 @@ els.view.addEventListener("input", (event) => {
 });
 
 els.view.addEventListener("focusout", (event) => {
+  if (event.target === state.skillAutocomplete.control) {
+    window.setTimeout(() => {
+      if (!document.activeElement?.closest?.("[data-skill-autocomplete]")) closeSkillAutocomplete();
+    }, 0);
+  }
+
   const control = event.target.closest("input, textarea");
   if (!control || !draftableTextControl(control)) return;
   const form = control.closest("form");
   if (form) saveFormDraft(form);
+});
+
+els.view.addEventListener("compositionstart", (event) => {
+  if (event.target?.tagName === "TEXTAREA") state.skillAutocomplete.composing = true;
+});
+
+els.view.addEventListener("compositionend", (event) => {
+  if (event.target?.tagName !== "TEXTAREA") return;
+  state.skillAutocomplete.composing = false;
+  refreshSkillAutocomplete(event.target);
 });
 
 els.view.addEventListener("change", (event) => {
@@ -7540,6 +7618,7 @@ function applyAgentTemplateSelection(select) {
     const templateName = String(option.dataset.templateName || "agent").toLowerCase();
     nameInput.value = `${projectName} ${templateName}`;
   }
+  if (promptInput === document.activeElement) refreshSkillAutocomplete(promptInput);
   saveFormDraft(form);
 }
 
@@ -7548,6 +7627,8 @@ function applyAgentHarnessSelection(select) {
   if (!form) return;
 
   updateAgentModelChoices(form, normalizeAgentHarness(select.value));
+  const promptInput = form.querySelector("#agent-prompt");
+  if (promptInput === document.activeElement) refreshSkillAutocomplete(promptInput);
   saveFormDraft(form);
 }
 
@@ -7736,6 +7817,384 @@ function validateInquiryForm(form) {
   return "";
 }
 
+function skillAutocompleteContext(control) {
+  if (!control || control.tagName !== "TEXTAREA") return null;
+
+  if (control.id === "prompt-input") {
+    const agent = findAgent(control.closest("#composer")?.dataset.agentKey);
+    if (!agent || agentIsRunning(agent)) return null;
+    return {
+      projectKey: agent.project_key,
+      harness: agent.agent,
+      trigger: agent.skill_trigger || skillTriggerForHarness(agent.agent),
+    };
+  }
+
+  if (control.id === "agent-prompt") {
+    const form = control.closest("#agent-form");
+    if (!form) return null;
+    const harness = normalizeAgentHarness(form.querySelector("#agent-harness")?.value);
+    return {
+      projectKey: form.dataset.projectKey,
+      harness,
+      trigger: skillTriggerForHarness(harness),
+    };
+  }
+
+  if (control.id === "quick-agent-prompt") {
+    const dialog = els.quickAgentDialog;
+    const projectKey = dialog?.querySelector("[data-quick-agent-project]")?.value
+      || dialog?.querySelector("#quick-agent-form")?.dataset.projectKey;
+    const project = findProject(projectKey);
+    const defaults = quickAgentProjectDefaults(project || {});
+    const harness = normalizeAgentHarness(dialog?.querySelector("[data-quick-agent-harness]")?.value || defaults.harness);
+    return {
+      projectKey,
+      harness,
+      trigger: skillTriggerForHarness(harness),
+    };
+  }
+
+  return null;
+}
+
+function skillAutocompleteToken(control, trigger) {
+  const value = control.value || "";
+  const caret = control.selectionStart ?? value.length;
+  if ((control.selectionEnd ?? caret) !== caret) return null;
+
+  let tokenStart = caret;
+  while (tokenStart > 0 && !/\s/.test(value[tokenStart - 1])) tokenStart -= 1;
+  if (tokenStart > 0 && !/\s/.test(value[tokenStart - 1])) return null;
+
+  const token = value.slice(tokenStart, caret);
+  if (!token.startsWith(trigger)) return null;
+
+  let tokenEnd = caret;
+  while (tokenEnd < value.length && !/\s/.test(value[tokenEnd])) tokenEnd += 1;
+
+  return {
+    start: tokenStart,
+    end: tokenEnd,
+    query: token.slice(trigger.length),
+  };
+}
+
+function refreshSkillAutocomplete(control) {
+  if (state.skillAutocomplete.composing) return;
+
+  const context = skillAutocompleteContext(control);
+  if (!context?.projectKey || !context.harness || !context.trigger) {
+    closeSkillAutocomplete();
+    return;
+  }
+
+  const token = skillAutocompleteToken(control, context.trigger);
+  if (!token) {
+    closeSkillAutocomplete();
+    return;
+  }
+
+  const requestId = state.skillAutocomplete.requestId + 1;
+  Object.assign(state.skillAutocomplete, {
+    control,
+    controlId: control.id || "",
+    projectKey: context.projectKey,
+    harness: context.harness,
+    trigger: context.trigger,
+    tokenStart: token.start,
+    tokenEnd: token.end,
+    query: token.query,
+    items: [],
+    highlightIndex: 0,
+    requestId,
+  });
+  closeSkillFlyout();
+  renderSkillAutocomplete({ loading: !state.skills[skillKey(context.projectKey, context.harness)] });
+
+  ensureSkillsForProject(context.projectKey, context.harness)
+    .then(() => {
+      if (state.skillAutocomplete.requestId !== requestId || state.skillAutocomplete.control !== control) return;
+      updateSkillAutocompleteItems();
+    })
+    .catch((error) => {
+      if (state.skillAutocomplete.requestId !== requestId) return;
+      closeSkillAutocomplete();
+      showGrowl(`Skills unavailable: ${error.message}`, "warning");
+    });
+}
+
+function updateSkillAutocompleteItems() {
+  const active = state.skillAutocomplete;
+  const query = active.query.toLowerCase();
+  const skills = state.skills[skillKey(active.projectKey, active.harness)] || [];
+  const matches = skills
+    .filter((skill) => String(skill?.name || skill?.["name"] || "").trim())
+    .filter((skill) => {
+      if (!query) return true;
+      return String(skill.name || skill["name"]).toLowerCase().includes(query);
+    })
+    .sort((left, right) => compareSkillAutocompleteItems(left, right, query))
+    .slice(0, 8);
+
+  active.items = matches;
+  active.highlightIndex = Math.min(active.highlightIndex, Math.max(matches.length - 1, 0));
+  renderSkillAutocomplete();
+}
+
+function compareSkillAutocompleteItems(left, right, query) {
+  const leftName = String(left.name || left["name"]).toLowerCase();
+  const rightName = String(right.name || right["name"]).toLowerCase();
+  if (query) {
+    const leftStarts = leftName.startsWith(query);
+    const rightStarts = rightName.startsWith(query);
+    if (leftStarts !== rightStarts) return leftStarts ? -1 : 1;
+  }
+  return compareDisplayText(leftName, rightName);
+}
+
+function skillAutocompleteElement() {
+  let element = document.querySelector("[data-skill-autocomplete]");
+  if (element) return element;
+
+  element = document.createElement("div");
+  element.className = "skill-autocomplete hidden";
+  element.setAttribute("data-skill-autocomplete", "");
+  element.setAttribute("role", "listbox");
+  element.setAttribute("aria-label", "Skill suggestions");
+  document.body.appendChild(element);
+  return element;
+}
+
+function renderSkillAutocomplete(options = {}) {
+  const active = state.skillAutocomplete;
+  const element = skillAutocompleteElement();
+  if (!rebindSkillAutocompleteControl()) {
+    closeSkillAutocomplete();
+    return;
+  }
+  const control = active.control;
+
+  const trigger = active.trigger || "$";
+  if (options.loading) {
+    element.innerHTML = `<div class="skill-autocomplete-empty">Loading skills…</div>`;
+    control.removeAttribute("aria-activedescendant");
+  } else {
+    const skillButtons = active.items.map((skill, index) => {
+      const name = String(skill.name || skill["name"] || "");
+      const selected = index === active.highlightIndex;
+      return `
+        <button
+          type="button"
+          id="skill-autocomplete-option-${index}"
+          role="option"
+          data-skill-autocomplete-index="${index}"
+          aria-selected="${selected ? "true" : "false"}"
+          class="${selected ? "active" : ""}"
+        >${escapeHtml(`${trigger}${name}`)}</button>
+      `;
+    }).join("");
+    const rescanIndex = active.items.length;
+    const rescanSelected = active.highlightIndex === rescanIndex;
+    const rescanButton = `
+      <button
+        type="button"
+        id="skill-autocomplete-option-${rescanIndex}"
+        role="option"
+        data-skill-autocomplete-index="${rescanIndex}"
+        data-skill-autocomplete-rescan
+        aria-selected="${rescanSelected ? "true" : "false"}"
+        class="skill-autocomplete-action${rescanSelected ? " active" : ""}"
+      >re-scan skills</button>
+    `;
+    element.innerHTML = active.items.length
+      ? `${skillButtons}${rescanButton}`
+      : `<div class="skill-autocomplete-empty">No skills match</div>${rescanButton}`;
+    control.setAttribute("aria-activedescendant", `skill-autocomplete-option-${active.highlightIndex}`);
+  }
+
+  control.setAttribute("aria-expanded", "true");
+  element.classList.remove("hidden");
+  positionSkillAutocomplete();
+  scrollSkillAutocompleteHighlightIntoView();
+}
+
+function positionSkillAutocomplete() {
+  const element = document.querySelector("[data-skill-autocomplete]");
+  if (!rebindSkillAutocompleteControl()) {
+    closeSkillAutocomplete();
+    return;
+  }
+  const control = state.skillAutocomplete.control;
+  if (!element || element.classList.contains("hidden")) return;
+
+  const rect = control.getBoundingClientRect();
+  const width = Math.min(360, Math.max(220, rect.width));
+  const left = Math.min(Math.max(12, rect.left), Math.max(12, window.innerWidth - width - 12));
+  const below = rect.bottom + 8;
+  element.style.width = `${width}px`;
+  element.style.left = `${left}px`;
+  if (below + 180 > window.innerHeight && rect.top > 80) {
+    element.style.top = "auto";
+    element.style.bottom = `${Math.max(12, window.innerHeight - rect.top + 8)}px`;
+  } else {
+    element.style.top = `${Math.min(below, Math.max(12, window.innerHeight - 188))}px`;
+    element.style.bottom = "auto";
+  }
+}
+
+function rebindSkillAutocompleteControl() {
+  const active = state.skillAutocomplete;
+  if (active.control && document.body.contains(active.control)) return true;
+  if (!active.controlId) return false;
+
+  const control = document.getElementById(active.controlId);
+  if (!control || control.tagName !== "TEXTAREA") return false;
+
+  active.control = control;
+  return true;
+}
+
+function restoreSkillAutocompleteAfterRender() {
+  const active = state.skillAutocomplete;
+  const element = document.querySelector("[data-skill-autocomplete]");
+  if (!active.controlId || !element || element.classList.contains("hidden")) return;
+  if (!rebindSkillAutocompleteControl()) {
+    closeSkillAutocomplete();
+    return;
+  }
+
+  refreshSkillAutocomplete(active.control);
+}
+
+function scrollSkillAutocompleteHighlightIntoView() {
+  const element = document.querySelector("[data-skill-autocomplete]:not(.hidden)");
+  if (!element) return;
+
+  const option = element.querySelector(`#skill-autocomplete-option-${state.skillAutocomplete.highlightIndex}`);
+  option?.scrollIntoView({ block: "nearest" });
+}
+
+function closeSkillAutocomplete() {
+  const active = state.skillAutocomplete;
+  active.control?.removeAttribute("aria-expanded");
+  active.control?.removeAttribute("aria-activedescendant");
+  const element = document.querySelector("[data-skill-autocomplete]");
+  if (element) element.classList.add("hidden");
+  Object.assign(active, {
+    control: null,
+    controlId: "",
+    projectKey: "",
+    harness: "",
+    tokenStart: 0,
+    tokenEnd: 0,
+    query: "",
+    items: [],
+    highlightIndex: 0,
+  });
+}
+
+function handleSkillAutocompleteKeydown(event) {
+  const active = state.skillAutocomplete;
+  if (active.control !== event.target || !document.querySelector("[data-skill-autocomplete]:not(.hidden)")) {
+    if (event.key.length === 1 || event.key === "Backspace" || event.key === "Delete") {
+      window.setTimeout(() => refreshSkillAutocomplete(event.target), 0);
+    }
+    return false;
+  }
+
+  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+    event.preventDefault();
+    const direction = event.key === "ArrowDown" ? 1 : -1;
+    const count = skillAutocompleteOptionCount();
+    if (count) {
+      active.highlightIndex = (active.highlightIndex + direction + count) % count;
+      renderSkillAutocomplete();
+    }
+    return true;
+  }
+
+  if (event.key === "Enter" || event.key === "Tab") {
+    if (!skillAutocompleteOptionCount()) return false;
+    event.preventDefault();
+    insertSkillAutocomplete(active.highlightIndex);
+    return true;
+  }
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeSkillAutocomplete();
+    return true;
+  }
+
+  window.setTimeout(() => refreshSkillAutocomplete(event.target), 0);
+  return false;
+}
+
+function skillAutocompleteOptionCount() {
+  const element = document.querySelector("[data-skill-autocomplete]:not(.hidden)");
+  if (!element || element.textContent.includes("Loading skills")) return 0;
+  return state.skillAutocomplete.items.length + 1;
+}
+
+function insertSkillAutocomplete(index) {
+  const active = state.skillAutocomplete;
+  const control = active.control;
+  if (index >= active.items.length) {
+    rescanSkillAutocomplete();
+    return;
+  }
+
+  const skill = active.items[index];
+  const name = String(skill?.name || skill?.["name"] || "").trim();
+  if (!control || !name) return;
+
+  const insert = `${active.trigger || "$"}${name} `;
+  const value = control.value || "";
+  control.value = `${value.slice(0, active.tokenStart)}${insert}${value.slice(active.tokenEnd)}`;
+  const caret = active.tokenStart + insert.length;
+  control.focus();
+  control.setSelectionRange(caret, caret);
+  control.dispatchEvent(new Event("input", { bubbles: true }));
+  closeSkillAutocomplete();
+
+  const form = control.closest("form");
+  if (form) saveFormDraft(form);
+}
+
+function rescanSkillAutocomplete() {
+  const active = state.skillAutocomplete;
+  const control = active.control;
+  if (!control || !active.projectKey || !active.harness) return;
+
+  const requestId = active.requestId + 1;
+  active.requestId = requestId;
+  active.items = [];
+  active.highlightIndex = 0;
+  renderSkillAutocomplete({ loading: true });
+
+  ensureSkillsForProject(active.projectKey, active.harness, { force: true })
+    .then(() => {
+      if (state.skillAutocomplete.requestId !== requestId || state.skillAutocomplete.control !== control) return;
+      const token = skillAutocompleteToken(control, active.trigger);
+      if (!token) {
+        closeSkillAutocomplete();
+        return;
+      }
+      Object.assign(active, {
+        tokenStart: token.start,
+        tokenEnd: token.end,
+        query: token.query,
+      });
+      updateSkillAutocompleteItems();
+    })
+    .catch((error) => {
+      if (state.skillAutocomplete.requestId !== requestId) return;
+      closeSkillAutocomplete();
+      showGrowl(`Skill re-scan failed: ${error.message}`, "warning");
+    });
+}
+
 function insertSkill(agentKey, skillName) {
   const agent = findAgent(agentKey);
   const input = document.getElementById("prompt-input");
@@ -7785,7 +8244,10 @@ function setSkillFlyoutOpen(open) {
   const button = document.querySelector("[data-toggle-skills]");
   if (!flyout || !button) return;
   if (open && button.disabled) return;
-  if (open) closeAttachmentFlyout();
+  if (open) {
+    closeAttachmentFlyout();
+    closeSkillAutocomplete();
+  }
 
   flyout.classList.toggle("hidden", !open);
   button.setAttribute("aria-expanded", open ? "true" : "false");
@@ -8312,6 +8774,8 @@ if (els.quickAgentDialog) {
       const effortSelect = dialog.querySelector("[data-quick-agent-effort]");
       if (modelSelect) modelSelect.innerHTML = modelChoiceOptions(harness, modelSelect.value || "");
       if (effortSelect) effortSelect.innerHTML = reasoningEffortChoiceOptions(harness, modelSelect?.value || "", effortSelect.value || "");
+      const prompt = dialog.querySelector("#quick-agent-prompt");
+      if (prompt === document.activeElement) refreshSkillAutocomplete(prompt);
       return;
     }
     const modelSelect = event.target.closest("[data-quick-agent-model]");
@@ -8334,7 +8798,30 @@ if (els.quickAgentDialog) {
     }
   });
 
+  els.quickAgentDialog.addEventListener("input", (event) => {
+    if (event.target?.id === "quick-agent-prompt") refreshSkillAutocomplete(event.target);
+  });
+
+  els.quickAgentDialog.addEventListener("compositionstart", (event) => {
+    if (event.target?.id === "quick-agent-prompt") state.skillAutocomplete.composing = true;
+  });
+
+  els.quickAgentDialog.addEventListener("compositionend", (event) => {
+    if (event.target?.id !== "quick-agent-prompt") return;
+    state.skillAutocomplete.composing = false;
+    refreshSkillAutocomplete(event.target);
+  });
+
+  els.quickAgentDialog.addEventListener("focusout", (event) => {
+    if (event.target !== state.skillAutocomplete.control) return;
+    window.setTimeout(() => {
+      if (!document.activeElement?.closest?.("[data-skill-autocomplete]")) closeSkillAutocomplete();
+    }, 0);
+  });
+
   els.quickAgentDialog.addEventListener("keydown", (event) => {
+    if (handleSkillAutocompleteKeydown(event)) return;
+
     const inPrompt = event.target.id === "quick-agent-prompt";
     if (event.key === "Enter" && inPrompt && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
       event.preventDefault();
@@ -8349,6 +8836,7 @@ if (els.quickAgentDialog) {
 
   // Click outside the form (on dialog backdrop) to close.
   els.quickAgentDialog.addEventListener("close", () => {
+    closeSkillAutocomplete();
     els.quickAgentDialog.innerHTML = "";
   });
 }

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1860,6 +1860,8 @@ module RemoteServerTest
     assert(css[:body].include?("overflow-wrap: anywhere"),
            "expected rendered markdown inline code to avoid horizontal page overflow")
     assert(css[:body].include?(".skill-flyout"), "expected skills to use a floating picker")
+    assert(css[:body].include?(".skill-autocomplete"), "expected prompt skill autocomplete to use a floating picker")
+    assert(css[:body].include?(".skill-autocomplete-action"), "expected skill autocomplete commands to have distinct styling")
     assert(css[:body].include?("min-height: min(180px, 42dvh)"),
            "expected the skill picker to show multiple skills before scrolling")
     assert(css[:body].include?(".agent-running-indicator"),
@@ -2287,6 +2289,22 @@ module RemoteServerTest
     assert(js[:body].include?("apiPatch"),
            "expected Remote UI to update agents through the API")
     assert(js[:body].include?("function toggleSkillFlyout"), "expected Insert Skill to use a floating slash picker")
+    assert(js[:body].include?("function refreshSkillAutocomplete"),
+           "expected Remote UI to provide prompt skill autocomplete")
+    assert(js[:body].include?("function ensureSkillsForProject"),
+           "expected Remote UI autocomplete to load skills for form project/harness pairs")
+    assert(js[:body].include?("skillAutocompleteToken(control, trigger)"),
+           "expected Remote UI autocomplete to replace the active trigger token")
+    assert(js[:body].include?("event.key === \"Enter\" || event.key === \"Tab\""),
+           "expected Remote UI autocomplete to support keyboard selection")
+    assert(js[:body].include?("data-skill-autocomplete-rescan"),
+           "expected Remote UI autocomplete to expose a re-scan command")
+    assert(js[:body].include?("ensureSkillsForProject(active.projectKey, active.harness, { force: true })"),
+           "expected Remote UI autocomplete re-scan to refresh the skill cache")
+    assert(js[:body].include?("function restoreSkillAutocompleteAfterRender"),
+           "expected Remote UI autocomplete to persist across polling renders")
+    assert(js[:body].include?("scrollSkillAutocompleteHighlightIntoView"),
+           "expected Remote UI autocomplete arrows to scroll the highlighted item into view")
     assert(js[:body].include?("!event.target.closest(\"[data-skill-flyout]\")"),
            "expected Skill flyout to close when clicking outside it")
     assert(js[:body].include?("agentIsRunning(agent)"),


### PR DESCRIPTION
## Summary

- Add token-aware skill autocomplete to the Remote UI chat composer, agent create/edit prompt, and Quick Agent prompt.
- Reuse the existing skills endpoint with a browser-side cache plus a `re-scan skills` command that forces a fresh discovery request.
- Keep the popup anchored near the composer, preserve it across polling refreshes, and scroll the highlighted option into view during keyboard navigation.

## Validation

- `node --check lib/hq/remote_ui/assets/app.js`
- `ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke`

## Note

- `bin/test` is blocked in this local environment before repo code runs because Bundler cannot materialize `openssl-4.0.1` and reports missing native gem extensions.
