### PR TITLE
Prepare v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.9.0 - 2026-07-31
+
+### Highlights
+
+- Make multiserver Agents and Projects persistent in Remote UI, with
+  server-qualified resources, bounded peer refresh, stale last-good snapshots,
+  and explicit peer cache removal.
+- Introduce the Remote UI design system across Settings, forms, menus, status
+  badges, confirmations, detail headers, empty states, and agent ledgers.
+- Show each connected server's Tycho version in Settings, and flag peers whose
+  version differs from the host while keeping older peers backward-compatible as
+  version unknown.
+
+### Other changes
+
+- Prepare for a future GitHub App workflow, including device login,
+  installation guidance, guarded review posting, immutable diff snapshots, and a
+  paused Review Inbox while eager aggregation is redesigned. The GitHub App is
+  not applicable for general use yet.
+- Compact grouped Agents and Projects lists while preserving ownership,
+  filtering, bulk archive behavior, and mobile action geometry.
+- Add Claude Opus 5 to Claude model suggestions.
+- Track lifetime agent run counts and preserve managed-agent run log offsets
+  beyond the raw-log tail window.
+- Add shared confirmation flows, contextual menu behavior, and composite
+  Settings section patterns.
+
+### Fixes
+
+- Make remote server tests independent of auth state.
+- Preserve Now context menus across polling refreshes.
+- Prevent schedule action menus from clipping.
+- Stop agents with stale unstructured output and preserve stopped-agent signal
+  exit status.
+- Normalize GitHub CLI output as UTF-8.
+
 ## 0.8.0 - 2026-07-21
 
 ### Highlights

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1987,6 +1987,7 @@ def write_smoke_script(path)
               icon: "server",
               url: "http://127.0.0.1:7499",
               local: false,
+              version: "0.1.0-peer",
               auth_configured: false,
               status: "online",
               stale: false,
@@ -1996,6 +1997,14 @@ def write_smoke_script(path)
           ];
           render();
         });
+        const serverSettingsText = await page.locator("#settings-servers").innerText();
+        const peerVersionLabel = await page.locator(".remote-server-list-item .server-target-line").innerText();
+        const peerVersionTitle = await page.locator(".remote-server-list-item .server-target-line").getAttribute("title");
+        if (!serverSettingsText.includes("Tycho ") ||
+            !peerVersionLabel.includes("Tycho 0.1.0-peer") ||
+            !peerVersionTitle?.includes("differs from host")) {
+          throw new Error(`Settings server list lost version metadata: ${JSON.stringify({ serverSettingsText, peerVersionLabel, peerVersionTitle })}`);
+        }
         const localServerMenu = page.locator(".local-server-list-item [data-server-action-menu]");
         await localServerMenu.locator("> summary").click();
         const localServerActions = await localServerMenu.locator("[role='menuitem']").evaluateAll((items) => (

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1428,6 +1428,10 @@ def write_smoke_script(path)
           if (state.agentSettingsOpen) toggleAgentSettings();
         });
         await page.waitForSelector("#agent-settings-panel", { state: "hidden", timeout: 10_000 });
+        await page.waitForFunction((key) => {
+          const agent = findAgent(key);
+          return agent && !agentIsRunning(agent);
+        }, agentKey, { timeout: 10_000 });
         await page.click("#prompt-input");
         await page.fill("#prompt-input", "$rev");
         await page.evaluate(() => refreshSkillAutocomplete(document.querySelector("#prompt-input")));

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-07-29
+2026-07-31
 
 ## Strategic Direction
 
@@ -76,50 +76,18 @@ Key references:
 
 ## Current Focus
 
