### PR TITLE
Fix expired Windows PWA push subscriptions

### DIFF
--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -345,6 +345,7 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | `GET` | `/settings/session-loops` | Read Loop session interval, cutoff, and prompt-template defaults. |
 | `PATCH` | `/settings/session-loops` | Save Loop session defaults in `hq.yml`. |
 | `GET` | `/push/config` | Read browser push readiness and VAPID public key. |
+| `POST` | `/push/status` | Check whether one browser endpoint is currently enabled. |
 | `POST` | `/push/subscriptions` | Save or refresh one browser push subscription. |
 | `DELETE` | `/push/subscriptions` | Disable one browser push subscription. |
 | `POST` | `/push/test` | Send a test notification to an enabled subscription. |
@@ -712,6 +713,18 @@ Saves or refreshes one browser push subscription. Send the browser's `PushSubscr
   }
 }
 ```
+
+### `POST /push/status`
+
+Checks the current browser's subscription without exposing its capability URL in a query string:
+
+```json
+{
+  "endpoint": "https://push.example/subscription/1"
+}
+```
+
+The response includes `subscribed` for that endpoint and the global `subscription_count`. The Remote UI uses the endpoint-specific result to show the correct controls when other devices are also subscribed.
 
 ### `DELETE /push/subscriptions`
 

--- a/docs/WEB_PUSH_BEHAVIOR.md
+++ b/docs/WEB_PUSH_BEHAVIOR.md
@@ -12,6 +12,14 @@ This note explains how Tycho Remote UI uses browser push notifications, notifica
 6. When the Remote UI page is open, `syncUnreadAlert()` also mirrors the unread-agent count into the app badge so foreground state and background push state stay aligned.
 7. Notification clicks focus an existing Tycho Remote tab when possible, otherwise they open the payload URL, usually `/#agent/{key}`.
 
+## Subscription Lifecycle
+
+Push-service endpoints can expire while the browser still retains a local `PushSubscription`. Windows Edge subscriptions use Windows Notification Service endpoints, while Chrome commonly uses Firebase Cloud Messaging endpoints. Both can return HTTP 404 or 410 after invalidating an endpoint.
+
+Tycho treats those responses as permanent: it disables the saved endpoint instead of retrying it. Transient failures such as HTTP 429 or 5xx remain enabled and increment their failure count. Settings checks the current browser's endpoint through `POST /push/status`; it does not infer this browser's state from the global subscription count. If the server has retired the local endpoint, or its application-server key differs from Tycho's current VAPID public key, **Enable notifications** unsubscribes it and creates a fresh subscription.
+
+Push endpoints are capability URLs. Tycho sends them in authenticated request bodies, not query strings, so normal URL logging does not expose them.
+
 ## Grouping Model
 
 The Web Notifications API does not provide a portable native "group" primitive like some mobile notification frameworks do. The closest standard tool is the notification `tag` option:
@@ -83,6 +91,16 @@ Example agent payload:
 - `lib/hq/remote_ui/assets/service-worker.js`: receives push events, displays notifications, and updates badges in the background.
 - `lib/hq/remote_ui/assets/app.js`: mirrors unread-agent state to the header logo badge and the installed PWA app badge.
 - `test/remote_server_test.rb`: regression coverage for push payload shape, service worker behavior, and Remote UI hooks.
+- `test/web_push_notifier_test.rb`: delivery-error coverage for permanent and transient subscription failures.
+
+## Windows Edge/Chrome Verification
+
+1. Update Tycho, start `bundle exec bin/tycho serve`, and open its HTTPS URL in the installed Edge or Chrome PWA on Windows.
+2. Open **Settings → Notifications**. Confirm it says either **Enabled — This browser is subscribed** or **Ready — This browser is not subscribed**; the total may include other devices.
+3. If it says **Ready**, select **Enable notifications** and accept the Windows/browser permission prompt.
+4. Select **Send test**. Confirm a Tycho notification appears in Windows Notification Center while the PWA is minimized or closed.
+5. Complete a disposable agent run. Confirm one completion notification arrives and opens that agent when selected.
+6. If delivery fails, open DevTools in the PWA, select **Application → Service workers**, and confirm `/service-worker.js` is active for the Tycho origin. Then check Windows **Settings → System → Notifications** for both the browser and installed Tycho PWA, and inspect `~/.tycho/logs/hq.log` on the Tycho host for the endpoint host plus HTTP response code. Do not copy or share the full endpoint.
 
 ## Improvement Ideas
 

