### PR TITLE
Prepare v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.8.0 - 2026-07-21
+
+### Highlights
+
+- Add `tycho project` commands to create, inspect, update, and archive projects.
+  Use `--json` in scripts.
+- Add session loops in Remote UI to rerun an agent until a set time.
+- Keep scheduled runs in the same agent session so they retain conversation
+  context.
+- Add response-style to set your agent tone. For example: "Use the simplest
+  accurate words, active verbs, and concrete details." (#49)
+- Add a full-screen conversation editor that keeps drafts during refresh and
+  works on mobile.
+
+### Other changes
+
+- Improve Remote UI navigation, forms, conversations, summaries, diffs, and
+  attachments on desktop and mobile.
+- Add controls to run, pause, resume, and edit an agent schedule.
+- Let inquiry replies include optional written feedback.
+- Add attachment menus, refreshed previews, focused summary and file views, and
+  a smaller mobile reply box.
+- Add side-by-side and unified views for uncommitted Git changes.
+- Improve run activity, token usage, attachment previews, schedule status, and
+  agent renaming.
+- Use `no_action_needed` only when a check finds nothing to do.
+
+### Fixes
+
+- Pass agent prompts safely so prompt text is not read as command-line options.
+- Fix copying usage details when a value is missing.
+- Remove extra header spacing on standalone iPads.
+- Stop model and authentication checks from hanging when an agent CLI does not
+  respond.
+- Read models and authentication details from OpenCode 1.18.4 reliably.
+- Keep follow-up messages sent in the same second an agent run finishes.
+
 ## 0.7.4 - 2026-07-06
 
 ### Bug Fixes

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-07-12
+2026-07-21
 
 ## Strategic Direction
 
@@ -68,11 +68,11 @@ Key references:
 
 ## Current Focus
 
-**Remote UI stabilization**: the cross-route design audit is implemented across
-the responsive shell, contextual navigation/actions, forms, inquiry submission,
-Settings, conversations, diffs, summaries, and attachment reading. The next
-focus is stabilizing install/update paths through Homebrew checks, hardening
-harness compatibility, and continuing browser/TUI smoke verification.
+**v0.8 release**: the Remote UI stabilization work, project lifecycle CLI,
+session loops, persistent scheduled sessions, and cross-harness response style
+are complete. Codex 0.144.6, Claude Code 2.1.216, and OpenCode 1.18.4 pass cold
+and resumed managed-agent validation. The remaining work is to merge, publish,
+and verify the 0.8.0 packages and Homebrew bottles.
 
 ## Roadmap
 
@@ -148,13 +148,25 @@ harness compatibility, and continuing browser/TUI smoke verification.
 - [x] Publish public Homebrew tap formula
 - [x] Add README screenshots for TUI and Remote UI workflows
 
+### v0.8 — Remote Workflows and Release Hardening ✓
+
+- [x] Add project lifecycle commands with JSON output
+- [x] Add persistent scheduled sessions and temporary Remote UI session loops
+- [x] Add global and scoped cross-harness response-style policy
+- [x] Complete the responsive Remote UI design remediation and full-screen
+      conversation workflows
+- [x] Validate Codex 0.144.6, Claude Code 2.1.216, and OpenCode 1.18.4 cold and
+      resumed sessions
+- [x] Bound harness catalog probes and normalize OpenCode catalog output
+- [x] Document the Homebrew bottle `pr-pull` publishing workflow
+
 ## Features Candidates
 
 ### Release Hardening
 
 - [ ] Formalize specs
-- [ ] Stabilize install/update paths through Homebrew checks
-- [ ] Continue browser/TUI smoke verification
+- [x] Stabilize source packaging and pre-release browser/TUI checks
+- [ ] Publish and verify the 0.8.0 Homebrew bottles
 
 ### Model And Effort Arguments
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -83,10 +83,22 @@ validation.
 ## Homebrew Tap
 
 Tycho's public tap is `firewalker06/homebrew-tycho`.