-**v0.8 release**: the Remote UI stabilization work, project lifecycle CLI,
-session loops, persistent scheduled sessions, and cross-harness response style
-are complete. Codex 0.144.6, Claude Code 2.1.216, and OpenCode 1.18.4 pass cold
-and resumed managed-agent validation. The remaining work is to merge, publish,
-and verify the 0.8.0 packages and Homebrew bottles. The first Remote UI design
-system increment now provides semantic foundations, a component preview, and a
-Settings Response style migration. Agent, project, schedule, and schedule-message
-lifecycle forms and structured inquiry decisions now use the same field, input,
-surface, error, and action contracts. Agent, schedule, project, setup, and diff
-health now map through one six-intent status taxonomy. Primary non-modal menus
-now share overlay layering, peer and outside dismissal, arrow navigation, Escape
-handling, and focus restoration without replacing native details/dialog behavior.
-Consequential Remote UI actions now use one native-dialog confirmation contract
-with explicit consequences, safe initial focus, and trigger focus restoration.
-Lifecycle forms and Settings sections now share composite layout, section-heading,
-action, selection, and panel contracts while route-specific grids and sticky
-behavior remain local. Agent runtime defaults are summarized behind an Advanced
-disclosure, and Session loop controls now use the same input surface as other
-Remote UI forms. The Agents index now uses a searchable-collection contract with
-explicit filtered-result feedback while keeping its grouping, sort, and bulk
-behavior unchanged. Focused project, agent, summary, attachment, and diff routes
-share one detail-header anatomy while preserving route history, menus, and
-split-reader layout. Settings server connection, browser-token, and harness
-catalog forms now use the same described field, input, action, and pending
-contracts as other Remote UI forms. Remote peer actions now use one contextual
-More menu, while custom catalog editors collapse without hiding configured model
-or effort values. Compact factual metadata now uses one neutral badge
-contract across Settings, schedules, projects, diffs, and lifecycle forms;
-operational health, urgency, and progress remain in the semantic status taxonomy.
-Route-level loading and settled empty states now use distinct shared contracts.
-Known-intent guidance and recovery messages use one alert helper that separates
-visual intent from polite or assertive announcement timing.
-All generated legacy primary, danger, inline-icon, icon-only, and button-link
-actions now consume the shared button contract while retaining their existing
-behavior selectors and product layout classes.
-The Remote UI now includes a GitHub App-authenticated pull request review loop. It aggregates
-agent, schedule, project, and current-branch occurrences into one queue, fetches
-review context through direct GitHub REST and GraphQL calls, and keeps immutable
-diff snapshots separate from read, viewed, selection, draft, handoff, and outcome
-state. OAuth device login keeps access and refresh tokens server-side, refreshes
-expiring sessions, and exposes installation guidance for each target owner. Existing
-`gh` authentication remains a compatibility source when no App session exists.
-Review posting is disabled unless `TYCHO_GITHUB_WRITE_ENABLED=true`, then requires
-an explicit confirmation and current base/head validation.
+**v0.9 release**: persistent multiserver Agent and Project catalogs and the
+second Remote UI design-system pass are complete. The Remote UI now aggregates
+peer agents and projects through a stale-while-revalidate broker catalog, keeps
+server-qualified detail and mutation routes explicit, persists last-good peer
+snapshots, and shows each connected server's Tycho version in Settings with
+host-version mismatch detection. GitHub App groundwork is present, including
+device login, guarded review posting, and immutable diff snapshots, but the
+canonical App workflow is not applicable for general use yet and the Review
+Inbox route remains paused until discovery is redesigned around bounded
+incremental loading. The remaining v0.9.0 work is to merge the release-prep
+commit, tag the release, publish GitHub notes, update the Homebrew tap, and
+verify the bottle.
 
 ## Roadmap
 
@@ -208,13 +176,25 @@ an explicit confirmation and current base/head validation.
 - [x] Bound harness catalog probes and normalize OpenCode catalog output
 - [x] Document the Homebrew bottle `pr-pull` publishing workflow
 
+### v0.9 — Multiserver and Review Workflows ✓
+
+- [x] Add persistent multiserver Agent and Project catalogs in Remote UI
+- [x] Persist last-good peer snapshots across broker restarts and failed refreshes
+- [x] Route peer Agent and Project details and mutations through explicit server keys
+- [x] Show peer health, token state, and Tycho version compatibility in Settings
+- [x] Prepare GitHub App device login and guarded pull request review posting
+- [x] Store immutable pull request diff snapshots separately from review state
+- [x] Promote Remote UI design-system contracts across forms, menus, badges,
+      confirmations, detail headers, and empty states
+- [x] Pause the eager Review Inbox until bounded discovery and loading are redesigned
+
 ## Features Candidates
 
 ### Release Hardening
 
 - [ ] Formalize specs
 - [x] Stabilize source packaging and pre-release browser/TUI checks
-- [ ] Publish and verify the 0.8.0 Homebrew bottles
+- [ ] Publish and verify the 0.9.0 Homebrew bottles
 
 ### Canonical Tycho GitHub App
 

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -692,7 +692,8 @@ module HQ
             icon: index.zero? ? "home" : config.icon,
             url: config.url,
             local: index.zero?,
