### PR TITLE
Add Markdown code block copy menus

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -518,6 +518,65 @@ def write_smoke_script(path)
           throw new Error(`Mermaid rendering contract failed: ${JSON.stringify(mermaidContract)}`);
         }
 
+        await page.evaluate(async () => {
+          Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: {
+              writeText: async (value) => {
+                window.__smokeCopiedMarkdownCode = value;
+              },
+            },
+          });
+          window.__smokeMarkdownCodeSource = [
+            "```javascript",
+            "const same = true;",
+            "```",
+            "```javascript",
+            "const same = true;",
+            "```",
+            "```mermaid",
+            "flowchart LR",
+            "  A[Copy source] --> B[Still a diagram]",
+            "```",
+          ].join("\\n");
+          window.__smokeMarkdownRender = render;
+          render = () => replaceView(renderMarkdown(window.__smokeMarkdownCodeSource, { menuScope: "smoke-markdown-code" }));
+          render();
+        });
+        await page.waitForSelector(".mermaid svg", { state: "visible", timeout: 20_000 });
+        const markdownCodeMenus = await page.locator("[data-toggle-markdown-code-menu]").count();
+        if (markdownCodeMenus !== 3) {
+          throw new Error(`Markdown code blocks did not get independent menus: ${markdownCodeMenus}`);
+        }
+        await page.click('[data-toggle-markdown-code-menu="markdown-code:smoke-markdown-code:1"]');
+        const codeMenuContract = await page.evaluate(() => ({
+          openMenus: document.querySelectorAll(".markdown-code-menu-popover").length,
+          copyLabel: document.querySelector(".markdown-code-menu-popover [role='menuitem'] strong")?.textContent?.trim(),
+        }));
+        if (codeMenuContract.openMenus !== 1 || codeMenuContract.copyLabel !== "Copy code") {
+          throw new Error(`Markdown code menu did not open independently: ${JSON.stringify(codeMenuContract)}`);
+        }
+        await page.click("[data-close-markdown-code-menu]");
+        const copiedMarkdownCode = await page.evaluate(() => window.__smokeCopiedMarkdownCode);
+        if (copiedMarkdownCode !== "const same = true;\\n") {
+          throw new Error(`Markdown code copy lost raw source: ${JSON.stringify(copiedMarkdownCode)}`);
+        }
+        await page.evaluate(() => {
+          navigator.clipboard.writeText = async () => { throw new Error("clipboard blocked"); };
+        });
+        await page.click('[data-toggle-markdown-code-menu="markdown-code:smoke-markdown-code:2"]');
+        await page.click("[data-close-markdown-code-menu]");
+        await page.waitForSelector(".growl.fail", { state: "visible", timeout: 10_000 });
+        const failedCodeCopy = await page.locator(".growl.fail").textContent();
+        if (failedCodeCopy !== "Copy failed") {
+          throw new Error(`Markdown code copy failure feedback was unclear: ${JSON.stringify(failedCodeCopy)}`);
+        }
+        await page.evaluate(() => {
+          render = window.__smokeMarkdownRender;
+          state.renderedViewHtml = "";
+          render();
+        });
+
         await page.evaluate(() => {
           state.renderedViewHtml = "";
           render();

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -4469,6 +4469,61 @@ select {
   word-break: normal;
 }
 
+.markdown-code-block {
+  position: relative;
+  min-width: 0;
+}
+
+.markdown-code-block > pre,
+.markdown-code-block > .mermaid {
+  margin-bottom: 14px;
+}
+
+.markdown-code-menu {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  z-index: 3;
+}
+
+.markdown-code-menu-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  min-height: 26px;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, var(--panel-soft));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  color: var(--muted);
+}
+
+.markdown-code-menu-trigger .ui-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.markdown-code-menu-trigger:hover,
+.markdown-code-menu-trigger.active {
+  background: var(--panel-soft);
+  color: var(--text);
+}
+
+.markdown-code-menu-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 4;
+  min-width: 150px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 98%, transparent);
+  box-shadow: var(--shadow);
+  padding: 6px;
+}
+
 .markdown-viewer table {
   display: block;
   min-width: 0;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -629,6 +629,7 @@ const state = {
   pullRequestDiffFetches: {},
   pullRequestDiffsInFlight: 0,
   openBlockMenu: null,
+  openMarkdownCodeMenu: null,
   agentSettingsOpen: false,
   headerMoreOpen: false,
   headerMoreBadge: "",
@@ -1479,6 +1480,7 @@ function backRouteValue(route) {
 
 function navigate(route) {
   state.openBlockMenu = null;
+  state.openMarkdownCodeMenu = null;
   const hash = routeHash(route);
   if (location.hash === hash) {
     render();
@@ -4684,7 +4686,7 @@ function renderAgentSummaryView(agent, options = {}) {
             ${kv("Est. Cost", sessionCostSnapshotText(summary.costSnapshot))}
             ${kv("Attachments", summary.attachments?.length || 0)}
           </div>
-          ${renderAgentSummaryContent(summary.content)}
+          ${renderAgentSummaryContent(summary.content, `agent-summary:${agent.key}:${summary.id || summary.createdAt || summary.runNumber || "current"}`)}
           ${renderSummaryAttachmentList(agent, summary.attachments)}
         </div>
       </section>
@@ -4693,11 +4695,12 @@ function renderAgentSummaryView(agent, options = {}) {
   `;
 }
 
-function renderAgentSummaryContent(content) {
+function renderAgentSummaryContent(content, menuScope = "agent-summary") {
   return renderMarkdown(content, {
     viewerClassName: "markdown-viewer agent-summary-markdown-viewer",
     fallbackClassName: "attachment-text-viewer agent-summary-fallback",
     emptyText: "No run summary yet.",
+    menuScope,
   });
 }
 
@@ -6346,7 +6349,7 @@ function renderConversationBlocks(blocks, options = {}) {
   while (index < blocks.length) {
     const block = blocks[index];
     if (primaryConversationBlock(block)) {
-      rendered.push(renderMessage(block, options));
+      rendered.push(renderMessage(block, { ...options, markdownMenuScope: `conversation:${index}:${blockStateToken(block)}` }));
       index += 1;
       continue;
     }
@@ -6376,7 +6379,10 @@ function renderMessageGroup(blocks, index, options = {}) {
     <details class="message-group" data-state-key="${escapeAttr(stateKey)}">
       <summary><span class="message-group-label">${messageGroupIcon(blocks)}<span>${escapeHtml(label)}</span></span><span>${escapeHtml(summary)}</span></summary>
       <div class="message-group-body">
-        ${blocks.map((block) => renderMessage(block, options)).join("")}
+        ${blocks.map((block, blockIndex) => renderMessage(block, {
+          ...options,
+          markdownMenuScope: `conversation-group:${index}:${blockIndex}:${blockStateToken(block)}`,
+        })).join("")}
       </div>
     </details>
   `;
@@ -6514,6 +6520,7 @@ function renderMessageContent(block, options = {}) {
           viewerClassName: "markdown-viewer message-markdown-viewer",
           fallbackClassName: "message-markdown-fallback",
           emptyText: "",
+          menuScope: options.markdownMenuScope || `message:${blockStateToken(block)}`,
         })}
       </div>
     `;
@@ -7451,7 +7458,7 @@ function attachmentViewerHtml(id, options = {}) {
     : format === "html"
       ? renderHtmlAttachment(content, attachment)
     : format === "markdown"
-      ? renderMarkdown(content, { breaks: true })
+      ? renderMarkdown(content, { breaks: true, menuScope: `attachment:${id}` })
       : renderCodeAttachment(content, attachment);
   const formatLabel = format === "markdown" ? "Markdown" : format === "html" ? "HTML" : "File";
 
@@ -7852,19 +7859,49 @@ function renderParsedMarkdown(text, options = {}) {
     FORBID_TAGS: ["embed", "iframe", "img", "object", "script", "style"],
     FORBID_ATTR: ["style", "srcset"],
   });
-  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${prepareMermaidBlocks(safe)}</div>`;
+  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${prepareMarkdownCodeBlocks(safe, options.menuScope)}</div>`;
 }
 
-function prepareMermaidBlocks(html) {
+function prepareMarkdownCodeBlocks(html, menuScope = "markdown") {
   const template = document.createElement("template");
   template.innerHTML = html;
-  template.content.querySelectorAll("pre > code.language-mermaid").forEach((code) => {
-    const diagram = document.createElement("div");
-    diagram.className = "mermaid";
-    diagram.textContent = code.textContent || "";
-    code.parentElement.replaceWith(diagram);
+  template.content.querySelectorAll("pre > code").forEach((code, index) => {
+    const source = code.textContent || "";
+    const pre = code.parentElement;
+    const menuId = `markdown-code:${menuScope}:${index}`;
+    const block = document.createElement("div");
+    block.className = "markdown-code-block";
+    block.innerHTML = renderMarkdownCodeMenu(menuId, source);
+
+    pre?.replaceWith(block);
+
+    if (code.classList.contains("language-mermaid")) {
+      const diagram = document.createElement("div");
+      diagram.className = "mermaid";
+      diagram.textContent = source;
+      block.appendChild(diagram);
+    } else {
+      block.appendChild(pre);
+    }
   });
   return template.innerHTML;
+}
+
+function renderMarkdownCodeMenu(menuId, source) {
+  const isOpen = state.openMarkdownCodeMenu === menuId;
+  const menuHtml = isOpen
+    ? `<div class="markdown-code-menu-popover" role="menu">
+        ${moreMenuButton({ label: "Copy code", icon: "copy", attrs: `data-copy="${escapeAttr(source)}" data-close-markdown-code-menu` })}
+      </div>`
+    : "";
+  return `
+    <div class="markdown-code-menu" data-markdown-code-menu="${escapeAttr(menuId)}">
+      <button class="markdown-code-menu-trigger${isOpen ? " active" : ""}" type="button"
+        aria-label="Code block actions" aria-expanded="${isOpen}"
+        data-toggle-markdown-code-menu="${escapeAttr(menuId)}">${iconSvg("ellipsis")}</button>
+      ${menuHtml}
+    </div>
+  `;
 }
 
 function queueMermaidRendering() {
@@ -10927,6 +10964,9 @@ els.view.addEventListener("click", (event) => {
   if (!event.target.closest("[data-toggle-block-menu]") && !event.target.closest(".block-menu-popover")) {
     closeBlockMenu();
   }
+  if (!event.target.closest("[data-markdown-code-menu]")) {
+    closeMarkdownCodeMenu();
+  }
 
   const summaryAttachmentMenu = event.target.closest("[data-summary-attachment-menu]");
   if (!summaryAttachmentMenu) {
@@ -11034,6 +11074,24 @@ els.view.addEventListener("click", (event) => {
   if (closeBlockMenuButton) {
     const copyValue = closeBlockMenuButton.dataset.copy;
     state.openBlockMenu = null;
+    event.stopPropagation(); // prevent document copy handler from firing on detached element
+    render();
+    if (copyValue !== undefined) copyToClipboard(copyValue);
+    return;
+  }
+
+  const markdownCodeMenuToggle = event.target.closest("[data-toggle-markdown-code-menu]");
+  if (markdownCodeMenuToggle) {
+    const menuId = markdownCodeMenuToggle.dataset.toggleMarkdownCodeMenu;
+    state.openMarkdownCodeMenu = state.openMarkdownCodeMenu === menuId ? null : menuId;
+    render();
+    return;
+  }
+
+  const closeMarkdownCodeMenuButton = event.target.closest("[data-close-markdown-code-menu]");
+  if (closeMarkdownCodeMenuButton) {
+    const copyValue = closeMarkdownCodeMenuButton.dataset.copy;
+    state.openMarkdownCodeMenu = null;
     event.stopPropagation(); // prevent document copy handler from firing on detached element
     render();
     if (copyValue !== undefined) copyToClipboard(copyValue);
@@ -13047,6 +13105,12 @@ function closeAgentBulkMenu() {
 function closeBlockMenu() {
   if (state.openBlockMenu === null) return;
   state.openBlockMenu = null;
+  render();
+}
+
+function closeMarkdownCodeMenu() {
+  if (state.openMarkdownCodeMenu === null) return;
+  state.openMarkdownCodeMenu = null;
   render();
 }
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -3347,6 +3347,8 @@ module RemoteServerTest
            "expected rendered markdown links to have readable underline spacing")
     assert(css[:body].include?("white-space: pre"),
            "expected rendered markdown code blocks to preserve whitespace")
+    assert(css[:body].include?(".markdown-code-menu") && css[:body].include?(".markdown-code-menu-popover"),
+           "expected rendered Markdown code blocks to style compact action menus")
     assert(css[:body].include?("overflow-wrap: anywhere"),
            "expected rendered markdown inline code to avoid horizontal page overflow")
     assert(css[:body].include?(".skill-flyout"), "expected skills to use a floating picker")
@@ -4699,7 +4701,16 @@ module RemoteServerTest
            "expected Remote UI to support #attachment/:id routes")
     assert(js[:body].include?("function renderMarkdown"),
            "expected markdown attachments to render as markdown")
-    assert(js[:body].include?("renderMarkdown(content, { breaks: true })") &&
+    assert(js[:body].include?("function prepareMarkdownCodeBlocks") &&
+           js[:body].include?("function renderMarkdownCodeMenu"),
+           "expected fenced Markdown code blocks to expose reusable action menus")
+    assert(js[:body].include?("data-toggle-markdown-code-menu") &&
+           js[:body].include?("data-close-markdown-code-menu"),
+           "expected Markdown code menus to support isolated toggles and copy actions")
+    assert(js[:body].include?("markdownMenuScope: `conversation:${index}:${blockStateToken(block)}`") &&
+           js[:body].include?("menuScope: `attachment:${id}`"),
+           "expected Markdown code menus to use their owning message or attachment as a stable scope")
+    assert(js[:body].include?("renderMarkdown(content, { breaks: true, menuScope: `attachment:${id}` })") &&
            js[:body].include?("breaks: options.breaks === true"),
            "expected only markdown attachment call sites to opt into single-newline breaks")
     assert(js[:body].include?("function renderHtmlAttachment") &&
@@ -4734,7 +4745,7 @@ module RemoteServerTest
     assert(js[:body].include?("https://cdn.jsdelivr.net/npm/dompurify@"),
            "expected markdown rendering to sanitize parsed HTML with DOMPurify")
     assert(js[:body].include?("https://cdn.jsdelivr.net/npm/mermaid@11.15.0/") &&
-           js[:body].include?("function prepareMermaidBlocks") &&
+           js[:body].include?("function prepareMarkdownCodeBlocks") &&
            js[:body].include?("function queueMermaidRendering"),
            "expected Mermaid code fences to lazy-load and render through a pinned CDN build")
     assert(js[:body].include?('securityLevel: "strict"'),


### PR DESCRIPTION
## Summary

- Add a compact Copy code menu to fenced Markdown code blocks, including Mermaid diagrams.
- Keep menu state isolated for repeated code blocks and show clipboard success or failure feedback.
- Cover the interaction in the Remote UI smoke workflow.

## Validation

- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke`
