### PR TITLE
Fix remote server token recovery

### DIFF
--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -755,6 +755,10 @@ textarea {
 .server-token-form {
   display: grid;
   gap: 10px;
+  margin-top: 10px;
+}
+
+.server-list-item .server-token-form {
   margin: 0 12px 12px 46px;
 }
 
@@ -774,6 +778,15 @@ textarea {
 .server-list-item {
   display: grid;
   gap: 0;
+}
+
+.server-list-item > .detail-row {
+  align-items: start;
+}
+
+.server-list-item .chip {
+  width: max-content;
+  margin-top: 4px;
 }
 
 .server-section-label > div {
@@ -829,6 +842,34 @@ textarea {
 @media (max-width: 640px) {
   .server-connection-grid {
     grid-template-columns: 1fr;
+  }
+
+  .remote-server-list-item > .detail-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .remote-server-list-item > .detail-row > .server-row-actions {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .remote-server-list-item .server-row-actions .inline-icon-button {
+    justify-content: center;
+    min-width: 0;
+    padding-inline: 8px;
+  }
+
+  .remote-server-list-item .server-row-actions .inline-icon-button span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .remote-server-list-item .server-token-form {
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1809,10 +1809,11 @@ function renderNow() {
   const running = state.agents.filter((agent) => agent.running);
   const unread = state.agents.filter((agent) => agent.unread && !agent.awaiting_input && !agent.blocked && !agent.running);
   const scheduleSection = renderScheduleNowSection();
+  const tokenRecovery = renderActiveServerTokenRecovery();
   setHeader("Needs attention", connectionText(), "HQ");
   setMainHeaderMore("now");
 
-  if (waiting.length === 0 && blocked.length === 0 && running.length === 0 && unread.length === 0 && !scheduleSection) {
+  if (waiting.length === 0 && blocked.length === 0 && running.length === 0 && unread.length === 0 && !scheduleSection && !tokenRecovery) {
     replaceView(`
       <section class="summary-card attention">
         <p class="summary-text">Nothing to do, hooray!</p>
@@ -1843,11 +1844,29 @@ function renderNow() {
 
   replaceView(`
     ${summary}
+    ${tokenRecovery}
     ${scheduleSection}
     ${nowSection}
     ${unreadSection}
     ${runningSection}
   `);
+}
+
+function renderActiveServerTokenRecovery() {
+  const server = activeServer();
+  if (!server || server.local || remoteServerToken(server.key)) return "";
+  if (!String(connectionText()).includes("rejected broker credentials")) return "";
+
+  return `
+    <section class="summary-card attention">
+      <div class="card-title">
+        <strong>Remote token required</strong>
+        <span class="wrap-anywhere">${escapeHtml(server.name || server.key)}</span>
+      </div>
+      <p class="summary-text">Enter this server's token to save it for this browser.</p>
+      ${renderServerTokenForm(server)}
+    </section>
+  `;
 }
 
 function renderScheduleNowSection() {
@@ -2509,7 +2528,7 @@ function renderServerRow(server) {
     ? `<span class="chip ${tokenConfigured || tokenSaved ? "done" : "need"}">${escapeHtml(tokenLabel)}</span>`
     : "";
   return `
-    <div class="server-list-item">
+    <div class="server-list-item ${server.local ? "local-server-list-item" : "remote-server-list-item"}">
       <div class="detail-row">
         <span class="status-mark ${className}" aria-hidden="true">${iconSvg(active ? "check" : "activity")}</span>
         <div>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2501,8 +2501,14 @@ module RemoteServerTest
            js[:body].include?("saveRemoteServerToken") &&
            js[:body].include?("brokerGetWithHeaders") &&
            js[:body].include?("Remote token saved for this browser") &&
-           js[:body].include?("Token needed here"),
+           js[:body].include?("Token needed here") &&
+           js[:body].include?("function renderActiveServerTokenRecovery") &&
+           js[:body].include?("Remote token required"),
            "expected Settings to let existing remote servers save a browser-local token")
+    assert(css[:body].include?(".remote-server-list-item > .detail-row > .server-row-actions") &&
+           css[:body].include?("grid-template-columns: repeat(3, minmax(0, 1fr))") &&
+           css[:body].include?(".remote-server-list-item .server-row-actions .inline-icon-button span"),
+           "expected remote server row actions to fit small screens")
     assert(js[:body].include?("Restart the local Remote server to enable ad hoc peer switching"),
            "expected stale broker errors to explain that the local Remote server must be restarted")
     assert(!js[:body].include?("Connect local peer"),


### PR DESCRIPTION
## Summary

- show a Remote token required recovery card on the active server error screen when a peer rejects broker credentials and this browser has no saved peer token
- reuse the existing token save form so switching to a token-protected server no longer strands the user without a re-auth path
- improve small-screen server row layout by moving remote server actions into a full-width grid row

Follow-up for #42 / #41 before v0.6.1.

## Verification

- `git diff --check`
- `node --check lib/hq/remote_ui/assets/app.js`
- `ruby -c test/remote_server_test.rb`

Full local Ruby tests remain blocked in this shell by the previously observed Ruby/Bundler path issue.