+Its authoritative bottle workflow is documented in the tap's
+[`docs/RELEASING.md`](https://github.com/firewalker06/homebrew-tycho/blob/main/docs/RELEASING.md).
+The tap uses `brew test-bot` to build bottle artifacts and the `pr-pull`
+pull-request label to publish them. Do not merge the formula PR manually before
+the publish workflow runs.
 
 After the GitHub release exists:
 
-1. Download the release tarball and calculate its SHA-256:
+1. Confirm the upstream tag is visible:
+
+   ```sh
+   git ls-remote --tags https://github.com/firewalker06/tycho.git \
+     "refs/tags/v<next-version>*"
+   ```
+
+2. Download the release tarball and calculate its SHA-256:
 
    ```sh
    curl -L -o tycho-v<next-version>.tar.gz \
@@ -94,25 +106,59 @@ After the GitHub release exists:
    shasum -a 256 tycho-v<next-version>.tar.gz
    ```
 
-2. Update `Formula/tycho.rb` in the tap:
+3. Create a branch such as `tycho-<next-version>` in the tap and update
+   `Formula/tycho.rb`:
 
    ```ruby
    url "https://github.com/firewalker06/tycho/archive/refs/tags/v<next-version>.tar.gz"
    sha256 "..."
    ```
 
-3. Verify the formula locally when Homebrew is available:
+   Use commit subject `tycho <next-version>`.
+
+4. Validate the formula from the installed tap checkout:
 
    ```sh
-   brew install --build-from-source --verbose ./Formula/tycho.rb
-   brew test tycho
+   cd "$(brew --repository firewalker06/tycho)"
+   brew audit --strict --online firewalker06/tycho/tycho
+   brew install --build-from-source firewalker06/tycho/tycho
+   brew test firewalker06/tycho/tycho
+   brew uninstall firewalker06/tycho/tycho
    ```
 
    The formula test should include `tycho doctor`. On Intel macOS bottles this
    confirms the Ruby Lipgloss compatibility backend is selected and the native
    Lipgloss extension is not loaded into the Bubbletea process.
 
-4. Push or merge the tap update.
+5. Push the branch, open a pull request in `firewalker06/homebrew-tycho`, and
+   wait for every `brew test-bot` job to pass. The standard matrix builds Apple
+   Silicon macOS and Linux bottles. The separate `macos-15-intel` job builds the
+   Intel macOS bottle; confirm its `bottles_macos-15-intel` artifact contains a
+   `sequoia` bottle before publishing.
+
+6. After all bottle jobs pass, have a trusted maintainer add the `pr-pull`
+   label to the formula pull request. The tap's `pull_request_target` workflow
+   has write access and will:
+
+   - download the bottle artifacts from the pull-request workflow;
+   - create or update the `tycho-<next-version>` GitHub Release;
+   - upload the bottle assets;
+   - merge the generated `bottle do` checksums into `Formula/tycho.rb`;
+   - push the result to the tap's `main` branch; and
+   - delete the pull-request branch when it belongs to the tap repository.
+
+   Only trusted maintainers should apply `pr-pull`. Confirm the tap has the
+   label and that GitHub Actions can write repository contents before relying
+   on this step.
+
+7. Verify the published bottle:
+
+   ```sh
+   brew update
+   brew reinstall firewalker06/tycho/tycho
+   brew test firewalker06/tycho/tycho
+   brew info firewalker06/tycho/tycho
+   ```
 
 ## Post-Release Verification
 

--- a/lib/hq/domain/harness_catalog.rb
+++ b/lib/hq/domain/harness_catalog.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
-require "open3"
-require "timeout"
+require "tempfile"
 
 require_relative "../harness_registry"
 require_relative "../utf8_text"
@@ -19,6 +18,7 @@ module HQ
     ].freeze
     CLAUDE_REASONING_EFFORTS = %w[low medium high xhigh max].freeze
     COMMAND_TIMEOUT = 2
+    OPENCODE_COMMAND_TIMEOUT = 6
 
     module_function
 
@@ -141,14 +141,8 @@ module HQ
     end
 
     def claude_help_efforts(command)
