### PR TITLE
Prepare v0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.6.1 - 2026-06-21
+
+### Bug Fixes
+
+- Add a Remote UI token re-authentication path for existing remote servers, so
+  another browser or device can save the peer token locally after switching to a
+  token-protected server. (#42)
+- Show a token recovery prompt when the active remote server rejects broker
+  credentials and tidy compact server-row actions on small screens. (#43)
+
 ## 0.6.0 - 2026-06-20
 
 ### Notable Releases

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
## Summary

- bump Tycho version to 0.6.1
- add v0.6.1 changelog entries for the Remote UI token re-authentication fixes

## Verification

- `mise exec -- bin/test`