--- a/lib/hq/domain/push_subscription_store.rb
+++ b/lib/hq/domain/push_subscription_store.rb
@@ -24,6 +24,13 @@ module HQ
       enabled.length
     end
 
+    def enabled_endpoint?(endpoint)
+      value = endpoint.to_s
+      return false if value.empty?
+
+      enabled.any? { |subscription| subscription["endpoint"] == value }
+    end
+
     def save_subscription(attrs, user_agent: nil)
       endpoint = attrs["endpoint"].to_s.strip
       keys = attrs["keys"].is_a?(Hash) ? attrs["keys"] : {}

--- a/lib/hq/domain/web_push_notifier.rb
+++ b/lib/hq/domain/web_push_notifier.rb
@@ -54,21 +54,26 @@ module HQ
           "endpoint=#{endpoint_label(endpoint)} enabled=#{enabled_count} matched=#{subscriptions.length} " \
           "urgency=#{urgency} ttl=#{ttl}"
       end
-      return { sent: 0, failed: 0, attempted: 0 } if subscriptions.empty?
+      return { sent: 0, failed: 0, attempted: 0, disabled: 0 } if subscriptions.empty?
 
       attempted = 0
       sent = 0
       failed = 0
+      disabled = 0
       subscriptions.each do |subscription|
         attempted += 1
-        if deliver(subscription, payload, urgency: urgency, ttl: ttl)
+        result = deliver(subscription, payload, urgency: urgency, ttl: ttl)
+        if result == :sent
           sent += 1
         else
           failed += 1
+          disabled += 1 if result == :disabled
         end
       end
-      HQ.logger.debug("Push") { "Push send complete attempted=#{attempted} sent=#{sent} failed=#{failed}" }
-      { sent: sent, failed: failed, attempted: attempted }
+      HQ.logger.debug("Push") do
+        "Push send complete attempted=#{attempted} sent=#{sent} failed=#{failed} disabled=#{disabled}"
+      end
+      { sent: sent, failed: failed, attempted: attempted, disabled: disabled }
     end
 
     private
@@ -107,15 +112,23 @@ module HQ
         read_timeout: 5
       )
       HQ.logger.debug("Push") { "Push delivered endpoint=#{endpoint_label(subscription["endpoint"])}" }
-      true
+      :sent
+    rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription => e
+      @subscription_store.disable(subscription["endpoint"])
+      log_delivery_failure(subscription, e, disabled: true)
+      :disabled
     rescue StandardError => e
       @subscription_store.record_failure(subscription["endpoint"])
+      log_delivery_failure(subscription, e, disabled: false)
+      :failed
+    end
+
+    def log_delivery_failure(subscription, error, disabled:)
       HQ.logger.debug("Push") do
         "Push delivery failed endpoint=#{endpoint_label(subscription["endpoint"])} " \
-          "host=#{endpoint_host(subscription["endpoint"])} #{push_failure_debug(e)}"
+          "host=#{endpoint_host(subscription["endpoint"])} disabled=#{disabled} #{push_failure_debug(error)}"
       end
-      HQ.logger.warn("Push") { "Web push send failed: #{e.class} - #{e.message}" }
-      false
+      HQ.logger.warn("Push") { "Web push send failed: #{error.class} - #{error.message}" }
     end
 
     def endpoint_label(endpoint)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -339,6 +339,7 @@ module HQ
       return ok(service.search_index) if method == "GET" && parts == ["search"]
       return accepted(schedule_restart!, headers: RESTART_CACHE_RESET_HEADERS) if method == "POST" && parts == ["server", "restart"]
       return ok(service.push_config) if method == "GET" && parts == ["push", "config"]
+      return ok(service.push_status(body)) if method == "POST" && parts == ["push", "status"]
       return service.attachment_blob(parts[1]) if method == "GET" && parts.length == 3 && parts.first == "attachments" && parts[2] == "blob"
       return ok(service.delete_attachment(parts[1])) if method == "DELETE" && parts.length == 2 && parts.first == "attachments"
       return ok(attachment: service.attachment(parts[1])) if method == "GET" && parts.length == 2 && parts.first == "attachments"
@@ -2314,6 +2315,13 @@ module HQ
         localhost_allowed: true,
         magic_dns_https_required: true
       )