-      _out, err, status = nil
-      out = ""
-      with_quiet_open3_timeout do
-        Timeout.timeout(COMMAND_TIMEOUT) do
-          out, err, status = Open3.capture3(command, "--help")
-        end
-      end
-      return [] unless status.success?
+      out, err, success = capture_command_output([command, "--help"])
+      return [] unless success
 
       text = "#{out}\n#{err}"
       match = text.match(/--effort\s+<[^>]+>.*?\(([^)]+)\)/m)
@@ -160,14 +154,8 @@ module HQ
     end
 
     def capture_json(command)
-      out = ""
-      status = nil
-      with_quiet_open3_timeout do
-        Timeout.timeout(COMMAND_TIMEOUT) do
-          out, _err, status = Open3.capture3(*command)
-        end
-      end
-      return nil unless status.success?
+      out, _err, success = capture_command_output(command)
+      return nil unless success
 
       JSON.parse(Utf8Text.normalize(out, replacement: "?"))
     rescue StandardError
@@ -175,11 +163,11 @@ module HQ
     end
 
     def opencode_model_rows(command)
-      out = capture_stdout([command, "models"])
+      out = capture_stdout([command, "models"], timeout: OPENCODE_COMMAND_TIMEOUT)
       return [] if out.to_s.empty?
 
       out.lines.filter_map do |line|
-        text = line.strip
+        text = strip_terminal_control(line).strip
         next if text.empty? || text.start_with?("Provider", "MODEL", "─", "-")
 
         value = text.split(/\s+/).find { |part| part.include?("/") }
@@ -191,36 +179,73 @@ module HQ
     end
 
     def opencode_auth_providers(command)
-      out = capture_stdout([command, "auth", "list"])
+      out = capture_stdout([command, "auth", "list"], timeout: OPENCODE_COMMAND_TIMEOUT)
       return [] if out.to_s.empty?
 
       out.lines.filter_map do |line|
-        text = line.strip
-        next if text.empty? || text.start_with?("─", "-") || text.match?(/\A(provider|name)\b/i)
+        text = strip_terminal_control(line).strip
+        text = text.sub(/\A[●○◐◯]\s*/, "")
+        next if text.empty? || text.start_with?("┌", "│", "└", "─", "-") || text.match?(/\A(provider|name)\b/i)
 
-        text.split(/\s+/).first
+        text.split(/\s+/).first&.downcase
       end.uniq
     end
 
-    def capture_stdout(command)
-      out = ""
-      status = nil
-      with_quiet_open3_timeout do
-        Timeout.timeout(COMMAND_TIMEOUT) do
-          out, _err, status = Open3.capture3(*command)
-        end
-      end
-      status.success? ? Utf8Text.normalize(out, replacement: "?") : ""
+    def capture_stdout(command, timeout: COMMAND_TIMEOUT)
+      out, _err, success = capture_command_output(command, timeout:)
+      success ? Utf8Text.normalize(out, replacement: "?") : ""
     rescue StandardError
       ""
     end
 
-    def with_quiet_open3_timeout
-      previous = Thread.report_on_exception
-      Thread.report_on_exception = false
-      yield
+    def capture_command_output(command, timeout: COMMAND_TIMEOUT)
+      stdout = Tempfile.new("tycho-harness-catalog-out")
+      stderr = Tempfile.new("tycho-harness-catalog-err")
+      pid = Process.spawn(*command, out: stdout.path, err: stderr.path, pgroup: true)
+      deadline = Time.now + timeout
+      status = nil
+      timed_out = false
+
+      loop do
+        _done, status = Process.waitpid2(pid, Process::WNOHANG)
+        break if status
+        break if Time.now >= deadline
+
+        sleep 0.05
+      end
+
+      unless status
+        timed_out = true
+        status = terminate_process_group(pid)
+        _done, status = Process.waitpid2(pid) unless status
+      end
+
+      stdout.rewind
+      stderr.rewind
+      [stdout.read, stderr.read, status.success? && !timed_out]
     ensure
