### PR TITLE
[codex] Prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.7.0 - 2026-07-04
+
+### Notable Releases
+
+- Add OpenCode harness support, including stream parsing, fixtures, registry
+  wiring, harness inventory documentation, and skill discovery behavior.
+- Add daemon mode for the Remote Sessions server so local Remote UI processes
+  can be supervised more directly.
+- Remove the app orchestration surface and consolidate project handling around
+  the current project model.
+
+### Others
+
+- Add Remote UI agent switcher shortcuts and improve remote chat submission
+  feedback.
+- Add attachment content copy actions, tidy attachment detail controls, and fix
+  Remote UI attachment downloads.
+- Fix pull request diff counts and PR diff snapshot handling.
+- Fix Codex skill discovery roots and refresh Remote UI loading states with the
+  Tycho loader.
+
 ## 0.6.1 - 2026-06-21
 
 ### Bug Fixes

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-06-20
+2026-07-04
 
 ## Strategic Direction
 
@@ -61,12 +61,11 @@ Key references:
 
 ## Current Focus
 
-**v0.6.0 release**: Tycho's current release packages Remote UI multiserver
-switching, skill autocomplete, quick agent switching, run summary visibility,
-attachment handling, source-checkout boot fixes, and Remote UI state
-preservation. After release, the next focus is formalizing specs, stabilizing
-install/update paths through Homebrew checks, and continuing browser/TUI smoke
-verification.
+**v0.7.0 release**: Tycho's current release packages OpenCode harness support,
+Remote Sessions daemon mode, Remote UI agent-switcher shortcuts, attachment and
+PR diff fixes, and removal of the app orchestration surface. After release, the
+next focus is stabilizing install/update paths through Homebrew checks,
+hardening harness compatibility, and continuing browser/TUI smoke verification.
 
 ## Roadmap
 

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
## Summary

Prepare the Tycho `v0.7.0` release by bumping the packaged version, moving the release notes into a dated changelog section, and refreshing the durable project status current-focus note.

## Changes

- Bump `HQ::VERSION` from `0.6.1` to `0.7.0`.
- Add the `0.7.0 - 2026-07-04` changelog section covering OpenCode harness support, Remote Sessions daemon mode, Remote UI agent switcher shortcuts, attachment and PR diff fixes, and app orchestration removal.
- Update `docs/PROJECT_STATUS.md` to reflect the `v0.7.0` release focus and next stabilization priorities.

## Validation

- `bin/test` passed.
- Confirmed `v0.7.0` does not already exist locally before committing.
