### PR TITLE
Add Markdown code copy menu

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -519,6 +519,57 @@ def write_smoke_script(path)
         }
 
         await page.evaluate(() => {
+          const copied = [];
+          Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: { writeText: async (value) => copied.push(value) },
+          });
+          window.__markdownCodeCopies = copied;
+          const source = [
+            "```ruby",
+            "puts '<ready>'",
+            "```",
+          ].join("\\n");
+          replaceView([renderMarkdown(source), renderMarkdown(source)].join(""));
+        });
+        const markdownCodeTriggers = page.locator("[data-toggle-markdown-code-menu]");
+        if (await markdownCodeTriggers.count() !== 2 ||
+            await page.locator(".markdown-code-block > pre > code").nth(0).textContent() !== "puts '<ready>'\\n") {
+          throw new Error("Markdown code menus did not render independently for identical viewers");
+        }
+        await markdownCodeTriggers.nth(0).click();
+        const markdownCopyItem = page.getByRole("menuitem", { name: "Copy" });
+        if (await markdownCopyItem.count() !== 1 ||
+            await markdownCodeTriggers.nth(0).getAttribute("aria-expanded") !== "true" ||
+            await markdownCodeTriggers.nth(1).getAttribute("aria-expanded") !== "false") {
+          throw new Error("Opening one Markdown code menu also opened another viewer's menu");
+        }
+        await markdownCopyItem.click();
+        await page.waitForFunction(() => document.querySelector("#growl")?.textContent === "Copied to clipboard");
+        const markdownCopySuccess = await page.evaluate(() => ({
+          copies: window.__markdownCodeCopies,
+          menus: document.querySelectorAll(".markdown-code-menu .block-menu-popover").length,
+        }));
+        if (JSON.stringify(markdownCopySuccess.copies) !== JSON.stringify(["puts '<ready>'\\n"]) ||
+            markdownCopySuccess.menus !== 0) {
+          throw new Error(`Markdown code Copy click did not copy raw text and close its menu: ${JSON.stringify(markdownCopySuccess)}`);
+        }
+
+        await page.evaluate(() => {
+          navigator.clipboard.writeText = async () => { throw new Error("blocked"); };
+        });
+        await markdownCodeTriggers.nth(1).click();
+        const markdownFailureCopyItem = page.getByRole("menuitem", { name: "Copy" });
+        if (await markdownFailureCopyItem.count() !== 1) {
+          throw new Error("Markdown code Copy menu did not open for failure feedback");
+        }
+        await markdownFailureCopyItem.click();
+        await page.waitForFunction(() => document.querySelector("#growl")?.textContent === "Copy failed");
+        if (await page.locator(".markdown-code-menu .block-menu-popover").count() !== 0) {
+          throw new Error("Markdown code Copy failure did not close the menu");
+        }
+
+        await page.evaluate(() => {
           state.renderedViewHtml = "";
           render();
         });

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -4452,10 +4452,42 @@ select {
   border: 1px solid color-mix(in srgb, var(--border) 78%, var(--panel-soft));
   border-radius: 8px;
   background: color-mix(in srgb, var(--bg) 82%, black);
-  padding: 12px;
+  padding: 12px 44px 12px 12px;
   color: var(--text);
   line-height: 1.55;
   white-space: pre;
+}
+
+.markdown-code-block {
+  position: relative;
+  min-width: 0;
+  max-width: 100%;
+  margin: 0 0 14px;
+}
+
+.markdown-code-block pre,
+.markdown-code-block .mermaid {
+  margin-bottom: 0;
+}
+
+.markdown-code-menu {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.markdown-code-menu .block-menu-trigger {
+  margin: 0;
+  background: color-mix(in srgb, var(--panel-soft) 78%, var(--bg));
+}
+
+.markdown-code-menu .block-menu-popover {
+  top: 0;
+  right: 0;
+}
+
+.markdown-mermaid-block .markdown-code-menu {
+  z-index: 1;
 }
 
 .markdown-viewer pre code {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -7852,7 +7852,7 @@ function renderParsedMarkdown(text, options = {}) {
     FORBID_TAGS: ["embed", "iframe", "img", "object", "script", "style"],
     FORBID_ATTR: ["style", "srcset"],
   });
-  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${prepareMermaidBlocks(safe)}</div>`;
+  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${prepareMarkdownCodeBlocks(prepareMermaidBlocks(safe))}</div>`;
 }
 
 function prepareMermaidBlocks(html) {
@@ -7862,9 +7862,60 @@ function prepareMermaidBlocks(html) {
     const diagram = document.createElement("div");
     diagram.className = "mermaid";
     diagram.textContent = code.textContent || "";
-    code.parentElement.replaceWith(diagram);
+    const block = document.createElement("div");
+    block.className = "markdown-code-block markdown-mermaid-block";
+    block.innerHTML = markdownCodeMenuHtml(diagram.textContent || "");
+    block.appendChild(diagram);
+    code.parentElement.replaceWith(block);
   });
   return template.innerHTML;