-            auth_configured: !config.resolved_token.to_s.empty?
+            auth_configured: !config.resolved_token.to_s.empty?,
+            version: index.zero? ? HQ::VERSION : nil
           }
           persisted = @persisted_entries[config.key]
           if persisted && !valid_persisted_entry?(persisted, metadata)
@@ -879,6 +880,7 @@ module HQ
       end
       {
         success: true,
+        version: resource_version(payload),
         agents: agents,
         projects: projects,
         resource_mode: mode
@@ -917,6 +919,7 @@ module HQ
           next_refresh_at: (Time.now + REFRESH_INTERVAL_SECONDS).iso8601,
           retry_after_ms: REFRESH_INTERVAL_SECONDS * 1000,
           resource_mode: result[:resource_mode],
+          version: result[:version],
           agents: decorate_resources(result[:agents], entry, kind: "agent"),
           projects: decorate_resources(result[:projects], entry, kind: "project")
         )
@@ -994,6 +997,7 @@ module HQ
       entry.merge(
         last_success_at: value_for(persisted, "last_success_at"),
         stale: true,
+        version: value_for(persisted, "version"),
         resource_mode: value_for(persisted, "resource_mode"),
         agents: decorate_resources(value_for(persisted, "agents"), metadata, kind: "agent"),
         projects: decorate_resources(value_for(persisted, "projects"), metadata, kind: "project")
@@ -1047,6 +1051,7 @@ module HQ
               {
                 key: entry[:key],
                 url: entry[:url],
+                version: entry[:version],
                 last_success_at: entry[:last_success_at],
                 resource_mode: entry[:resource_mode],
                 agents: persisted_resources(entry[:agents]),
@@ -1074,6 +1079,15 @@ module HQ
           result[name] = value
         end
       end
+    end
+
+    def resource_version(payload)
+      build = value_for(payload, "build")
+      version = build.is_a?(Hash) ? value_for(build, "version").to_s : ""
+      version = value_for(payload, "version").to_s if version.empty?
+      server = value_for(payload, "server")
+      version = value_for(server, "version").to_s if version.empty? && server.is_a?(Hash)
+      version.empty? ? nil : version
     end
 
     def config_for(key, registry:, server_url:)
@@ -1325,7 +1339,8 @@ module HQ
         icon: local ? "home" : (config.respond_to?(:icon) ? config.icon : "server"),
         url: config.url,
         local: local,
-        auth_configured: !config.resolved_token.to_s.empty?
+        auth_configured: !config.resolved_token.to_s.empty?,
+        version: local ? HQ::VERSION : nil
       }
     end
 
@@ -1451,6 +1466,9 @@ module HQ
       {
         schema_version: RemoteResourceCatalog::SCHEMA_VERSION,
         generated_at: Time.now.iso8601,
+        build: {
+          version: HQ::VERSION
+        },
         agents: agents.map { |agent| agent_list_payload(agent) },
         projects: visible_projects.map do |project|
           project_list_payload(project, agents: agents_by_project.fetch(project.key, []))

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1026,6 +1026,7 @@ textarea {
 
 .server-list-item > .detail-row {
   align-items: start;
+  padding: 6px 10px;
 }
 
 .server-list-item .chip {
@@ -1039,6 +1040,18 @@ textarea {
 
 .server-list-item .server-row-chips .chip {
   margin-top: 0;
+}
+
+.server-target-line {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.server-target-line[data-intent="warning"] {
+  color: var(--warning);
 }
 
 .server-section-label > div {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -914,6 +914,29 @@ function serverHealthClass(server) {
   return "fail";
 }
 
+function hostVersion() {
+  return String(state.setup?.build?.version || "").trim();
+}
+
+function serverVersion(server) {
+  return String(server?.version || "").trim();
+}
+
+function serverVersionState(server) {
+  const version = serverVersion(server);
+  const host = hostVersion();
+  if (!version) return { label: "Version unknown", title: "Tycho version unknown", className: "detail" };
+  if (!host || server.local || version === host) return { label: `Tycho ${version}`, title: `Tycho ${version}`, className: "detail" };
+  return { label: `Tycho ${version}`, title: `Tycho ${version} differs from host ${host}`, className: "need" };
+}
+
+function serverTargetLine(server, label) {
+  const version = serverVersionState(server);
+  const className = String(version.className || "detail");
+  const title = `${label} · ${version.title}`;
+  return `<span class="server-target-line ${escapeAttr(className)}" data-intent="${escapeAttr(statusIntent(className))}" title="${escapeAttr(title)}" aria-label="${escapeAttr(title)}">${escapeHtml(label)} · ${escapeHtml(version.label)}</span>`;
+}
+
 function serverHealthIconBadge(server) {
   const label = serverHealthLabel(server);
   const className = serverHealthClass(server);
@@ -4039,7 +4062,7 @@ function renderServerRow(server) {
         <span class="status-mark ${className}" ${statusMarkAttributes(className)} aria-hidden="true">${iconSvg(serverIconName(server))}</span>
         <div>
           <strong>${escapeHtml(serverDisplayName(server))}</strong>
-          <span class="wrap-anywhere">${escapeHtml(label)}</span>
+          ${serverTargetLine(server, label)}
           <span class="chip-row server-row-chips">
             ${statusBadge(serverHealthLabel(server), className, "chip")}
             ${tokenPill}

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2205,8 +2205,10 @@ module RemoteServerTest
              "expected broker server list to include local and configured remotes")
       assert(servers.first[:local] == true, "expected local broker server to be marked local")
       assert(servers.first[:icon] == "home", "expected local broker server to use the home icon")
-      assert(servers.first.keys.sort == %i[auth_configured icon key local name url],
+      assert(servers.first.keys.sort == %i[auth_configured icon key local name url version],
              "expected broker server list to include only display metadata")
+      assert(servers.first[:version] == HQ::VERSION,
+             "expected local broker server to expose the running Tycho version")
       remote = servers.last
       assert(remote[:name] == "Office Mac", "expected configured remote display name")
       assert(remote[:icon] == "computer", "expected configured remote icon")
@@ -2221,6 +2223,7 @@ module RemoteServerTest
     peer_failing = false
     peer_payload = {
       schema_version: 1,
+      build: { version: "0.9.0-peer" },
       agents: [{ key: "peer-agent", name: "Peer Agent", project_key: "peer-project" }],
       projects: [{ key: "peer-project", name: "Peer Project" }]
     }
@@ -2266,6 +2269,7 @@ module RemoteServerTest
         local_service = local_service_class.new(
           {
             schema_version: 1,
+            build: { version: HQ::VERSION },
             agents: [{ key: "local-agent", name: "Local Agent", project_key: "local-project" }],
             projects: [{ key: "local-project", name: "Local Project" }]
           }
@@ -2303,6 +2307,8 @@ module RemoteServerTest
                "expected peer catalog resources to carry ownership")
         assert(peer[:projects].first[:key] == "peer-project",
                "expected peer projects to share the combined catalog")
+        assert(local[:version] == HQ::VERSION && peer[:version] == "0.9.0-peer",
+               "expected resource catalog servers to expose host and peer Tycho versions")
         assert(File.exist?(snapshot_path), "expected a successful peer refresh to persist its snapshot")
         assert((File.stat(snapshot_path).mode & 0o777) == 0o600,
                "expected persisted peer snapshots to be private")
@@ -2337,6 +2343,8 @@ module RemoteServerTest
                "expected a restored peer snapshot to start stale while it reconnects")
         assert(restored_peer[:last_success_at] == peer[:last_success_at],
                "expected a restored peer snapshot to preserve its last successful refresh")
+        assert(restored_peer[:version] == "0.9.0-peer",
+               "expected a restored peer snapshot to preserve the last known Tycho version")
         assert(restored_peer[:agents].first[:key] == "peer-agent",
                "expected peer agents to survive a broker restart")
 


### PR DESCRIPTION
## Summary

- bump Tycho to `0.9.0`
- add the `0.9.0 - 2026-07-31` changelog section
- update project status for the v0.9 release milestone
- include the Settings server-version compatibility work in the release notes
- harden the Remote UI smoke fixture by waiting for the agent to be idle before asserting skill autocomplete

## Validation

- `bin/test`
- `bin/remote-ui-smoke`

## Release Notes

Highlights focus on persistent multiserver Agents and Projects in Remote UI, the Remote UI design system, and connected-server version compatibility. GitHub App work is listed as preparation for a future workflow and is not presented as generally applicable yet.
