### PR TITLE
[codex] Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.6.0 - 2026-06-20
+
+### Notable Releases
+
+- Add persisted Remote UI server switching for configured `remote_servers`,
+  including backend proxy routes, selected-server persistence, and peer health
+  display. (#39)
+- Add Remote UI skill autocomplete and a quick agent switcher for faster chat
+  composition and agent navigation. (#38)
+- Show run summaries in Remote UI conversations and allow any Remote UI
+  attachment file type.
+- Improve source-checkout execution by loading the local Bundler context from
+  `bin/tycho`. (#34)
+
+### Others
+
+- Preserve Remote UI scroll positions, menus, embedded attachment scroll, and
+  local diff scroll controls across polling refreshes.
+- Fix summary attachment menu behavior.
+- Split managed-agent command building, structured result normalization, and
+  shared Remote UI helpers into focused modules.
+- Add a throwaway Remote UI smoke script for browser checks against temp config
+  and log roots.
+- Add semantic `name` attributes to Remote UI form controls while preserving
+  existing labels and ARIA behavior. (#37)
+- Read and write FileStore JSON/YAML content as UTF-8 so persisted state remains
+  readable when Ruby's default external encoding is ASCII.
+
 ## 0.5.0 - 2026-06-13
 
 ### Notable Releases

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-06-13
+2026-06-20
 
 ## Strategic Direction
 
@@ -66,11 +66,12 @@ Key references:
 
 ## Current Focus
 
-**v0.5.0 release**: Tycho's current release focus is Remote UI schedule
-management, in-app project and PR diff review, Quick Agent creation,
-managed-agent CLI controls, and Remote UI polling/readability refinements. After
-release, the next focus is stabilizing install/update paths through Homebrew
-checks and continuing browser/TUI smoke verification.
+**v0.6.0 release**: Tycho's current release packages Remote UI multiserver
+switching, skill autocomplete, quick agent switching, run summary visibility,
+attachment handling, source-checkout boot fixes, and Remote UI state
+preservation. After release, the next focus is formalizing specs, stabilizing
+install/update paths through Homebrew checks, and continuing browser/TUI smoke
+verification.
 
 ## Roadmap
 
@@ -120,7 +121,7 @@ checks and continuing browser/TUI smoke verification.
 - [x] Connection-reused, tightened-timeout health checks
 - [x] Global `ctrl-g` terminal shortcut; `ctrl-r` HQ restart
 
-### v0.6 — [Current]: Agent UX Polish and Stabilize
+### v0.6 — Agent UX Polish and Stabilize ✓
 
 - [x] Project git info surfaced in agent detail
 - [x] Managed-agent unread-state fixes
@@ -129,9 +130,12 @@ checks and continuing browser/TUI smoke verification.
 - [x] Project’s icon statuses, similar to Agent’s icon statuses
 - [x] Omnisearch floating fuzzy finder for agents and projects
 - [x] Agent chat attachments from structured output (`ctrl+a` floating panel)
-- [ ] Formalize specs
+- [x] Remote UI multiserver switching for configured `remote_servers`
+- [x] Remote UI skill autocomplete and quick agent switching
+- [x] Remote UI run summaries, broader attachments, and state preservation fixes
+- [x] Source-checkout `bin/tycho` Bundler boot fix
 
-### v0.7 — [Current]: Open Source Readiness
+### v0.7 — Open Source Readiness ✓
 
 - [x] Add MIT license, README, contributing guide, code of conduct, security policy, changelog, issue templates, PR template, and CI workflow
 - [x] Add `bin/test` as the public CI-equivalent test runner
@@ -146,6 +150,12 @@ checks and continuing browser/TUI smoke verification.
 - [x] Add README screenshots for TUI and Remote UI workflows
 
 ## Features Candidates
+
+### Release Hardening
+
+- [ ] Formalize specs
+- [ ] Stabilize install/update paths through Homebrew checks
+- [ ] Continue browser/TUI smoke verification
 
 ### Model And Effort Arguments
 

--- a/lib/hq/domain/file_store.rb
+++ b/lib/hq/domain/file_store.rb
@@ -12,7 +12,7 @@ module HQ
     def read_json(path, fallback:)
       return fallback unless File.exist?(path)
 
-      JSON.parse(File.read(path))
+      JSON.parse(read_text(path))
     rescue StandardError => e
       if (backup = read_backup_json(path))
         log_warning("Recovered #{path} from backup after #{e.class}: #{e.message}")
@@ -36,7 +36,7 @@ module HQ
       temp_path = "#{path}.tmp-#{$PROCESS_ID}-#{SecureRandom.hex(6)}"
 
       File.open(temp_path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
-        file.write(content.to_s)
+        file.write(content.to_s.encode(Encoding::UTF_8))
         file.flush
         file.fsync
       end
@@ -57,10 +57,14 @@ module HQ
       backup = backup_path(path)
       return nil unless File.exist?(backup)
 
-      JSON.parse(File.read(backup))
+      JSON.parse(read_text(backup))
     rescue StandardError => e
       log_warning("Failed to read backup #{backup}: #{e.class} - #{e.message}")
       nil
+    end
+
+    def read_text(path)
+      File.read(path, mode: "r:UTF-8")
     end
 
     def copy_backup(path)

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/test/file_store_test.rb
+++ b/test/file_store_test.rb
@@ -13,6 +13,7 @@ module FileStoreTest
     assert_write_json_creates_backup_and_replaces_atomically
     assert_write_yaml_creates_backup_and_replaces_atomically
     assert_read_json_recovers_from_backup
+    assert_read_json_handles_utf8_when_external_encoding_is_ascii
     puts "file_store_test: ok"
   end
 
@@ -58,6 +59,22 @@ module FileStoreTest
 
       recovered = HQ::FileStore.read_json(path, fallback: [])
       assert(recovered == [{ "key" => "backup" }], "expected invalid primary JSON to recover from backup")
+    end
+  end
+
+  def assert_read_json_handles_utf8_when_external_encoding_is_ascii
+    Dir.mktmpdir("hq-file-store-test") do |dir|
+      path = File.join(dir, "state.json")
+      File.binwrite(path, JSON.pretty_generate([{ "name" => "Let’s implement autocomplete" }]))
+
+      previous_external = Encoding.default_external
+      Encoding.default_external = Encoding::US_ASCII
+      loaded = HQ::FileStore.read_json(path, fallback: [])
+
+      assert(loaded == [{ "name" => "Let’s implement autocomplete" }],
+             "expected UTF-8 JSON to load when default external encoding is US-ASCII")
+    ensure
+      Encoding.default_external = previous_external if previous_external
     end
   end
 


### PR DESCRIPTION
## Summary

- Bump Tycho to `0.6.0` and add the dated `CHANGELOG.md` release notes for June 20, 2026.
- Update `docs/PROJECT_STATUS.md` so the v0.6 milestone reflects the release scope and moves remaining release-hardening work into future candidates.
- Include the FileStore UTF-8 persistence fix and regression coverage so JSON/YAML state remains readable when Ruby's default external encoding is ASCII.

## Validation

- `bin/test`