+}
+
+function prepareMarkdownCodeBlocks(html) {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  template.content.querySelectorAll("pre > code").forEach((code) => {
+    const pre = code.parentElement;
+    const block = document.createElement("div");
+    block.className = "markdown-code-block";
+    pre.replaceWith(block);
+    block.appendChild(pre);
+    block.insertAdjacentHTML("beforeend", markdownCodeMenuHtml(code.textContent || ""));
+  });
+  return template.innerHTML;
+}
+
+function markdownCodeMenuHtml(code) {
+  return `
+    <div class="block-menu-anchor markdown-code-menu">
+      <button class="block-menu-trigger" type="button"
+        aria-label="Code actions" aria-expanded="false"
+        data-toggle-markdown-code-menu data-markdown-code="${escapeAttr(code)}">${iconSvg("ellipsis")}</button>
+    </div>
+  `;
+}
+
+function toggleMarkdownCodeMenu(trigger) {
+  const anchor = trigger.closest(".markdown-code-menu");
+  const open = Boolean(anchor?.querySelector(".block-menu-popover"));
+  closeMarkdownCodeMenus();
+  if (open || !anchor) return;
+
+  anchor.insertAdjacentHTML("beforeend", `
+    <div class="block-menu-popover" role="menu">
+      ${moreMenuButton({ label: "Copy", icon: "copy", attrs: `data-markdown-code="${escapeAttr(trigger.dataset.markdownCode || "")}" data-copy-markdown-code` })}
+    </div>
+  `);
+  trigger.classList.add("active");
+  trigger.setAttribute("aria-expanded", "true");
+}
+
+function closeMarkdownCodeMenus() {
+  document.querySelectorAll(".markdown-code-menu .block-menu-popover").forEach((menu) => menu.remove());
+  document.querySelectorAll("[data-toggle-markdown-code-menu]").forEach((trigger) => {
+    trigger.classList.remove("active");
+    trigger.setAttribute("aria-expanded", "false");
+  });
 }
 
 function queueMermaidRendering() {
@@ -10924,7 +10975,9 @@ els.view.addEventListener("click", (event) => {
     closeAgentBulkMenu();
   }
 
-  if (!event.target.closest("[data-toggle-block-menu]") && !event.target.closest(".block-menu-popover")) {
+  if (!event.target.closest("[data-toggle-block-menu]") &&
+      !event.target.closest("[data-toggle-markdown-code-menu]") &&
+      !event.target.closest(".block-menu-popover")) {
     closeBlockMenu();
   }
 
@@ -11027,6 +11080,20 @@ els.view.addEventListener("click", (event) => {
     const menuId = blockMenuToggle.dataset.toggleBlockMenu;
     state.openBlockMenu = state.openBlockMenu === menuId ? null : menuId;
     render();
+    return;
+  }
+
+  const markdownCodeMenuToggle = event.target.closest("[data-toggle-markdown-code-menu]");
+  if (markdownCodeMenuToggle) {
+    toggleMarkdownCodeMenu(markdownCodeMenuToggle);
+    return;
+  }
+
+  const markdownCodeCopyButton = event.target.closest("[data-copy-markdown-code]");
+  if (markdownCodeCopyButton) {
+    event.stopPropagation();
+    closeMarkdownCodeMenus();
+    copyToClipboard(markdownCodeCopyButton.dataset.markdownCode || "");
     return;
   }
 
@@ -13045,9 +13112,11 @@ function closeAgentBulkMenu() {
 }
 
 function closeBlockMenu() {
-  if (state.openBlockMenu === null) return;
-  state.openBlockMenu = null;
-  render();
+  closeMarkdownCodeMenus();
+  if (state.openBlockMenu !== null) {
+    state.openBlockMenu = null;
+    render();
+  }
 }
 
 function setSkillFlyoutOpen(open) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4699,6 +4699,16 @@ module RemoteServerTest
            "expected Remote UI to support #attachment/:id routes")
     assert(js[:body].include?("function renderMarkdown"),
            "expected markdown attachments to render as markdown")
+    assert(js[:body].include?("function prepareMarkdownCodeBlocks") &&
+           js[:body].include?("function markdownCodeMenuHtml"),
+           "expected fenced Markdown code blocks to receive action menus")
+    assert(js[:body].include?('aria-label="Code actions"') &&
+           js[:body].include?('label: "Copy"') &&
+           js[:body].include?('data-markdown-code="${escapeAttr(code)}"'),
+           "expected Markdown code menus to copy only their raw code text")
+    assert(js[:body].include?('showGrowl("Copied to clipboard", "done")') &&
+           js[:body].include?('showGrowl("Copy failed", "fail")'),
+           "expected code copy actions to provide success and failure feedback")
     assert(js[:body].include?("renderMarkdown(content, { breaks: true })") &&
            js[:body].include?("breaks: options.breaks === true"),
            "expected only markdown attachment call sites to opt into single-newline breaks")


### PR DESCRIPTION
## Summary

- Add a compact Code actions menu to fenced Markdown and Mermaid blocks in the Remote UI.
- Copy the complete raw code text without menu or viewer markup.
- Close each menu after copying and show success or failure feedback.
- Keep menus independent when identical Markdown appears more than once.

## Why

Implements [Fizzy #116](https://fizzy.startkit.tech/1/cards/116) so code blocks can be copied without manual selection.

## Impact

Remote UI Markdown rendering only. Existing block menus and clipboard behavior remain unchanged.

## Verification

- `bin/test`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke` (Chrome-backed real clicks, identical viewers, clipboard success and failure)