-      Thread.report_on_exception = previous
+      stdout&.close!
+      stderr&.close!
+    end
+
+    def terminate_process_group(pid)
+      Process.kill("TERM", -pid)
+      deadline = Time.now + 0.5
+      loop do
+        _done, status = Process.waitpid2(pid, Process::WNOHANG)
+        return status if status
+        break if Time.now >= deadline
+
+        sleep 0.05
+      end
+      Process.kill("KILL", -pid)
+      nil
+    rescue Errno::ESRCH, Errno::ECHILD
+      nil
+    end
+
+    def strip_terminal_control(text)
+      text.to_s.gsub(/\e\[[0-9;?]*[ -\/]*[@-~]/, "")
     end
 
     def sort_efforts(values)

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -1373,7 +1373,8 @@ module HQ
                       composed_prompt
                     else
                       threshold = last_run&.finished_at || @finished_at || @started_at
-                      latest = memory_store.latest_user_message_after(threshold)
+                      threshold = Time.at(threshold.to_i) if threshold
+                      latest = memory_store.latest_user_message_after(threshold, inclusive: true)
                       latest.to_s.strip.empty? ? "Continue from the current HQ managed-agent state." : latest.to_s
                     end
       with_execution_guidance(base_prompt, response_style:)

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.7.4"
+  VERSION = "0.8.0"
 end

--- a/test/harness_catalog_test.rb
+++ b/test/harness_catalog_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+require_relative "../lib/hq/domain/harness_catalog"
+
+module HarnessCatalogTest
+  module_function
+
+  def run!
+    assert_codex_catalog_probe_times_out_hung_cli
+    assert_timeout_handles_term_exit_without_double_wait
+    assert_opencode_auth_table_strips_status_glyphs
+    puts "harness_catalog_test: ok"
+  end
+
+  def assert_timeout_handles_term_exit_without_double_wait
+    Dir.mktmpdir("hq-harness-catalog-test") do |dir|
+      executable = File.join(dir, "term-aware-probe")
+      File.write(executable, <<~SH)
+        #!/bin/sh
+        trap 'exit 0' TERM
+        sleep 30
+      SH
+      FileUtils.chmod(0o755, executable)
+
+      started = Time.now
+      _out, _err, success = HQ::HarnessCatalog.send(
+        :capture_command_output,
+        [executable],
+        timeout: 0.2
+      )
+      elapsed = Time.now - started
+
+      assert(elapsed < 2.0, "expected TERM-aware probe to stop promptly, took #{elapsed.round(2)}s")
+      assert(!success, "expected a timed-out probe not to count a successful TERM handler exit")
+    end
+  end
+
+  def assert_codex_catalog_probe_times_out_hung_cli
+    Dir.mktmpdir("hq-harness-catalog-test") do |dir|
+      executable = File.join(dir, "hung-codex")
+      File.write(executable, <<~SH)
+        #!/bin/sh
+        trap '' TERM
+        sleep 30
+      SH
+      FileUtils.chmod(0o755, executable)
+
+      previous_timeout = replace_constant(HQ::HarnessCatalog, :COMMAND_TIMEOUT, 0.2)
+      started = Time.now
+      catalog = HQ::HarnessCatalog.codex_catalog(
+        Struct.new(:command, keyword_init: true) do
+          def available?
+            true
+          end
+        end.new(command: executable)
+      )
+      elapsed = Time.now - started
+
+      assert(elapsed < 2.0, "expected hung Codex catalog probe to time out, took #{elapsed.round(2)}s")
+      assert(catalog[:catalog_source] == "codex debug models unavailable",
+             "expected unavailable catalog source for hung Codex CLI")
+    ensure
+      replace_constant(HQ::HarnessCatalog, :COMMAND_TIMEOUT, previous_timeout) if previous_timeout
+    end
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+
+  def assert_opencode_auth_table_strips_status_glyphs
+    Dir.mktmpdir("hq-harness-catalog-test") do |dir|
+      executable = File.join(dir, "opencode")
+      File.write(executable, <<~SH)
+        #!/bin/sh
+        if [ "$1" = "auth" ] && [ "$2" = "list" ]; then
+          printf '\\033[0m\\n'
+          printf '┌  Credentials ~/.local/share/opencode/auth.json\\n'
+          printf '│\\n'
+          printf '●  Anthropic api\\n'
+          printf '●  Google oauth\\n'
+          printf '└  2 credentials\\n'
+          exit 0
+        fi
+        exit 0
+      SH
+      FileUtils.chmod(0o755, executable)
+
+      providers = HQ::HarnessCatalog.opencode_auth_providers(executable)
+      assert(providers == %w[anthropic google],
+             "expected OpenCode auth providers without table glyphs, got #{providers.inspect}")
+    end
+  end
+
+  def replace_constant(parent, name, value)
+    old = parent.const_get(name)
+    parent.send(:remove_const, name)
+    parent.const_set(name, value)
+    old
+  end
+end
+
+HarnessCatalogTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -25,6 +25,7 @@ module ManagedAgentTest
     assert_opencode_assistant_json_structured_output_normalizes
     assert_final_output_checklist_is_ephemeral_execution_context
     assert_response_style_applies_to_cold_and_resumed_runs
+    assert_native_resume_includes_same_second_follow_up
     assert_response_style_can_be_disabled_and_run_session_is_recorded
     assert_agent_result_schema_describes_summary
     assert_no_action_status_conflicts_are_normalized
@@ -70,6 +71,43 @@ module ManagedAgentTest
            "expected response style guidance on a native resumed run")
     assert(!resume_prompt.include?("Inspect the project."),
            "expected a native resumed run not to replay the base prompt")