+    end
+
+    def push_status(attrs)
+      {
+        subscribed: @push_subscription_store.enabled_endpoint?(attrs["endpoint"]),
+        subscription_count: @push_subscription_store.count
+      }
     end
 
     def save_push_subscription(attrs, user_agent: nil)

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1696,7 +1696,10 @@ async function refresh(options = {}) {
 async function ensureRouteData(options = {}) {
   const route = parseRoute();
   if (route.type === "tab" && route.tab === "settings") {
-    await ensureResponseStyle(options.forceResponseStyle || options.force);
+    await Promise.all([
+      ensureResponseStyle(options.forceResponseStyle || options.force),
+      refreshCurrentPushConfig(),
+    ]);
   }
   if (agentShellRoute(route)) {
     await ensureAgentDetail(route.key, options.forceAgent || options.force);
@@ -4520,13 +4523,16 @@ function renderPushSetup(setup) {
   const configured = !!push.configured && !!push.public_key;
   const denied = "Notification" in window && Notification.permission === "denied";
   const enabledCount = push.subscription_count || 0;
+  const subscribed = push.subscribed === true;
   const canEnable = configured && support.supported && !denied;
-  const statusClassName = canEnable ? "done" : denied ? "fail" : configured ? "info" : "fail";
-  const status = !support.supported ? "Unsupported" : denied ? "Blocked" : configured ? "Ready" : "Missing keys";
+  const statusClassName = subscribed ? "done" : denied ? "fail" : configured ? "info" : "fail";
+  const status = !support.supported ? "Unsupported" : denied ? "Blocked" : subscribed ? "Enabled" : configured ? "Ready" : "Missing keys";
   const detail = !support.supported
     ? support.detail
-    : denied ? "Notification permission is blocked in this browser" : configured ? `${enabledCount} subscription${enabledCount === 1 ? "" : "s"}` : "VAPID keys are unavailable";
-  const pushActions = enabledCount > 0
+    : denied ? "Notification permission is blocked in this browser" : configured
+      ? `${subscribed ? "This browser is subscribed" : "This browser is not subscribed"}; ${enabledCount} total subscription${enabledCount === 1 ? "" : "s"}`
+      : "VAPID keys are unavailable";
+  const pushActions = subscribed
     ? `
       <button type="button" data-test-push ${canEnable ? "" : "disabled"}>Send test</button>
       <button class="danger ui-button" data-variant="danger" type="button" data-disable-push ${support.supported ? "" : "disabled"}>Disable notifications</button>
@@ -4538,7 +4544,7 @@ function renderPushSetup(setup) {
       <div class="detail-card-body" style="padding-top: 12px;">
         <div class="section-label"><strong>Push notifications</strong><span>browser alerts</span></div>
         <div class="detail-row">
-          <span class="status-mark ${statusClassName}" ${statusMarkAttributes(statusClassName)} aria-hidden="true">${statusIcon(canEnable)}</span>
+          <span class="status-mark ${statusClassName}" ${statusMarkAttributes(statusClassName)} aria-hidden="true">${statusIcon(subscribed || canEnable)}</span>
           <div><strong>${escapeHtml(status)}</strong><span>${escapeHtml(detail)}</span></div>
           ${statusBadge(titleFromKey(notificationPermissionLabel()), statusClassName)}
         </div>
@@ -10287,11 +10293,22 @@ async function enablePushNotifications() {
   mutate(async () => {
     const config = await apiGet("/push/config");
     if (!config.configured || !config.public_key) throw new Error("Push notifications are not configured");
-    const registration = await navigator.serviceWorker.register("/service-worker.js", { updateViaCache: "none" });
-    await registration.update().catch(() => null);
+    const registered = await navigator.serviceWorker.register("/service-worker.js", { updateViaCache: "none" });
+    await registered.update().catch(() => null);
+    const registration = await navigator.serviceWorker.ready;
     const permission = await Notification.requestPermission();
     if (permission !== "granted") throw new Error(`Notification permission ${permission}`);
-    const existing = await registration.pushManager.getSubscription();
+    let existing = await registration.pushManager.getSubscription();
+    if (existing) {
+      const endpointStatus = await apiPost("/push/status", { endpoint: existing.endpoint });
+      const currentKey = pushSubscriptionApplicationServerKey(existing);
+      const expectedKey = urlBase64ToUint8Array(config.public_key);
+      if (!endpointStatus.subscribed || !byteArraysEqual(currentKey, expectedKey)) {
+        await apiDelete("/push/subscriptions", existing.toJSON()).catch(() => null);
+        await existing.unsubscribe();
+        existing = null;
+      }
+    }
     const subscription = existing || await registration.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: urlBase64ToUint8Array(config.public_key),
@@ -10323,7 +10340,12 @@ async function sendTestPushNotification() {
     const subscription = await currentPushSubscription();
     const payload = subscription ? { endpoint: subscription.endpoint } : {};
     const result = await apiPost("/push/test", payload);
-    setConnection(result.sent > 0 ? "Test notification sent" : "No notification sent");
+    if (result.disabled > 0) {
+      setConnection("Subscription expired; enable notifications again");
+      showGrowl("Push subscription expired. Enable notifications to renew it.", "need");
+    } else {
+      setConnection(result.sent > 0 ? "Test notification sent" : "No notification sent");
+    }
   });
 }
 
@@ -10491,6 +10513,24 @@ async function currentPushSubscription() {
   const registration = await navigator.serviceWorker.getRegistration("/service-worker.js") ||
     await navigator.serviceWorker.getRegistration("/");
   return registration ? registration.pushManager.getSubscription() : null;
+}
+
+async function refreshCurrentPushConfig() {
+  if (!state.setup?.push || !pushSupport().supported) return;
+
+  const subscription = await currentPushSubscription();
+  const status = await apiPost("/push/status", { endpoint: subscription?.endpoint || "" });
+  state.setup.push = { ...state.setup.push, ...status };
+}
+
+function pushSubscriptionApplicationServerKey(subscription) {
+  const key = subscription?.options?.applicationServerKey;
+  return key ? new Uint8Array(key) : new Uint8Array();
+}
+
+function byteArraysEqual(left, right) {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
 }
 
 function urlBase64ToUint8Array(value) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2799,10 +2799,16 @@ module RemoteServerTest
       )
       assert(saved[:subscribed], "expected subscription save response")
       assert(saved[:subscription_count] == 1, "expected one enabled subscription")
+      assert(service.push_status("endpoint" => "https://push.example.test/subscription/1")[:subscribed],
+             "expected push config to identify the current browser subscription")
+      assert(!service.push_status("endpoint" => "https://push.example.test/subscription/other")[:subscribed],
+             "expected push config not to confuse another browser subscription with this browser")
 
       disabled = service.disable_push_subscription("endpoint" => "https://push.example.test/subscription/1")
       assert(!disabled[:subscribed], "expected unsubscribe response")
       assert(disabled[:subscription_count].zero?, "expected disabled subscription to be excluded from count")
+      assert(!service.push_status("endpoint" => "https://push.example.test/subscription/1")[:subscribed],
+             "expected push config to expose a disabled browser subscription as inactive")
     end
   end
 
@@ -4199,6 +4205,14 @@ module RemoteServerTest
            "expected Remote UI to warn when MagicDNS is not HTTPS")
     assert(js[:body].include?("navigator.serviceWorker.register"),
            "expected Remote UI to register the service worker")
+    assert(js[:body].include?("await navigator.serviceWorker.ready"),
+           "expected push setup to wait for the active service worker")
+    assert(js[:body].include?('push.subscribed === true') &&
+           js[:body].include?('apiPost("/push/status", { endpoint: existing.endpoint })'),
+           "expected push controls to track this browser instead of the global subscription count")
+    assert(js[:body].include?("await existing.unsubscribe()") &&
+           js[:body].include?("pushSubscriptionApplicationServerKey"),
+           "expected push setup to replace expired or VAPID-mismatched browser subscriptions")
     assert(js[:body].include?("function renderAgentForm"),
            "expected Remote UI to render create/edit agent forms")
     assert(!js[:body].include?('name="workspace"'),

--- a/test/web_push_notifier_test.rb
+++ b/test/web_push_notifier_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "tmpdir"
+
+require_relative "../lib/hq/domain/push_subscription_store"
+require_relative "../lib/hq/domain/web_push_notifier"
+
+module WebPushNotifierTest
+  module_function
+
+  ENDPOINT = "https://wns2-pn1p.notify.windows.com/subscription/expired"
+
+  def run!
+    assert_expired_subscription_is_disabled
+    assert_transient_failure_remains_enabled
+    puts "web_push_notifier_test: ok"
+  end
+
+  def assert_expired_subscription_is_disabled
+    with_notifier do |notifier, store|
+      with_web_push_error(WebPush::ExpiredSubscription, Net::HTTPGone, "410", "Gone") do
+        result = notifier.send_test!(endpoint: ENDPOINT)
+
+        assert(result == { sent: 0, failed: 1, attempted: 1, disabled: 1 },
+               "expected the expired send to fail once and retire the endpoint, got #{result.inspect}")
+        assert(store.enabled.empty?, "expected an expired Windows push endpoint to be disabled")
+      end
+    end
+  end
+
+  def assert_transient_failure_remains_enabled
+    with_notifier do |notifier, store|
+      with_web_push_error(WebPush::PushServiceError, Net::HTTPServiceUnavailable, "503", "Service Unavailable") do
+        result = notifier.send_test!(endpoint: ENDPOINT)
+        subscription = store.enabled.fetch(0)
+
+        assert(result == { sent: 0, failed: 1, attempted: 1, disabled: 0 },
+               "expected the transient send to fail once")
+        assert(subscription["failure_count"] == 1, "expected a transient failure to remain retryable")
+      end
+    end
+  end
+
+  def with_notifier
+    Dir.mktmpdir("hq-web-push-notifier-test") do |dir|
+      subscriptions_path = File.join(dir, "push_subscriptions.json")
+      vapid_path = File.join(dir, "web_push_vapid.json")
+      store = HQ::PushSubscriptionStore.new(path: subscriptions_path)
+      store.save_subscription(
+        {
+          "endpoint" => ENDPOINT,
+          "keys" => { "p256dh" => "p256dh-key", "auth" => "auth-key" }
+        },
+        user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edg/148.0.0.0"
+      )
+      notifier = HQ::WebPushNotifier.new(subscription_store: store, vapid_path: vapid_path)
+      yield notifier, store
+    end
+  end
+
+  def with_web_push_error(error_class, response_class, code, message)
+    original = WebPush.method(:payload_send)
+    response = response_class.new("1.1", code, message)
+    response.instance_variable_set(:@body, "")
+    response.instance_variable_set(:@read, true)
+    WebPush.define_singleton_method(:payload_send) do |**_options|
+      raise error_class.new(response, "wns2-pn1p.notify.windows.com")
+    end
+    yield
+  ensure
+    WebPush.define_singleton_method(:payload_send, original)
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+end
+
+WebPushNotifierTest.run! if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary

- retire Web Push endpoints when WNS/FCM/APNs returns HTTP 404 or 410 instead of retrying them forever
- track the current browser subscription separately from the global subscription count
- renew local subscriptions that the server retired or that use an old VAPID application-server key
- wait for the service worker to become active before subscribing and give expired test sends a clear recovery path
- document subscription lifecycle behavior and an exact Windows Edge/Chrome PWA verification flow

## Diagnosis

The persisted Windows Edge subscription targets `wns2-pn1p.notify.windows.com`. Real delivery attempts consistently return HTTP 410 through `WebPush::ExpiredSubscription`, but Tycho only incremented `failure_count`, leaving the dead endpoint enabled (322 retries at diagnosis time). Settings then treated any globally enabled endpoint as proof that this browser was subscribed, so it hid the enable/renew action. Re-enabling also reused the browser copy of the expired subscription.

The push never reached the service worker, which rules out Windows notification rendering as the primary failure. The fix disables permanent 404/410 endpoints, keeps transient errors retryable, checks the current endpoint through an authenticated request body, and replaces a retired or VAPID-mismatched browser subscription.

Fizzy: https://fizzy.startkit.tech/1/cards/122

## Verification

- `mise exec ruby@3.4.7 -- bundle exec ruby test/web_push_notifier_test.rb`
- `mise exec ruby@3.4.7 -- bundle exec ruby test/remote_server_test.rb`
- `mise exec ruby@3.4.7 -- bin/test`
- `node --check lib/hq/remote_ui/assets/app.js`
- `mise exec ruby@3.4.7 -- bundle exec bin/remote-ui-smoke`

A final installed-PWA check still needs Windows: open Settings → Notifications in Edge or Chrome, enable if the browser is reported unsubscribed, send a test while the PWA is minimized or closed, then complete a disposable agent run and confirm its notification opens the agent.