### PR TITLE
Fix mobile attachment flyout clipping

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -2958,6 +2958,49 @@ def write_smoke_script(path)
             !["auto", "scroll"].includes(quickAgentMobileLayout.formOverflowY)) {
           throw new Error(`Quick Agent form is not a scrollable mobile full-screen surface: ${JSON.stringify(quickAgentMobileLayout)}`);
         }
+        await mobileQuickAgentPage.evaluate((key) => {
+          closeQuickAgent();
+          const agent = findAgent(key);
+          agent.attachments = Array.from({ length: 5 }, (_, index) => ({
+            id: `mobile-attachment-${index}`,
+            agent_key: key,
+            type: "file",
+            title: `report-${index + 1}.html`,
+            path: `/Users/smoke/Code/example-project/very-long-report-directory/report-${index + 1}.html`,
+            blob_path: `/attachments/mobile-attachment-${index}/blob`,
+            format: "html",
+          }));
+          history.replaceState(null, "", routeHash({ type: "agent", key }));
+          state.renderedRouteKey = null;
+          state.renderedViewHtml = "";
+          render();
+        }, agentKey);
+        await mobileQuickAgentPage.waitForSelector("[data-toggle-attachments]", { state: "visible", timeout: 10_000 });
+        await mobileQuickAgentPage.click("[data-toggle-attachments]");
+        await mobileQuickAgentPage.waitForSelector("[data-attachment-flyout]:not(.hidden)", { state: "visible", timeout: 10_000 });
+        const mobileAttachmentFlyout = await mobileQuickAgentPage.evaluate(() => {
+          const flyout = document.querySelector("[data-attachment-flyout]:not(.hidden)");
+          const header = flyout?.querySelector(".attachment-panel-header");
+          const dock = document.querySelector("[data-agent-dock]");
+          const flyoutRect = flyout?.getBoundingClientRect();
+          const headerRect = header?.getBoundingClientRect();
+          const headerHit = headerRect
+            ? document.elementFromPoint(headerRect.left + headerRect.width / 2, headerRect.top + headerRect.height / 2)
+            : null;
+          return {
+            viewport: { width: window.innerWidth, height: window.innerHeight },
+            flyout: flyoutRect?.toJSON(),
+            dock: dock?.getBoundingClientRect().toJSON(),
+            dockOverflowY: dock ? getComputedStyle(dock).overflowY : "",
+            headerVisible: Boolean(headerHit && flyout?.contains(headerHit)),
+          };
+        });
+        if (!mobileAttachmentFlyout.headerVisible || mobileAttachmentFlyout.flyout?.top < 0 ||
+            mobileAttachmentFlyout.flyout?.left < 0 ||
+            mobileAttachmentFlyout.flyout?.right > mobileAttachmentFlyout.viewport.width ||
+            mobileAttachmentFlyout.flyout?.bottom > mobileAttachmentFlyout.viewport.height) {
+          throw new Error(`Conversation attachments are cropped on mobile: ${JSON.stringify(mobileAttachmentFlyout)}`);
+        }
         await mobileQuickAgentPage.close();
         const loopAgentKey = await page.evaluate(async () => {
           const data = await apiPost("/agents", {

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -6625,6 +6625,10 @@ body:has(.inquiry-form-full-screen) {
     overscroll-behavior: contain;
   }
 
+  .agent-dock:has(.attachment-flyout:not(.hidden)) {
+    overflow: visible;
+  }
+
   .attachment-flyout {
     max-height: min(64dvh, 520px);
     overflow-y: auto;

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -3392,6 +3392,8 @@ module RemoteServerTest
            "expected the skill flyout to stack above the floating Summary shortcut")
     assert(css[:body].include?(".agent-dock:has(.attachment-flyout:not(.hidden))"),
            "expected the attachment flyout to stack above the skill flyout")
+    assert(css[:body].include?(".agent-dock:has(.attachment-flyout:not(.hidden)) {\n    overflow: visible;"),
+           "expected mobile attachment flyouts to escape the scrollable composer dock")
     assert(!css[:body].include?(".server-lifecycle-card"),
            "expected Settings restart readiness to use the normal automation readiness card")
     assert(css[:body].include?("#settings-push-notifications"),


### PR DESCRIPTION
## Summary
- let the composer dock expose an open attachment flyout on mobile
- add a mobile regression assertion to the Remote UI smoke
- cover the CSS contract in the Remote Server test

## Validation
- bundle exec ruby test/remote_server_test.rb
- bin/test
- bin/remote-ui-smoke