+  end
+
+  def assert_native_resume_includes_same_second_follow_up
+    old_logs_dir = nil
+    Dir.mktmpdir("hq-managed-agent-resume-prompt-test") do |dir|
+      logs_dir = File.join(dir, "agents")
+      FileUtils.mkdir_p(logs_dir)
+      old_logs_dir = replace_constant(HQ, :AGENT_LOGS_DIR, logs_dir)
+      finished_at = Time.parse("2026-07-18T13:09:48+07:00") + 0.75
+      follow_up = "Resume immediately with this same-second follow-up."
+      agent = HQ::ManagedAgent.new(
+        key: "same-second-resume",
+        name: "Same second resume",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "Cold prompt",
+        agent: "opencode",
+        session_id: "ses_same_second",
+        runs: [HQ::ManagedAgent::AgentRun.new(
+          started_at: finished_at - 5,
+          finished_at: finished_at,
+          exit_code: 0,
+          status: "success",
+          command: "opencode run"
+        )]
+      )
+      agent.send(:memory_store).append_user_message!(follow_up, created_at: finished_at)
+
+      prompt = agent.send(:prompt_for_execution)
+      assert(prompt.include?(follow_up),
+             "expected native resume prompt to include follow-up created at the prior finish timestamp")
+      assert(!prompt.include?("Continue from the current HQ managed-agent state."),
+             "expected same-second follow-up to replace generic resume prompt")
+    end
+  ensure
+    replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
   end
 
   def assert_response_style_can_be_disabled_and_run_session_is_recorded


### PR DESCRIPTION
## Summary

- prepare the changelog and project status for Tycho 0.8.0
- document the Homebrew tap `pr-pull` workflow
- harden harness checks against commands that hang and current OpenCode output
- keep follow-up messages sent as an agent run finishes
- bump `HQ::VERSION` to `0.8.0`

Existing config and managed-agent state require no migration.

Validated with Codex 0.144.6, Claude Code 2.1.216, and OpenCode 1.18.4.

## Validation

- `bin/test`
- `bundle exec ruby -c bin/tycho`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke`
- isolated `bin/tycho` TUI launch and clean exit
- temporary `tycho project create|show|update|archive --json` lifecycle
- `gem build hq.gemspec` plus unpacked package inspection
- cold and resumed managed-agent runs for all three built-in harnesses
