### PR TITLE
Keep Remote UI and push API builds coherent

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-07-31
+2026-08-05
 
 ## Strategic Direction
 
@@ -63,6 +63,7 @@ Key references:
 | Remote UI responsive shell | Mobile keeps bottom navigation; wide desktop uses a wider content frame with side navigation; creation actions live in the header and focused detail/form routes remove unrelated global actions | Prevent fixed controls from obscuring content, use desktop space effectively, and keep page actions contextual across mobile, tablet, and desktop |
 | Remote UI control sizing | Shared 44 px control and touch-target tokens, 16 px mobile form text, visible focus states, and explicit validation/status text | Avoid mobile auto-zoom, undersized targets, color-only state, and inconsistent action geometry |
 | Remote UI design system | Keep a no-build internal system: semantic `--ds-*` tokens and reusable CSS components in `design_system.css`, product composition in `app.css`, and a static `/design-system` preview; migrate routes incrementally | Match the existing Ruby/vanilla-JS deployment, preserve behavior, make foundations governable, and avoid a framework or package rewrite |
+| Remote UI deployment coherence | Snapshot all browser assets and their shared hash when `tycho serve` starts; require a daemon restart to load source updates | Prevent an old Ruby API from serving a newer on-disk JavaScript client after a pull, which can break push subscription renewal and other cross-boundary flows |
 | Remote multiserver resources | Keep one UI-serving broker, aggregate only compact Agent and Project resources through a disk-backed stale-while-revalidate catalog, and require explicit server identity for details and mutations | Combined lists stay responsive across peer failures and broker restarts; only a validated full snapshot may remove cached resources, while schedules, setup, GitHub, push, restart, and other server-level behavior remain local |
 | Scheduled runs | Dedicated `tycho schedule daemon`, definitions in `~/.tycho/config/schedules.yml`, runtime state in `~/.tycho/logs/schedules.json`, validated standard cron syntax | Scheduled work should continue independently from the TUI and Remote UI while still reusing existing agent execution paths |
 | Temporary session loops | Remote UI can adopt an idle conversation as a normal recurring schedule, run it immediately with schedule context, and stop it at a configured cutoff | Review-waiting sessions need lightweight polling without losing their existing context or creating a separate agent |

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -724,7 +724,7 @@ Checks the current browser's subscription without exposing its capability URL in
 }
 ```
 
-The response includes `subscribed` for that endpoint and the global `subscription_count`. The Remote UI uses the endpoint-specific result to show the correct controls when other devices are also subscribed.
+The response includes `subscribed`, the global `subscription_count`, and redacted delivery diagnostics for that endpoint: subscription ID, provider host, browser user agent, lifecycle timestamps, last provider response code, last error class, failure count, and disabled time. The full endpoint and encryption keys are never returned. The Remote UI uses the endpoint-specific result to show the correct controls when other devices are also subscribed.
 
 ### `DELETE /push/subscriptions`
 
@@ -739,6 +739,8 @@ Disables one browser push subscription by endpoint:
 ### `POST /push/test`
 
 Sends a test notification to an enabled subscription. Automatic agent-transition notifications are sent by the Remote server poll loop, de-duplicated in `~/.tycho/logs/push_notifications.json`, grouped through a shared notification tag, and mirrored to the installed-app badge when the browser exposes the Badging API.
+
+`sent: 1` means the push provider returned HTTP 2xx. It does not prove that the service worker received the payload or that Windows displayed it. Provider response codes and acceptance/failure times are persisted with the subscription and logged with a hashed endpoint label.
 
 ```json
 {

--- a/docs/WEB_PUSH_BEHAVIOR.md
+++ b/docs/WEB_PUSH_BEHAVIOR.md
@@ -12,11 +12,19 @@ This note explains how Tycho Remote UI uses browser push notifications, notifica
 6. When the Remote UI page is open, `syncUnreadAlert()` also mirrors the unread-agent count into the app badge so foreground state and background push state stay aligned.
 7. Notification clicks focus an existing Tycho Remote tab when possible, otherwise they open the payload URL, usually `/#agent/{key}`.
 
+## Deployment Coherence
+
+The Remote server snapshots the Remote UI templates, JavaScript, service worker, icons, and their shared asset hash when the daemon starts. A source update therefore cannot make an old Ruby API serve a newer JavaScript client. Restart `tycho serve` after updating Tycho; the restarted daemon exposes its loaded version and asset hash in **Settings → Connection → Tycho build**, `/setup`, and the `X-Tycho-Asset-Version` response header.
+
+The service worker is served with `Service-Worker-Allowed: /` and cache revalidation, registers at `/service-worker.js`, and controls the root scope. `skipWaiting()` and `clients.claim()` activate an updated worker promptly after the daemon restarts.
+
 ## Subscription Lifecycle
 
 Push-service endpoints can expire while the browser still retains a local `PushSubscription`. Windows Edge subscriptions use Windows Notification Service endpoints, while Chrome commonly uses Firebase Cloud Messaging endpoints. Both can return HTTP 404 or 410 after invalidating an endpoint.
 
 Tycho treats those responses as permanent: it disables the saved endpoint instead of retrying it. Transient failures such as HTTP 429 or 5xx remain enabled and increment their failure count. Settings checks the current browser's endpoint through `POST /push/status`; it does not infer this browser's state from the global subscription count. If the server has retired the local endpoint, or its application-server key differs from Tycho's current VAPID public key, **Enable notifications** unsubscribes it and creates a fresh subscription.
+
+Each send records the last attempt time, provider response code, provider acceptance or failure time, and error class on the saved subscription. A provider HTTP 2xx response proves that WNS, FCM, or APNs accepted the encrypted Web Push request; it does not prove that Windows displayed the notification. If an accepted push is not visible, continue at the service-worker, browser-permission, and Windows notification layers.
 
 Push endpoints are capability URLs. Tycho sends them in authenticated request bodies, not query strings, so normal URL logging does not expose them.
 
@@ -100,7 +108,7 @@ Example agent payload:
 3. If it says **Ready**, select **Enable notifications** and accept the Windows/browser permission prompt.
 4. Select **Send test**. Confirm a Tycho notification appears in Windows Notification Center while the PWA is minimized or closed.
 5. Complete a disposable agent run. Confirm one completion notification arrives and opens that agent when selected.
-6. If delivery fails, open DevTools in the PWA, select **Application → Service workers**, and confirm `/service-worker.js` is active for the Tycho origin. Then check Windows **Settings → System → Notifications** for both the browser and installed Tycho PWA, and inspect `~/.tycho/logs/hq.log` on the Tycho host for the endpoint host plus HTTP response code. Do not copy or share the full endpoint.
+6. If delivery fails, copy the **Tycho build** value, open DevTools in the PWA, select **Application → Service workers**, and confirm `/service-worker.js` is active with scope `/` for the Tycho origin. Then check Windows **Settings → System → Notifications** for both the browser and installed Tycho PWA, and inspect `~/.tycho/logs/hq.log` on the Tycho host for the endpoint host plus HTTP response code. Do not copy or share the full endpoint.
 
 ## Improvement Ideas
 

--- a/lib/hq/domain/push_subscription_store.rb
+++ b/lib/hq/domain/push_subscription_store.rb
@@ -2,6 +2,7 @@
 
 require "digest"
 require "json"
+require "uri"
 
 require_relative "constants"
 require_relative "file_store"
@@ -29,6 +30,27 @@ module HQ
       return false if value.empty?
 
       enabled.any? { |subscription| subscription["endpoint"] == value }
+    end
+
+    def status(endpoint)
+      subscription = all.find { |candidate| candidate["endpoint"] == endpoint.to_s }
+      return { subscribed: false } unless subscription
+
+      {
+        subscribed: subscription["disabled_at"].to_s.empty?,
+        subscription_id: subscription["id"],
+        endpoint_host: endpoint_host(subscription["endpoint"]),
+        user_agent: subscription["user_agent"],
+        created_at: subscription["created_at"],
+        last_seen_at: subscription["last_seen_at"],
+        last_attempted_at: subscription["last_attempted_at"],
+        last_accepted_at: subscription["last_accepted_at"],
+        last_failed_at: subscription["last_failed_at"],
+        last_response_code: subscription["last_response_code"],
+        last_error_class: subscription["last_error_class"],
+        failure_count: subscription["failure_count"].to_i,
+        disabled_at: subscription["disabled_at"]
+      }
     end
 
     def save_subscription(attrs, user_agent: nil)
@@ -78,21 +100,53 @@ module HQ
       disabled
     end
 
-    def record_failure(endpoint)
+    def record_success(endpoint, response_code: nil)
+      update_delivery(endpoint) do |subscription, now|
+        subscription["failure_count"] = 0
+        subscription["last_attempted_at"] = now
+        subscription["last_accepted_at"] = now
+        subscription["last_response_code"] = integer_or_nil(response_code)
+        subscription["last_error_class"] = nil
+      end
+    end
+
+    def record_failure(endpoint, response_code: nil, error_class: nil)
+      update_delivery(endpoint) do |subscription, now|
+        subscription["failure_count"] = subscription["failure_count"].to_i + 1
+        subscription["last_attempted_at"] = now
+        subscription["last_failed_at"] = now
+        subscription["last_response_code"] = integer_or_nil(response_code)
+        subscription["last_error_class"] = error_class.to_s.empty? ? nil : error_class.to_s
+      end
+    end
+
+    private
+
+    def update_delivery(endpoint)
       endpoint = endpoint.to_s
       subscriptions = all
       changed = false
+      now = Time.now.utc.iso8601
       subscriptions.each do |subscription|
         next unless subscription["endpoint"] == endpoint
 
-        subscription["failure_count"] = subscription["failure_count"].to_i + 1
-        subscription["updated_at"] = Time.now.utc.iso8601
+        yield subscription, now
+        subscription["updated_at"] = now
         changed = true
       end
       write(subscriptions) if changed
     end
 
-    private
+    def integer_or_nil(value)
+      text = value.to_s
+      text.match?(/\A\d+\z/) ? text.to_i : nil
+    end
+
+    def endpoint_host(endpoint)
+      URI.parse(endpoint.to_s).host.to_s
+    rescue URI::InvalidURIError
+      "invalid"
+    end
 
     def read
       parsed = FileStore.read_json(@path, fallback: [])

--- a/lib/hq/domain/web_push_notifier.rb
+++ b/lib/hq/domain/web_push_notifier.rb
@@ -94,7 +94,7 @@ module HQ
           "vapid_public_key=#{presence_label(keys[:public_key])} " \
           "vapid_private_key=#{presence_label(keys[:private_key])}"
       end
-      WebPush.payload_send(
+      response = WebPush.payload_send(
         message: message,
         endpoint: subscription.fetch("endpoint"),
         p256dh: subscription.fetch("p256dh"),
@@ -111,16 +111,31 @@ module HQ
         open_timeout: 5,
         read_timeout: 5
       )
-      HQ.logger.debug("Push") { "Push delivered endpoint=#{endpoint_label(subscription["endpoint"])}" }
+      @subscription_store.record_success(subscription["endpoint"], response_code: response&.code)
+      HQ.logger.debug("Push") do
+        "Push provider accepted endpoint=#{endpoint_label(subscription["endpoint"])} " \
+          "host=#{endpoint_host(subscription["endpoint"])} " \
+          "response_code=#{response&.code || "unknown"} response_message=#{response&.message.to_s.inspect}"
+      end
       :sent
     rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription => e
+      record_delivery_failure(subscription, e)
       @subscription_store.disable(subscription["endpoint"])
       log_delivery_failure(subscription, e, disabled: true)
       :disabled
     rescue StandardError => e
-      @subscription_store.record_failure(subscription["endpoint"])
+      record_delivery_failure(subscription, e)
       log_delivery_failure(subscription, e, disabled: false)
       :failed
+    end
+
+    def record_delivery_failure(subscription, error)
+      response = error.respond_to?(:response) ? error.response : nil
+      @subscription_store.record_failure(
+        subscription["endpoint"],
+        response_code: response&.code,
+        error_class: error.class.name
+      )
     end
 
     def log_delivery_failure(subscription, error, disabled:)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -427,7 +427,14 @@ module HQ
       when "/ui.js"
         ui_asset("application/javascript; charset=utf-8", RemoteUI.js)
       when "/service-worker.js"
-        ui_asset("application/javascript; charset=utf-8", RemoteUI.service_worker_js)
+        ui_asset(
+          "application/javascript; charset=utf-8",
+          RemoteUI.service_worker_js,
+          headers: {
+            "Cache-Control" => "no-cache, max-age=0, must-revalidate",
+            "Service-Worker-Allowed" => "/"
+          }
+        )
       when "/manifest.webmanifest"
         ui_asset("application/manifest+json; charset=utf-8", RemoteUI.manifest_json)
       when "/remote-logo.png", "/favicon.png", "/favicon.ico"
@@ -449,8 +456,13 @@ module HQ
       end
     end
 
-    def ui_asset(content_type, body)
-      { status: 200, content_type: content_type, body: body }
+    def ui_asset(content_type, body, headers: {})
+      {
+        status: 200,
+        content_type: content_type,
+        body: body,
+        headers: { "X-Tycho-Asset-Version" => RemoteUI.asset_version }.merge(headers)
+      }
     end
 
     def ui_request?(request)
@@ -2318,10 +2330,9 @@ module HQ
     end
 
     def push_status(attrs)
-      {
-        subscribed: @push_subscription_store.enabled_endpoint?(attrs["endpoint"]),
+      @push_subscription_store.status(attrs["endpoint"]).merge(
         subscription_count: @push_subscription_store.count
-      }
+      )
     end
 
     def save_push_subscription(attrs, user_agent: nil)

--- a/lib/hq/remote_ui.rb
+++ b/lib/hq/remote_ui.rb
@@ -50,28 +50,37 @@ module HQ
       </svg>
     SVG
 
+    ASSET_CONTENTS = ASSET_VERSION_PATHS.to_h do |path|
+      [path, File.binread(path).freeze]
+    end.freeze
+    ASSET_VERSION = begin
+      digest = Digest::SHA256.new
+      ASSET_VERSION_PATHS.each { |path| digest.update(ASSET_CONTENTS.fetch(path)) }
+      digest.hexdigest[0, 12].freeze
+    end
+
     def self.index
-      ERB.new(File.read(TEMPLATE_PATH)).result(binding)
+      ERB.new(asset_content(TEMPLATE_PATH)).result(binding)
     end
 
     def self.design_system_index
-      ERB.new(File.read(DESIGN_SYSTEM_TEMPLATE_PATH)).result(binding)
+      ERB.new(asset_content(DESIGN_SYSTEM_TEMPLATE_PATH)).result(binding)
     end
 
     def self.css
-      [File.read(DESIGN_SYSTEM_CSS_PATH), File.read(CSS_PATH)].join("\n")
+      [asset_content(DESIGN_SYSTEM_CSS_PATH), asset_content(CSS_PATH)].join("\n")
     end
 
     def self.js
-      File.read(JS_PATH)
+      asset_content(JS_PATH)
     end
 
     def self.helpers_js
-      File.read(HELPERS_JS_PATH)
+      asset_content(HELPERS_JS_PATH)
     end
 
     def self.service_worker_js
-      File.read(SERVICE_WORKER_PATH)
+      asset_content(SERVICE_WORKER_PATH)
     end
 
     def self.manifest_json
@@ -110,17 +119,20 @@ module HQ
     end
 
     def self.png_asset(name)
-      File.binread(PNG_ASSETS.fetch(name))
+      asset_content(PNG_ASSETS.fetch(name))
     end
 
     def self.asset_version
-      digest = Digest::SHA256.new
-      ASSET_VERSION_PATHS.each { |path| digest.update(File.binread(path)) }
-      digest.hexdigest[0, 12]
+      ASSET_VERSION
     end
 
     def self.favicon_svg
       FAVICON_SVG
     end
+
+    def self.asset_content(path)
+      ASSET_CONTENTS.fetch(path)
+    end
+    private_class_method :asset_content
   end
 end

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2799,8 +2799,13 @@ module RemoteServerTest
       )
       assert(saved[:subscribed], "expected subscription save response")
       assert(saved[:subscription_count] == 1, "expected one enabled subscription")
-      assert(service.push_status("endpoint" => "https://push.example.test/subscription/1")[:subscribed],
+      current_status = service.push_status("endpoint" => "https://push.example.test/subscription/1")
+      assert(current_status[:subscribed],
              "expected push config to identify the current browser subscription")
+      assert(current_status[:endpoint_host] == "push.example.test" && current_status[:user_agent] == "Remote UI test",
+             "expected push status to expose provider and browser diagnostics")
+      assert(!current_status.key?(:endpoint) && !current_status.key?(:p256dh) && !current_status.key?(:auth),
+             "expected push status to keep capability URLs and encryption keys private")
       assert(!service.push_status("endpoint" => "https://push.example.test/subscription/other")[:subscribed],
              "expected push config not to confuse another browser subscription with this browser")
 
@@ -3085,6 +3090,12 @@ module RemoteServerTest
 
     service_worker = server.send(:route_ui, "/service-worker.js")
     assert(service_worker[:content_type].include?("javascript"), "expected service worker route to return JavaScript")
+    assert(service_worker.dig(:headers, "Service-Worker-Allowed") == "/",
+           "expected the service worker route to declare root scope")
+    assert(service_worker.dig(:headers, "Cache-Control").include?("no-cache"),
+           "expected the browser to revalidate service worker updates")
+    assert(service_worker.dig(:headers, "X-Tycho-Asset-Version") == HQ::RemoteUI.asset_version,
+           "expected service worker responses to identify their loaded daemon build")
     assert(service_worker[:body].include?("skipWaiting"), "expected service worker updates to activate immediately")
     assert(service_worker[:body].include?("clients.claim"), "expected service worker updates to claim active clients")
     assert(service_worker[:body].include?("showNotification"), "expected service worker to display push notifications")

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+module RemoteUIAssetSnapshotTest
+  module_function
+
+  ROOT = File.expand_path("..", __dir__)
+
+  def run!
+    assert_loaded_daemon_keeps_one_asset_build
+    puts "remote_ui_asset_snapshot_test: ok"
+  end
+
+  def assert_loaded_daemon_keeps_one_asset_build
+    Dir.mktmpdir("tycho-remote-ui-snapshot") do |dir|
+      lib_dir = File.join(dir, "lib", "hq")
+      FileUtils.mkdir_p(lib_dir)
+      FileUtils.cp(File.join(ROOT, "lib", "hq", "remote_ui.rb"), lib_dir)
+      FileUtils.cp_r(File.join(ROOT, "lib", "hq", "remote_ui"), lib_dir)
+
+      script = <<~'RUBY'
+        require "hq/remote_ui"
+
+        loaded_js = HQ::RemoteUI.js
+        loaded_version = HQ::RemoteUI.asset_version
+        File.write(HQ::RemoteUI::JS_PATH, "#{loaded_js}\n// simulated update\n")
+
+        abort "running daemon served JavaScript from a different build" unless HQ::RemoteUI.js == loaded_js
+        abort "running daemon changed its asset version after startup" unless HQ::RemoteUI.asset_version == loaded_version
+      RUBY
+      stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        "-I#{File.join(dir, "lib")}",
+        "-e",
+        script
+      )
+      return if status.success?
+
+      raise "asset snapshot regression failed: #{[stdout, stderr].join.strip}"
+    end
+  end
+end
+
+RemoteUIAssetSnapshotTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/service_worker_test.rb
+++ b/test/service_worker_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module ServiceWorkerTest
+  module_function
+
+  ROOT = File.expand_path("..", __dir__)
+  SERVICE_WORKER_PATH = File.join(ROOT, "lib", "hq", "remote_ui", "assets", "service-worker.js")
+
+  def run!
+    assert_push_display_and_click_flow
+    puts "service_worker_test: ok"
+  end
+
+  def assert_push_display_and_click_flow
+    script = <<~'JAVASCRIPT'
+      const fs = require("fs");
+      const vm = require("vm");
+      const assert = require("assert");
+      const source = fs.readFileSync(process.argv[1], "utf8");
+      const handlers = {};
+      const notifications = [];
+      const badges = [];
+      const navigations = [];
+      const opened = [];
+      let focused = 0;
+      let matchedClients = [{
+        url: "https://tycho.test/#setup",
+        navigate: async (url) => navigations.push(url),
+        focus: async () => { focused += 1; },
+      }];
+      const worker = {
+        location: { origin: "https://tycho.test" },
+        navigator: {
+          setAppBadge: async (count) => badges.push(count),
+          clearAppBadge: async () => badges.push(0),
+        },
+        registration: {
+          showNotification: async (title, options) => notifications.push({ title, options }),
+        },
+        clients: {
+          claim: async () => {},
+          matchAll: async () => matchedClients,
+          openWindow: async (url) => opened.push(url),
+        },
+        skipWaiting: () => {},
+        addEventListener: (name, handler) => { handlers[name] = handler; },
+      };
+      const context = { self: worker, URL, Promise, Number, Object, Boolean, Math };
+      vm.runInNewContext(source, context, { filename: process.argv[1] });
+
+      async function dispatch(name, event) {
+        let pending = Promise.resolve();
+        handlers[name]({ ...event, waitUntil: (promise) => { pending = Promise.resolve(promise); } });
+        await pending;
+      }
+
+      (async () => {
+        await dispatch("push", {
+          data: { json: () => ({
+            title: "Agent finished",
+            body: "Windows check",
+            tag: "hq:agents",
+            renotify: true,
+            silent: false,
+            badge_count: 2,
+            url: "/#agent/windows-check",
+          }) },
+        });
+        assert.deepStrictEqual(badges, [2]);
+        assert.strictEqual(notifications.length, 1);
+        assert.strictEqual(notifications[0].title, "Agent finished");
+        assert.strictEqual(notifications[0].options.body, "Windows check");
+        assert.strictEqual(notifications[0].options.tag, "hq:agents");
+        assert.strictEqual(notifications[0].options.renotify, true);
+        assert.strictEqual(notifications[0].options.silent, false);
+        assert.strictEqual(notifications[0].options.data.url, "/#agent/windows-check");
+
+        let closed = 0;
+        await dispatch("notificationclick", {
+          notification: {
+            data: { url: "/#agent/windows-check" },
+            close: () => { closed += 1; },
+          },
+        });
+        assert.strictEqual(closed, 1);
+        assert.deepStrictEqual(navigations, ["https://tycho.test/#agent/windows-check"]);
+        assert.strictEqual(focused, 1);
+
+        matchedClients = [];
+        await dispatch("notificationclick", {
+          notification: {
+            data: { url: "/#agent/new-window" },
+            close: () => {},
+          },
+        });
+        assert.deepStrictEqual(opened, ["https://tycho.test/#agent/new-window"]);
+      })().catch((error) => {
+        console.error(error.stack || error.message);
+        process.exitCode = 1;
+      });
+    JAVASCRIPT
+    stdout, stderr, status = Open3.capture3("node", "-e", script, SERVICE_WORKER_PATH)
+    return if status.success?
+
+    raise "service worker regression failed: #{[stdout, stderr].join.strip}"
+  end
+end
+
+ServiceWorkerTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/web_push_notifier_test.rb
+++ b/test/web_push_notifier_test.rb
@@ -13,9 +13,27 @@ module WebPushNotifierTest
   ENDPOINT = "https://wns2-pn1p.notify.windows.com/subscription/expired"
 
   def run!
+    assert_success_records_provider_response
     assert_expired_subscription_is_disabled
     assert_transient_failure_remains_enabled
     puts "web_push_notifier_test: ok"
+  end
+
+  def assert_success_records_provider_response
+    with_notifier do |notifier, store|
+      with_web_push_response(Net::HTTPCreated, "201", "Created") do
+        result = notifier.send_test!(endpoint: ENDPOINT)
+        subscription = store.enabled.fetch(0)
+
+        assert(result == { sent: 1, failed: 0, attempted: 1, disabled: 0 },
+               "expected the provider-accepted send to succeed")
+        assert(subscription["last_response_code"] == 201,
+               "expected the accepted provider response code to be persisted")
+        assert(!subscription["last_accepted_at"].to_s.empty?,
+               "expected provider acceptance time to be persisted")
+        assert(subscription["failure_count"].zero?, "expected provider acceptance to clear failures")
+      end
+    end
   end
 
   def assert_expired_subscription_is_disabled
@@ -26,6 +44,11 @@ module WebPushNotifierTest
         assert(result == { sent: 0, failed: 1, attempted: 1, disabled: 1 },
                "expected the expired send to fail once and retire the endpoint, got #{result.inspect}")
         assert(store.enabled.empty?, "expected an expired Windows push endpoint to be disabled")
+        subscription = store.all.fetch(0)
+        assert(subscription["last_response_code"] == 410,
+               "expected the permanent provider response code to be persisted")
+        assert(subscription["last_error_class"] == "WebPush::ExpiredSubscription",
+               "expected the permanent provider error class to be persisted")
       end
     end
   end
@@ -39,6 +62,8 @@ module WebPushNotifierTest
         assert(result == { sent: 0, failed: 1, attempted: 1, disabled: 0 },
                "expected the transient send to fail once")
         assert(subscription["failure_count"] == 1, "expected a transient failure to remain retryable")
+        assert(subscription["last_response_code"] == 503,
+               "expected the transient provider response code to be persisted")
       end
     end
   end
@@ -68,6 +93,17 @@ module WebPushNotifierTest
     WebPush.define_singleton_method(:payload_send) do |**_options|
       raise error_class.new(response, "wns2-pn1p.notify.windows.com")
     end
+    yield
+  ensure
+    WebPush.define_singleton_method(:payload_send, original)
+  end
+
+  def with_web_push_response(response_class, code, message)
+    original = WebPush.method(:payload_send)
+    response = response_class.new("1.1", code, message)
+    response.instance_variable_set(:@body, "")
+    response.instance_variable_set(:@read, true)
+    WebPush.define_singleton_method(:payload_send) { |**_options| response }
     yield
   ensure
     WebPush.define_singleton_method(:payload_send, original)


### PR DESCRIPTION
## Summary

- snapshot Remote UI templates, JavaScript, service worker, icons, and their shared hash when `tycho serve` starts so a source update cannot pair an old Ruby API with a newer browser client
- persist and expose redacted push-provider delivery diagnostics, including response code and acceptance/failure timestamps
- declare root service-worker scope and forced update revalidation, and add executable coverage for push display and notification click routing

## Diagnosis

The Windows retest ran against a hybrid deployment. The daemon started at 20:58 from commit `650b583` before PR #56 was present in its loaded Ruby process, while `/ui.js` was read from the working tree for every request and changed after the later pull. The resulting client called `POST /push/status`, but the running daemon returned 404. Its older notifier also kept retrying the WNS endpoint after HTTP 410 instead of disabling it.

After this change, the restarted daemon reports Tycho `0.9.0` / UI `2079015efa3b` consistently through `/setup` and `X-Tycho-Asset-Version`; `POST /push/status` returns 200; and `/service-worker.js` reports `Service-Worker-Allowed: /` with cache revalidation. A targeted send to the persisted Windows endpoint returned 410, recorded `WebPush::ExpiredSubscription`, and disabled the endpoint as expected.

Provider HTTP 2xx will prove WNS accepted a fresh request, not that Windows displayed it. Final Edge/Chrome PWA delivery and click verification remains pending and Fizzy #122 must stay open until that passes.

Fizzy: https://fizzy.startkit.tech/1/cards/122

## Verification

- `bin/test`
- `bundle exec bin/remote-ui-smoke`
- live daemon restart and build/API/header comparison
- live targeted WNS send: HTTP 410 persisted and endpoint disabled
