### PR TITLE
Add remote-server control to Tycho CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+- Add direct `--server` CLI targeting for remote project inspection and the
+  complete managed-agent lifecycle, with token/token_env authentication, JSON
+  output, and explicit transport, authentication, compatibility, and API errors.
+
 ## 0.9.0 - 2026-07-31
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ tycho project create my-workspace \
   --reasoning-effort medium
 
 tycho project show my-workspace
+tycho project list
 tycho project update my-workspace --group Work --model=""
 tycho project archive my-workspace
 ```
@@ -326,6 +327,31 @@ remote_servers:
     url: http://vps-cd946cb7.tail952bf7.ts.net:7373
     token_env: TYCHO_VPS_REMOTE_TOKEN
 ```
+
+Target a configured peer directly from the CLI with `--server`. Project reads
+and the full managed-agent lifecycle use the peer's Remote JSON API; commands
+without `--server` keep using local state.
+
+```bash
+tycho project list --server vps
+tycho project show my-workspace --server vps --json
+
+tycho agent list my-workspace --server vps
+tycho agent status <agent-key> --server vps --json
+tycho agent create my-workspace "Inspect the failing build" --server vps
+tycho agent run <agent-key> --server vps
+tycho agent send <agent-key> "Try the smaller reproduction" --server vps
+tycho agent stop <agent-key> --server vps
+tycho agent archive <agent-key> --server vps
+```
+
+Remote CLI commands resolve the server only from `remote_servers` in
+`hq.yml`. Authentication uses `token_env` when configured, otherwise `token`;
+browser local storage is never read. Prefer `token_env` so credentials stay out
+of the config file. `--json` is supported by project list/show and every agent
+command above. Errors distinguish unknown server keys, unreachable servers,
+timeouts, rejected credentials, unsupported endpoints, and other Remote API
+responses without printing the token.
 
 The Remote UI always includes the local server and combines agents and projects
 from every configured peer into the same Agents list. Use the server filter to

--- a/README.md
+++ b/README.md
@@ -346,12 +346,31 @@ tycho agent archive <agent-key> --server vps
 ```
 
 Remote CLI commands resolve the server only from `remote_servers` in
-`hq.yml`. Authentication uses `token_env` when configured, otherwise `token`;
-browser local storage is never read. Prefer `token_env` so credentials stay out
-of the config file. `--json` is supported by project list/show and every agent
-command above. Errors distinguish unknown server keys, unreachable servers,
-timeouts, rejected credentials, unsupported endpoints, and other Remote API
-responses without printing the token.
+`hq.yml`. Each server key owns its credential. Tycho-managed tokens live in
+`~/.tycho/config/remote_credentials.json`, which Tycho writes atomically with
+`0600` permissions. An explicit `token_env` on that server entry takes
+precedence; if the variable is missing, the request fails instead of silently
+using another source.
+
+```bash
+tycho server login vps                 # hidden prompt; verify before saving
+tycho server login vps --no-verify     # save for an offline server
+tycho server status [vps] [--json]     # metadata only; never the token
+tycho server verify vps
+tycho server logout vps
+tycho server migrate vps               # move an inline hq.yml token
+tycho server migrate --all
+```
+
+Credentials bind to the stable server key and, after verification, to the
+server's scheme, normalized host, and effective port. Changing that origin
+requires login or verification. Authentication rejection marks a credential
+rejected and stops automatic reuse until explicit recovery. Inline `token`
+entries remain a warned migration fallback through v0.10.x and will be removed
+in v0.11.0. `--json` is supported by project list/show and every agent command
+above. Errors distinguish unknown server keys, missing external sources,
+origin changes, unreachable servers, timeouts, rejected credentials,
+unsupported endpoints, and other Remote API responses without printing tokens.
 
 The Remote UI always includes the local server and combines agents and projects
 from every configured peer into the same Agents list. Use the server filter to
@@ -533,8 +552,9 @@ Tailscale IPs, and QR codes.
 For multiple Remote servers, the browser still talks only to the Tycho server
 that served the UI. That local server returns a cached combined resource
 catalog and brokers each detail or mutation request to the resource's owner,
-using `token_env` values from local config or per-browser peer tokens entered
-in Settings. Browser-entered peer tokens are not written to `hq.yml`.
+using each peer's selected external or Tycho-stored credential. Saving a token
+in Settings verifies it, writes it to the host's private
+`remote_credentials.json`, and only then removes the browser-local copy.
 
 ## Custom Claude Harnesses
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-08-05
+2026-08-08
 
 ## Strategic Direction
 
@@ -65,6 +65,7 @@ Key references:
 | Remote UI design system | Keep a no-build internal system: semantic `--ds-*` tokens and reusable CSS components in `design_system.css`, product composition in `app.css`, and a static `/design-system` preview; migrate routes incrementally | Match the existing Ruby/vanilla-JS deployment, preserve behavior, make foundations governable, and avoid a framework or package rewrite |
 | Remote UI deployment coherence | Snapshot all browser assets and their shared hash when `tycho serve` starts; require a daemon restart to load source updates | Prevent an old Ruby API from serving a newer on-disk JavaScript client after a pull, which can break push subscription renewal and other cross-boundary flows |
 | Remote multiserver resources | Keep one UI-serving broker, aggregate only compact Agent and Project resources through a disk-backed stale-while-revalidate catalog, and require explicit server identity for details and mutations | Combined lists stay responsive across peer failures and broker restarts; only a validated full snapshot may remove cached resources, while schedules, setup, GitHub, push, restart, and other server-level behavior remain local |
+| Remote credential ownership | Bind one bearer credential to each stable remote server key and verified scheme/host/effective-port origin; keep Tycho-managed values in atomic mode-`0600` `~/.tycho/config/remote_credentials.json`, with explicit per-server `token_env` overrides | CLI and broker share one resolver, multiple peers cannot select credentials by incidental names, origin changes require explicit recovery, and browser promotion removes its copy only after verified persistence |
 | Scheduled runs | Dedicated `tycho schedule daemon`, definitions in `~/.tycho/config/schedules.yml`, runtime state in `~/.tycho/logs/schedules.json`, validated standard cron syntax | Scheduled work should continue independently from the TUI and Remote UI while still reusing existing agent execution paths |
 | Temporary session loops | Remote UI can adopt an idle conversation as a normal recurring schedule, run it immediately with schedule context, and stop it at a configured cutoff | Review-waiting sessions need lightweight polling without losing their existing context or creating a separate agent |
 | Run cost provenance | Persist harness and model on each managed-agent run; raw-log cost rebuilds use that per-run metadata and leave legacy runs unpriced when provenance is missing | Historical estimates must not silently apply the agent's current model price to older runs |

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -182,6 +182,7 @@ verify the bottle.
 - [x] Add persistent multiserver Agent and Project catalogs in Remote UI
 - [x] Persist last-good peer snapshots across broker restarts and failed refreshes
 - [x] Route peer Agent and Project details and mutations through explicit server keys
+- [x] Add direct `--server` CLI control for remote project reads and managed-agent lifecycles
 - [x] Show peer health, token state, and Tycho version compatibility in Settings
 - [x] Prepare GitHub App device login and guarded pull request review posting
 - [x] Store immutable pull request diff snapshots separately from review state

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -195,6 +195,35 @@ For ad hoc peers, open Settings, use the **Add server** toggle in the **Servers*
 
 UI-entered remote tokens are not written to `hq.yml`. The browser stores them in local storage under `hq.remote.serverTokens`, keyed by server key, and sends only the owning peer's token to the local broker as `X-Tycho-Remote-Server-Token`. The broker uses that value only for the outgoing peer request. If another browser can see an existing remote server but does not have its token, use that server row's **Token** action in Settings to re-authenticate it for the current browser. The UI's own bearer token remains separate under `hq.remote.token` and is sent as the normal `Authorization` header to the server that served the UI. For durable server-side peer credentials, configure `token_env` manually in `hq.yml`.
 
+## Remote CLI Control
+
+Project inspection and managed-agent lifecycle commands can target one
+configured peer directly. The CLI connects to that peer's `url`; it does not
+depend on a running local broker or any browser state.
+
+```bash
+tycho project list --server office-mac [--json]
+tycho project show <project-key> --server office-mac [--json]
+tycho agent list [<project-key>] --server office-mac [--json]
+tycho agent status <agent-key> --server office-mac [--json]
+tycho agent create <project-key> <prompt> --server office-mac [--run] [--json]
+tycho agent run <agent-key> --server office-mac [--json]
+tycho agent send <agent-key> <message> --server office-mac [--json]
+tycho agent stop <agent-key> --server office-mac [--json]
+tycho agent archive <agent-key> --server office-mac [--json]
+```
+
+The selected key must exist under `remote_servers`. Requests send
+`Authorization: Bearer ...` from the configured `token_env`, or from `token`
+when no environment variable name is configured. Keep production credentials
+in `token_env`; command output and errors never include them. Without
+`--server`, all commands retain their local behavior.
+
+Remote failures use explicit messages for unknown keys, connection failures,
+timeouts, authentication rejection, unsupported endpoints, and non-success API
+responses. The CLI exits nonzero for each failure. Agent `run`, `send`, and
+`stop` also enforce the same running/idle preconditions as their local forms.
+
 Browser push notification work is tracked in [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md), and the current grouping, silent-notification, and PWA badge behavior is summarized in [WEB_PUSH_BEHAVIOR.md](./WEB_PUSH_BEHAVIOR.md). Push can use a Tailscale MagicDNS domain when it is served over HTTPS, preferably with Tailscale Serve or Tailscale Funnel. Plain HTTP MagicDNS URLs show a soft warning, but the UI still lets the user try enabling notifications when the browser exposes the required push APIs.
 
 The Remote server polls managed-agent state while it is running and sends one push notification when an agent requires response or finishes. Structured `no_action_needed` outcomes stay quiet and do not mark the agent unread. Agent notifications share the `hq:agents` browser notification tag so repeated agent updates replace the previous Tycho agent notification instead of piling up; input-required notifications renotify audibly, while routine finish notifications are marked silent. Agent payloads also carry the current unread-agent count so browsers with the Badging API can show the count on the installed PWA app icon. Agent notification clicks open `/#agent/{key}`.

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -133,7 +133,7 @@ The remote server also serves a lightweight mobile web UI:
 http://127.0.0.1:7373/
 ```
 
-The UI is plain server-served HTML/CSS/JavaScript, with no frontend build step or JavaScript package dependencies. It uses the existing JSON endpoints, stores the optional bearer token in browser local storage, and sends it as `Authorization: Bearer ...` for API requests.
+The UI is plain server-served HTML/CSS/JavaScript, with no frontend build step or JavaScript package dependencies. It uses the existing JSON endpoints and stores only the UI-serving host's optional bearer token in browser local storage for `Authorization: Bearer ...` API requests. Peer credentials are external or host-managed as described below.
 
 New managed agents use timestamp-based keys such as `web-agent-20260712-120501-123456`. Existing numeric keys remain valid and load unchanged.
 
@@ -187,13 +187,13 @@ session_loops:
       prompt: Check the pull request for approvals, reviews, and comments. Address actionable feedback, run the relevant checks, and update the pull request. If nobody has acted, return no_action_needed.
 ```
 
-`key` must be stable and URL-safe. `url` must be an `http` or `https` base URL without embedded credentials. `icon` accepts `server` or `computer` and defaults to `server`. Prefer `token_env` over inline `token` outside local development. The synthetic `local` server is always present and cannot be redefined in config.
+`key` must be stable and URL-safe. It is also the local credential identity. `url` must be an `http` or `https` base URL without embedded credentials. `icon` accepts `server` or `computer` and defaults to `server`. Use `token_env` for an explicit external credential override or enroll a Tycho-managed credential with `tycho server login`. The synthetic `local` server is always present and cannot be redefined in config.
 
 The Settings screen manages the configured server list; the default local server is always present. Each peer row can edit its display name, choose the Lucide **Server** or **Computer** icon, and explicitly **Forget cached data** without changing the remote server itself. The Agents screen combines agents and projects from all servers and offers an **All servers** filter. Local ownership uses a home icon without a visible label; peers show their configured icon and name. Resource health remains explicit as **Online**, **Offline**, **Stale**, or **Token required**. There is no global active-server switch.
 
 For ad hoc peers, open Settings, use the **Add server** toggle in the **Servers** header, and enter a display name plus a loopback or Tailscale MagicDNS URL such as `tycho-peer` and `http://127.0.0.1:7374/` or `http://vps-cd946cb7.tail952bf7.ts.net:7373`. If the peer requires a bearer token, enter it in **Remote token**. The UI verifies the peer through the agent API, writes the peer metadata to `remote_servers` in `~/.tycho/config/hq.yml`, reloads the registry, and refreshes that peer's resource catalog. Removing a non-local server from the list also removes it from `hq.yml`. Ad hoc UI-added peers are intentionally limited to loopback and Tailscale MagicDNS hosts; edit `remote_servers` directly for broader LAN, public, or credentialed peers.
 
-UI-entered remote tokens are not written to `hq.yml`. The browser stores them in local storage under `hq.remote.serverTokens`, keyed by server key, and sends only the owning peer's token to the local broker as `X-Tycho-Remote-Server-Token`. The broker uses that value only for the outgoing peer request. If another browser can see an existing remote server but does not have its token, use that server row's **Token** action in Settings to re-authenticate it for the current browser. The UI's own bearer token remains separate under `hq.remote.token` and is sent as the normal `Authorization` header to the server that served the UI. For durable server-side peer credentials, configure `token_env` manually in `hq.yml`.
+UI-entered remote tokens are not written to `hq.yml`. Saving one verifies it against the selected peer, atomically writes it to the UI-serving Tycho host's private credential file, and removes the browser-local copy only after persistence succeeds. Existing browser tokens under `hq.remote.serverTokens` remain usable for promotion and are sent only to their owning peer as `X-Tycho-Remote-Server-Token`; a failed promotion leaves that browser copy intact. The UI's own bearer token remains separate under `hq.remote.token` and authenticates the browser to the server that served the UI.
 
 ## Remote CLI Control
 
@@ -213,15 +213,44 @@ tycho agent stop <agent-key> --server office-mac [--json]
 tycho agent archive <agent-key> --server office-mac [--json]
 ```
 
-The selected key must exist under `remote_servers`. Requests send
-`Authorization: Bearer ...` from the configured `token_env`, or from `token`
-when no environment variable name is configured. Keep production credentials
-in `token_env`; command output and errors never include them. Without
-`--server`, all commands retain their local behavior.
+The selected key must exist under `remote_servers`. Requests use the credential
+selected for that exact entry:
+
+1. If `token_env` is configured, its environment value wins. A missing value is
+   an error; Tycho does not fall through to its store.
+2. Otherwise, Tycho uses the server key's entry from
+   `~/.tycho/config/remote_credentials.json`.
+3. Otherwise, an inline `token` is accepted temporarily with a migration
+   warning. This fallback will be removed in v0.11.0.
+
+The credential file is local to each Tycho installation, written atomically,
+and mode `0600`. It stores one bearer token per server key plus verification
+metadata. Status output includes the source, state, bound origin, and timestamps
+but no token or fingerprint. A verified origin is the lowercased scheme and
+host plus effective port; URL paths do not affect the binding.
+
+```bash
+tycho server login office-mac
+tycho server login office-mac --no-verify
+tycho server status [office-mac] [--json]
+tycho server verify office-mac
+tycho server logout office-mac
+tycho server migrate office-mac
+tycho server migrate --all
+```
+
+`login` reads the token from a hidden prompt and normally verifies it before
+saving. `--no-verify` supports offline enrollment and records the credential as
+unverified until its first successful authenticated request. `verify` can
+recover an unverified or rejected credential. `logout` deletes only the
+Tycho-stored token and reports an external source without changing it. Migration
+moves inline values out of `hq.yml` and stores them as unverified. Without
+`--server`, project and agent commands retain their local behavior.
 
 Remote failures use explicit messages for unknown keys, connection failures,
 timeouts, authentication rejection, unsupported endpoints, and non-success API
-responses. The CLI exits nonzero for each failure. Agent `run`, `send`, and
+responses, missing external variables, origin mismatches, and credentials that
+remain rejected until explicit verification. The CLI exits nonzero for each failure. Agent `run`, `send`, and
 `stop` also enforce the same running/idle preconditions as their local forms.
 
 Browser push notification work is tracked in [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md), and the current grouping, silent-notification, and PWA badge behavior is summarized in [WEB_PUSH_BEHAVIOR.md](./WEB_PUSH_BEHAVIOR.md). Push can use a Tailscale MagicDNS domain when it is served over HTTPS, preferably with Tailscale Serve or Tailscale Funnel. Plain HTTP MagicDNS URLs show a soft warning, but the UI still lets the user try enabling notifications when the browser exposes the required push APIs.
@@ -387,6 +416,7 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | `POST` | `/servers` | Add or update one loopback or Tailscale MagicDNS Remote server in `remote_servers` inside `hq.yml`. |
 | `PATCH` | `/servers/{key}` | Update one peer server's display name and `server` or `computer` icon. |
 | `DELETE` | `/servers/{key}` | Remove one non-local Remote server from `remote_servers` inside `hq.yml`. |
+| `POST` | `/servers/{key}/credentials` | Verify a peer bearer token, save it in the UI-serving host's private credential store, and return metadata without the token. |
 | `GET` / `POST` / `PUT` / `PATCH` / `DELETE` | `/servers/{key}/agents/{path}` | Forward an agent-owned request to one peer. |
 | `GET` / `POST` / `PUT` / `PATCH` / `DELETE` | `/servers/{key}/projects/{path}` | Forward a project-owned request to one peer. |
 | `GET` / `POST` / `PUT` / `PATCH` / `DELETE` | `/servers/{key}/attachments/{path}` | Forward an attachment-owned request to one peer. |

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -3,6 +3,8 @@
 require "json"
 require "open3"
 require "rbconfig"
+require "time"
+require "uri"
 
 require "dry/cli"
 require "lipgloss"
@@ -47,6 +49,11 @@ module HQ
           option :hidden, desc: "Visibility override: true, false, or inherit"
           option :json, type: :boolean, default: false, desc: "Print JSON"
         end
+
+        def remote_options(json: true)
+          option :server, desc: "Remote server key from hq.yml"
+          option :json, type: :boolean, default: false, desc: "Print JSON" if json
+        end
       end
 
       class Project < Dry::CLI::Command
@@ -82,11 +89,23 @@ module HQ
 
         desc "Show project configuration"
         argument :project_key, required: true, desc: "Project key"
-        option :json, type: :boolean, default: false, desc: "Print JSON"
-        usage_template "project show %{project_key} [--json]"
+        remote_options
+        usage_template "project show %{project_key} [--server SERVER_KEY] [--json]"
 
         def call(project_key:, **opts)
           exit CLICommand.show_project(project_key, opts, out: out, err: err)
+        end
+      end
+
+      class ProjectList < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "List projects"
+        remote_options
+        usage_template "project list [--server SERVER_KEY] [--json]"
+
+        def call(**opts)
+          exit CLICommand.list_projects(opts, out: out, err: err)
         end
       end
 
@@ -118,6 +137,7 @@ module HQ
 
       register "project", Project do |prefix|
         prefix.register "create", ProjectCreate
+        prefix.register "list", ProjectList
         prefix.register "show", ProjectShow
         prefix.register "update", ProjectUpdate
         prefix.register "archive", ProjectArchive
@@ -142,7 +162,8 @@ module HQ
         option :name, desc: "Agent name override"
         option :template, desc: "Template key to use (defaults to project's first template)"
         option :run, type: :boolean, default: false, desc: "Start the agent immediately after creating"
-        usage_template "agent create %{project_key} %{prompt}"
+        remote_options
+        usage_template "agent create %{project_key} %{prompt} [--server SERVER_KEY] [--json]"
 
         def call(project_key:, prompt:, **opts)
           exit CLICommand.create_agent(project_key, prompt, opts, out: out, err: err)
@@ -154,10 +175,11 @@ module HQ
 
         desc "List managed agents"
         argument :project_key, required: false, desc: "Filter by project key"
-        usage_template "agent list [%{project_key}]"
+        remote_options
+        usage_template "agent list [%{project_key}] [--server SERVER_KEY] [--json]"
 
         def call(**opts)
-          exit CLICommand.list_agents(opts[:project_key], out: out, err: err)
+          exit CLICommand.list_agents(opts[:project_key], opts, out: out, err: err)
         end
       end
 
@@ -166,10 +188,11 @@ module HQ
 
         desc "Show status and metadata for an agent"
         argument :agent_key, required: true, desc: "Agent key"
-        usage_template "agent status %{agent_key}"
+        remote_options
+        usage_template "agent status %{agent_key} [--server SERVER_KEY] [--json]"
 
-        def call(agent_key:, **)
-          exit CLICommand.agent_status(agent_key, out: out, err: err)
+        def call(agent_key:, **opts)
+          exit CLICommand.agent_status(agent_key, opts, out: out, err: err)
         end
       end
 
@@ -178,10 +201,11 @@ module HQ
 
         desc "Start (or re-run) an existing agent"
         argument :agent_key, required: true, desc: "Agent key"
-        usage_template "agent run %{agent_key}"
+        remote_options
+        usage_template "agent run %{agent_key} [--server SERVER_KEY] [--json]"
 
-        def call(agent_key:, **)
-          exit CLICommand.run_agent(agent_key, out: out, err: err)
+        def call(agent_key:, **opts)
+          exit CLICommand.run_agent(agent_key, opts, out: out, err: err)
         end
       end
 
@@ -190,10 +214,11 @@ module HQ
 
         desc "Stop a running agent"
         argument :agent_key, required: true, desc: "Agent key"
-        usage_template "agent stop %{agent_key}"
+        remote_options
+        usage_template "agent stop %{agent_key} [--server SERVER_KEY] [--json]"
 
-        def call(agent_key:, **)
-          exit CLICommand.stop_agent(agent_key, out: out, err: err)
+        def call(agent_key:, **opts)
+          exit CLICommand.stop_agent(agent_key, opts, out: out, err: err)
         end
       end
 
@@ -217,10 +242,11 @@ module HQ
         desc "Send a message to an agent and re-run it"
         argument :agent_key, required: true, desc: "Agent key"
         argument :message, required: true, desc: "Message to send"
-        usage_template "agent send %{agent_key} %{message}"
+        remote_options
+        usage_template "agent send %{agent_key} %{message} [--server SERVER_KEY] [--json]"
 
-        def call(agent_key:, message:, **)
-          exit CLICommand.send_agent_message(agent_key, message, out: out, err: err)
+        def call(agent_key:, message:, **opts)
+          exit CLICommand.send_agent_message(agent_key, message, opts, out: out, err: err)
         end
       end
 
@@ -229,10 +255,11 @@ module HQ
 
         desc "Archive an agent and move its logs"
         argument :agent_key, required: true, desc: "Agent key"
-        usage_template "agent archive %{agent_key}"
+        remote_options
+        usage_template "agent archive %{agent_key} [--server SERVER_KEY] [--json]"
 
-        def call(agent_key:, **)
-          exit CLICommand.archive_agent(agent_key, out: out, err: err)
+        def call(agent_key:, **opts)
+          exit CLICommand.archive_agent(agent_key, opts, out: out, err: err)
         end
       end
 
@@ -422,6 +449,7 @@ module HQ
     PROJECT_COMMANDS = [
       Commands::Project,
       Commands::ProjectCreate,
+      Commands::ProjectList,
       Commands::ProjectShow,
       Commands::ProjectUpdate,
       Commands::ProjectArchive
@@ -795,6 +823,8 @@ module HQ
     end
 
     def show_project(project_key, opts = {}, out: $stdout, err: $stderr)
+      return remote_show_project(project_key, opts, out:, err:) if remote_requested?(opts)
+
       require_relative "registry"
 
       registry = Registry.new
@@ -805,6 +835,25 @@ module HQ
       0
     rescue StandardError => e
       failure("Failed to show #{project_key}: #{e.message}", err: err)
+    end
+
+    def list_projects(opts = {}, out: $stdout, err: $stderr)
+      return remote_list_projects(opts, out:, err:) if remote_requested?(opts)
+
+      payload = registry_projects.map do |project|
+        project.refresh_metadata!
+        {
+          key: project.key,
+          name: project.name,
+          group: project.group.empty? ? nil : project.group,
+          path: project.path,
+          status: project.status
+        }
+      end
+      print_project_list(payload, json: opts[:json], out: out)
+      0
+    rescue StandardError => e
+      failure("Failed to list projects: #{e.message}", err: err)
     end
 
     def update_project(project_key, opts, out: $stdout, err: $stderr)
@@ -960,6 +1009,8 @@ module HQ
     end
 
     def create_agent(project_key, prompt, opts, out: $stdout, err: $stderr)
+      return remote_create_agent(project_key, prompt, opts, out:, err:) if remote_requested?(opts)
+
       require_relative "registry"
       require_relative "harness_registry"
 
@@ -997,13 +1048,6 @@ module HQ
       existing.unshift(agent)
       agent_store.save(existing)
 
-      out.puts "Created agent #{agent.key}"
-      out.puts "  Name:    #{agent.name}"
-      out.puts "  Project: #{agent.project_key}"
-      out.puts "  Harness: #{agent.agent}"
-      out.puts "  Model:   #{agent.model || "(project default)"}"
-      out.puts "  Prompt:  #{agent.prompt.lines.first&.chomp}"
-
       if opts[:run]
         agent.start!
         # Persist started state (pid, status, started_at) back to disk.
@@ -1011,23 +1055,28 @@ module HQ
         idx = existing.index { |a| a.key == agent.key }
         existing[idx] = agent if idx
         agent_store.save(existing)
-        if agent.running?
-          out.puts "  Status:  running (pid #{agent.pid})"
-          out.puts "  Log:     #{agent.raw_log_path}"
-        else
-          out.puts "  Status:  start failed — #{agent.last_run&.error || "unknown error"}"
+        unless agent.running?
+          out.puts "Status: start failed — #{agent.last_run&.error || "unknown error"}" unless opts[:json]
           return 1
         end
       end
 
+      print_created_agent(agent_cli_payload(agent), json: opts[:json], out: out)
       0
     rescue StandardError => e
       failure("Failed to create agent: #{e.message}", err: err)
     end
 
-    def list_agents(project_key, out: $stdout, err: $stderr)
+    def list_agents(project_key, opts = {}, out: $stdout, err: $stderr)
+      return remote_list_agents(project_key, opts, out:, err:) if remote_requested?(opts)
+
       agents = load_all_agents
       agents = agents.select { |a| a.project_key == project_key.to_s } if project_key
+      payload = agents.map { |agent| agent_cli_payload(agent) }
+      if opts[:json]
+        out.puts JSON.pretty_generate(payload)
+        return 0
+      end
       if agents.empty?
         out.puts project_key ? "No agents for project: #{project_key}" : "No agents found."
         return 0
@@ -1042,41 +1091,21 @@ module HQ
       failure("Failed to list agents: #{e.message}", err: err)
     end
 
-    def agent_status(agent_key, out: $stdout, err: $stderr)
+    def agent_status(agent_key, opts = {}, out: $stdout, err: $stderr)
+      return remote_agent_status(agent_key, opts, out:, err:) if remote_requested?(opts)
+
       agent = load_all_agents.find { |a| a.key == agent_key.to_s }
       return failure("Unknown agent: #{agent_key}", err: err) unless agent
 
-      last = agent.last_run
-      rows = [
-        ["Key", agent.key],
-        ["Name", agent.name],
-        ["Project", agent.project_key],
-        ["Schedule key", agent.schedule_key || "n/a"],
-        ["Harness", agent.agent],
-        ["Model", agent.model || "(project default)"],
-        ["Status", agent.status],
-        ["PID", agent.pid ? agent.pid.to_s : "n/a"],
-        ["Runs", agent.run_count.to_s],
-        ["Started", agent.started_at ? agent.started_at.strftime("%Y-%m-%d %H:%M:%S") : "n/a"],
-        ["Finished", agent.finished_at ? agent.finished_at.strftime("%Y-%m-%d %H:%M:%S") : "n/a"],
-        ["Exit code", agent.last_exit_code ? agent.last_exit_code.to_s : "n/a"],
-        ["Last run", last ? last.started_at&.strftime("%Y-%m-%d %H:%M:%S") || "n/a" : "n/a"],
-        ["Workspace", agent.workspace],
-        ["Log", agent.raw_log_path || "n/a"],
-      ]
-      table = Lipgloss::Table.new
-        .rows(rows)
-        .border_style(Lipgloss::Style.new.foreground(COLORS[:accent_alt]))
-        .style_func(rows: rows.length, columns: 2) { |_row, column|
-          column.zero? ? Lipgloss::Style.new.bold(true).foreground(COLORS[:notice]) : Lipgloss::Style.new.foreground(COLORS[:text])
-        }
-      out.puts table.render
+      print_agent_status(agent_cli_payload(agent), json: opts[:json], out: out)
       0
     rescue StandardError => e
       failure("Failed to get agent status: #{e.message}", err: err)
     end
 
-    def run_agent(agent_key, out: $stdout, err: $stderr)
+    def run_agent(agent_key, opts = {}, out: $stdout, err: $stderr)
+      return remote_agent_action(agent_key, "start", opts, out:, err:) if remote_requested?(opts)
+
       agent = load_all_agents.find { |a| a.key == agent_key.to_s }
       return failure("Unknown agent: #{agent_key}", err: err) unless agent
       return failure("Agent #{agent_key} is already running", err: err) if agent.running?
@@ -1084,8 +1113,7 @@ module HQ
       agent.start!
       save_agent_in_store(agent)
       if agent.running?
-        out.puts "Started #{agent.key} (pid #{agent.pid})"
-        out.puts "Log: #{agent.raw_log_path}"
+        print_started_agent(agent_cli_payload(agent), json: opts[:json], out: out)
       else
         out.puts "Failed to start #{agent.key}"
         return 1
@@ -1095,14 +1123,16 @@ module HQ
       failure("Failed to run agent: #{e.message}", err: err)
     end
 
-    def stop_agent(agent_key, out: $stdout, err: $stderr)
+    def stop_agent(agent_key, opts = {}, out: $stdout, err: $stderr)
+      return remote_agent_action(agent_key, "stop", opts, out:, err:) if remote_requested?(opts)
+
       agent = load_all_agents.find { |a| a.key == agent_key.to_s }
       return failure("Unknown agent: #{agent_key}", err: err) unless agent
       return failure("Agent #{agent_key} is not running", err: err) unless agent.running?
 
       agent.stop!
       save_agent_in_store(agent)
-      out.puts "Stopped #{agent.key}"
+      print_simple_agent_action("Stopped", agent_cli_payload(agent), json: opts[:json], out: out)
       0
     rescue StandardError => e
       failure("Failed to stop agent: #{e.message}", err: err)
@@ -1130,7 +1160,9 @@ module HQ
       failure("Failed to read agent logs: #{e.message}", err: err)
     end
 
-    def send_agent_message(agent_key, message, out: $stdout, err: $stderr)
+    def send_agent_message(agent_key, message, opts = {}, out: $stdout, err: $stderr)
+      return remote_send_agent_message(agent_key, message, opts, out:, err:) if remote_requested?(opts)
+
       agent = load_all_agents.find { |a| a.key == agent_key.to_s }
       return failure("Unknown agent: #{agent_key}", err: err) unless agent
       return failure("Agent #{agent_key} is already running", err: err) if agent.running?
@@ -1139,8 +1171,7 @@ module HQ
       agent.start!
       save_agent_in_store(agent)
       if agent.running?
-        out.puts "Message sent and agent started (pid #{agent.pid})"
-        out.puts "Log: #{agent.raw_log_path}"
+        print_sent_agent(agent_cli_payload(agent), json: opts[:json], out: out)
       else
         out.puts "Message saved but agent failed to start"
         return 1
@@ -1150,7 +1181,9 @@ module HQ
       failure("Failed to send message: #{e.message}", err: err)
     end
 
-    def archive_agent(agent_key, out: $stdout, err: $stderr)
+    def archive_agent(agent_key, opts = {}, out: $stdout, err: $stderr)
+      return remote_archive_agent(agent_key, opts, out:, err:) if remote_requested?(opts)
+
       agents = load_all_agents
       agent = agents.find { |a| a.key == agent_key.to_s }
       return failure("Unknown agent: #{agent_key}", err: err) unless agent
@@ -1159,8 +1192,13 @@ module HQ
       archive_path = agent.archive_logs!
       remaining = agents.reject { |a| a.key == agent_key.to_s }
       agent_store_for_all.save(remaining)
-      out.puts "Archived #{agent.key}"
-      out.puts "Archive: #{archive_path}" if archive_path
+      result = { archived: true, agent_key: agent.key, archive_path: archive_path }.compact
+      if opts[:json]
+        out.puts JSON.pretty_generate(result)
+      else
+        out.puts "Archived #{agent.key}"
+        out.puts "Archive: #{archive_path}" if archive_path
+      end
       0
     rescue StandardError => e
       failure("Failed to archive agent: #{e.message}", err: err)
@@ -1202,6 +1240,323 @@ module HQ
       0
     rescue StandardError => e
       failure("Failed to clone agent: #{e.message}", err: err)
+    end
+
+    def remote_requested?(opts)
+      !opts[:server].to_s.strip.empty?
+    end
+
+    def remote_client(server_key)
+      require_relative "registry"
+      require_relative "domain/remote_cli_client"
+
+      RemoteCLIClient.from_registry(server_key, registry: Registry.new)
+    end
+
+    def remote_show_project(project_key, opts, out:, err:)
+      payload = remote_client(opts[:server]).request("GET", remote_resource_path("projects", project_key)).fetch("project")
+      print_project_result(remote_project_detail(payload), json: opts[:json], out: out)
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_list_projects(opts, out:, err:)
+      payload = remote_client(opts[:server]).request("GET", "/projects").fetch("projects").map do |project|
+        remote_project_list_item(project)
+      end
+      print_project_list(payload, json: opts[:json], out: out)
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_create_agent(project_key, prompt, opts, out:, err:)
+      body = {
+        "project_key" => project_key.to_s,
+        "prompt" => prompt.to_s,
+        "start" => opts[:run] == true
+      }
+      {
+        name: "name",
+        template: "template_key",
+        harness: "agent",
+        model: "model"
+      }.each do |option, field|
+        value = opts[option].to_s.strip
+        body[field] = value unless value.empty?
+      end
+      payload = remote_client(opts[:server]).request("POST", "/agents", body: body).fetch("agent")
+      print_created_agent(remote_agent_payload(payload), json: opts[:json], out: out)
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_list_agents(project_key, opts, out:, err:)
+      agents = remote_client(opts[:server]).request("GET", "/agents").fetch("agents")
+      agents = agents.select { |agent| agent["project_key"] == project_key.to_s } if project_key
+      agents = agents.map { |agent| remote_agent_payload(agent) }
+      if opts[:json]
+        out.puts JSON.pretty_generate(agents)
+      elsif agents.empty?
+        out.puts project_key ? "No agents for project: #{project_key}" : "No agents found."
+      else
+        rows = agents.map do |agent|
+          [agent["key"], agent["project_key"], agent["name"], agent["agent"], agent["status"], agent["run_count"].to_s]
+        end
+        out.puts agent_table(%w[Key Project Name Harness Status Runs], rows)
+      end
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_agent_status(agent_key, opts, out:, err:)
+      payload = remote_client(opts[:server]).request("GET", remote_resource_path("agents", agent_key)).fetch("agent")
+      payload = remote_agent_payload(payload)
+      print_agent_status(payload, json: opts[:json], out: out)
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_agent_action(agent_key, action, opts, out:, err:)
+      client = remote_client(opts[:server])
+      current = client.request("GET", remote_resource_path("agents", agent_key)).fetch("agent")
+      if action == "start" && current["running"]
+        return failure("Agent #{agent_key} is already running", err: err)
+      end
+      if action == "stop" && !current["running"]
+        return failure("Agent #{agent_key} is not running", err: err)
+      end
+
+      payload = client
+        .request("POST", "#{remote_resource_path("agents", agent_key)}/#{action}")
+        .fetch("agent")
+      payload = remote_agent_payload(payload)
+      if action == "start"
+        print_started_agent(payload, json: opts[:json], out: out)
+      else
+        print_simple_agent_action("Stopped", payload, json: opts[:json], out: out)
+      end
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_send_agent_message(agent_key, message, opts, out:, err:)
+      client = remote_client(opts[:server])
+      current = client.request("GET", remote_resource_path("agents", agent_key)).fetch("agent")
+      return failure("Agent #{agent_key} is already running", err: err) if current["running"]
+
+      payload = client
+        .request(
+          "POST",
+          "#{remote_resource_path("agents", agent_key)}/messages",
+          body: { "prompt" => message.to_s, "start" => true }
+        )
+        .fetch("agent")
+      payload = remote_agent_payload(payload)
+      print_sent_agent(payload, json: opts[:json], out: out)
+      0
+    rescue RemoteCLIClient::Error, KeyError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_archive_agent(agent_key, opts, out:, err:)
+      payload = remote_client(opts[:server])
+        .request("POST", "#{remote_resource_path("agents", agent_key)}/archive")
+      payload = {
+        "archived" => payload["archived"],
+        "agent_key" => payload["agent_key"],
+        "archive_path" => payload["archive_path"]
+      }.compact
+      if opts[:json]
+        out.puts JSON.pretty_generate(payload)
+      else
+        out.puts "Archived #{payload["agent_key"] || agent_key}"
+        out.puts "Archive: #{payload["archive_path"]}" unless payload["archive_path"].to_s.empty?
+      end
+      0
+    rescue RemoteCLIClient::Error => e
+      failure(e.message, err: err)
+    end
+
+    def remote_resource_path(root, key)
+      encoded = URI.encode_www_form_component(key.to_s).gsub("+", "%20")
+      "/#{root}/#{encoded}"
+    end
+
+    def remote_project_detail(payload)
+      {
+        key: payload["key"],
+        name: payload["name"],
+        group: payload["group"],
+        path: payload["path"],
+        harness: payload["agent"],
+        model: payload["model"],
+        reasoning_effort: payload["reasoning_effort"],
+        response_style: nil,
+        pr_url: payload["pr_url"],
+        hidden: false,
+        visibility_source: "remote server",
+        git: {
+          branch: payload["branch"],
+          commit: payload["commit_hash"],
+          dirty_files: payload["dirty_files"]
+        }
+      }
+    end
+
+    def remote_project_list_item(payload)
+      {
+        "key" => payload["key"],
+        "name" => payload["name"],
+        "group" => payload["group"],
+        "path" => payload["path"],
+        "status" => payload["status"]
+      }
+    end
+
+    def remote_agent_payload(payload)
+      {
+        "key" => payload["key"],
+        "name" => payload["name"],
+        "project_key" => payload["project_key"],
+        "schedule_key" => payload["schedule_key"],
+        "agent" => payload["agent"],
+        "model" => payload["model"],
+        "status" => payload["status"],
+        "running" => payload["running"],
+        "pid" => payload["pid"],
+        "run_count" => payload["run_count"],
+        "started_at" => payload["started_at"],
+        "finished_at" => payload["finished_at"],
+        "last_exit_code" => payload["last_exit_code"],
+        "last_run_at" => payload["started_at"],
+        "workspace" => payload["workspace"],
+        "log_path" => payload["log_path"],
+        "prompt" => payload["prompt"]
+      }
+    end
+
+    def print_project_list(payload, json:, out:)
+      return out.puts(JSON.pretty_generate(payload)) if json
+
+      if payload.empty?
+        out.puts "No projects found."
+        return
+      end
+      rows = payload.map do |project|
+        value = project.transform_keys(&:to_s)
+        [value["key"], value["name"], value["group"] || "(none)", value["status"] || "n/a", value["path"]]
+      end
+      out.puts agent_table(%w[Key Name Group Status Path], rows)
+    end
+
+    def agent_cli_payload(agent)
+      last = agent.last_run
+      {
+        key: agent.key,
+        name: agent.name,
+        project_key: agent.project_key,
+        schedule_key: agent.schedule_key,
+        agent: agent.agent,
+        model: agent.model,
+        status: agent.status,
+        running: agent.running?,
+        pid: agent.pid,
+        run_count: agent.run_count,
+        started_at: agent.started_at&.iso8601,
+        finished_at: agent.finished_at&.iso8601,
+        last_exit_code: agent.last_exit_code,
+        last_run_at: last&.started_at&.iso8601,
+        workspace: agent.workspace,
+        log_path: agent.raw_log_path,
+        prompt: agent.prompt
+      }
+    end
+
+    def print_created_agent(payload, json:, out:)
+      return out.puts(JSON.pretty_generate(payload)) if json
+
+      value = payload.transform_keys(&:to_s)
+      out.puts "Created agent #{value["key"]}"
+      out.puts "  Name:    #{value["name"]}"
+      out.puts "  Project: #{value["project_key"]}"
+      out.puts "  Harness: #{value["agent"]}"
+      out.puts "  Model:   #{value["model"] || "(project default)"}"
+      out.puts "  Prompt:  #{value["prompt"].to_s.lines.first&.chomp}"
+      if value["running"]
+        out.puts "  Status:  running (pid #{value["pid"]})"
+        out.puts "  Log:     #{value["log_path"]}"
+      end
+    end
+
+    def print_agent_status(payload, json:, out:)
+      return out.puts(JSON.pretty_generate(payload)) if json
+
+      value = payload.transform_keys(&:to_s)
+      rows = [
+        ["Key", value["key"]],
+        ["Name", value["name"]],
+        ["Project", value["project_key"]],
+        ["Schedule key", value["schedule_key"] || "n/a"],
+        ["Harness", value["agent"]],
+        ["Model", value["model"] || "(project default)"],
+        ["Status", value["status"]],
+        ["PID", value["pid"] || "n/a"],
+        ["Runs", value["run_count"].to_i.to_s],
+        ["Started", display_timestamp(value["started_at"])],
+        ["Finished", display_timestamp(value["finished_at"])],
+        ["Exit code", value["last_exit_code"].nil? ? "n/a" : value["last_exit_code"].to_s],
+        ["Last run", display_timestamp(value["last_run_at"] || value["started_at"])],
+        ["Workspace", value["workspace"]],
+        ["Log", value["log_path"] || "n/a"]
+      ]
+      out.puts detail_table(rows)
+    end
+
+    def print_started_agent(payload, json:, out:)
+      return out.puts(JSON.pretty_generate(payload)) if json
+
+      value = payload.transform_keys(&:to_s)
+      out.puts "Started #{value["key"]} (pid #{value["pid"]})"
+      out.puts "Log: #{value["log_path"]}"
+    end
+
+    def print_sent_agent(payload, json:, out:)
+      return out.puts(JSON.pretty_generate(payload)) if json
+
+      value = payload.transform_keys(&:to_s)
+      out.puts "Message sent and agent started (pid #{value["pid"]})"
+      out.puts "Log: #{value["log_path"]}"
+    end
+
+    def print_simple_agent_action(action, payload, json:, out:)
+      return out.puts(JSON.pretty_generate(payload)) if json
+
+      value = payload.transform_keys(&:to_s)
+      out.puts "#{action} #{value["key"]}"
+    end
+
+    def display_timestamp(value)
+      return "n/a" if value.to_s.empty?
+
+      Time.parse(value.to_s).strftime("%Y-%m-%d %H:%M:%S")
+    rescue ArgumentError
+      value.to_s
+    end
+
+    def detail_table(rows)
+      Lipgloss::Table.new
+        .rows(rows)
+        .border_style(Lipgloss::Style.new.foreground(COLORS[:accent_alt]))
+        .style_func(rows: rows.length, columns: 2) { |_row, column|
+          column.zero? ? Lipgloss::Style.new.bold(true).foreground(COLORS[:notice]) : Lipgloss::Style.new.foreground(COLORS[:text])
+        }
+        .render
     end
 
     def validate_schedules(out: $stdout, err: $stderr)

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "io/console"
 require "open3"
 require "rbconfig"
 require "time"
@@ -288,6 +289,85 @@ module HQ
         prefix.register "clone", AgentClone
       end
 
+      class Server < Dry::CLI::Command
+        desc "Manage remote server credentials"
+
+        def call(**)
+          exit CLICommand.usage("Missing server command", err: err)
+        end
+      end
+
+      class ServerLogin < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Save a remote server credential"
+        argument :server_key, required: true, desc: "Remote server key"
+        option :no_verify, type: :boolean, default: false, desc: "Save without contacting the server"
+        usage_template "server login SERVER_KEY [--no-verify]"
+
+        def call(server_key:, **opts)
+          exit CLICommand.server_login(server_key, opts, input: $stdin, out: out, err: err)
+        end
+      end
+
+      class ServerLogout < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Delete a Tycho-stored remote server credential"
+        argument :server_key, required: true, desc: "Remote server key"
+        usage_template "server logout SERVER_KEY"
+
+        def call(server_key:, **)
+          exit CLICommand.server_logout(server_key, out: out, err: err)
+        end
+      end
+
+      class ServerStatus < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Show remote server credential metadata"
+        argument :server_key, required: false, desc: "Remote server key"
+        option :json, type: :boolean, default: false, desc: "Print JSON"
+        usage_template "server status [SERVER_KEY] [--json]"
+
+        def call(server_key: nil, **opts)
+          exit CLICommand.server_status(server_key, opts, out: out, err: err)
+        end
+      end
+
+      class ServerVerify < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Verify the active credential for a remote server"
+        argument :server_key, required: true, desc: "Remote server key"
+        usage_template "server verify SERVER_KEY"
+
+        def call(server_key:, **)
+          exit CLICommand.server_verify(server_key, out: out, err: err)
+        end
+      end
+
+      class ServerMigrate < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Move inline hq.yml tokens into the credential store"
+        argument :server_key, required: false, desc: "Remote server key"
+        option :all, type: :boolean, default: false, desc: "Migrate every inline remote token"
+        usage_template "server migrate [SERVER_KEY | --all]"
+
+        def call(server_key: nil, **opts)
+          exit CLICommand.server_migrate(server_key, opts, out: out, err: err)
+        end
+      end
+
+      register "server", Server do |prefix|
+        prefix.register "login", ServerLogin
+        prefix.register "logout", ServerLogout
+        prefix.register "status", ServerStatus
+        prefix.register "verify", ServerVerify
+        prefix.register "migrate", ServerMigrate
+      end
+
       class Schedule < Dry::CLI::Command
         desc "Manage scheduled agent runs"
 
@@ -478,6 +558,13 @@ module HQ
       Commands::GithubStatus,
       Commands::GithubLogout
     ].freeze
+    SERVER_COMMANDS = [
+      Commands::ServerLogin,
+      Commands::ServerLogout,
+      Commands::ServerStatus,
+      Commands::ServerVerify,
+      Commands::ServerMigrate
+    ].freeze
     DEBUG_COMMANDS = [
       Commands::DebugClaude
     ].freeze
@@ -498,6 +585,7 @@ module HQ
       },
       *SCHEDULE_COMMANDS.map { |command| "  #{COMMAND_NAME} #{format(command.usage_template, schedule_key: "<schedule-key>")}" },
       *GITHUB_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
+      *SERVER_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
       *DEBUG_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
       "",
       "Run without a command to open the interactive Tycho TUI."
@@ -601,6 +689,179 @@ module HQ
       0
     rescue GitHubAuth::Error => e
       failure(e.message, err:)
+    end
+
+    def server_login(server_key, opts = {}, input: $stdin, out: $stdout, err: $stderr)
+      registry, config, resolver = remote_credential_context(server_key, err: err)
+      return 1 unless config
+      unless config.token_env.to_s.empty?
+        return failure(
+          "Remote server #{config.key} uses external credential #{config.token_env}; " \
+          "update that environment variable or remove token_env before storing a Tycho credential",
+          err: err
+        )
+      end
+
+      err.print "Token for #{config.key}: "
+      token = if input.respond_to?(:tty?) && input.tty? && input.respond_to?(:noecho)
+                input.noecho(&:gets)
+              else
+                input.gets
+              end
+      err.puts
+      token = token.to_s.chomp
+      return failure("Remote token is required", err: err) if token.empty?
+
+      unless opts[:no_verify]
+        credential = resolver.transient(config, token)
+        RemoteCLIClient.new(config, credential_resolver: resolver, credential: credential).request("GET", "/agents")
+      end
+      resolver.save(config, token: token, verified: !opts[:no_verify])
+      state = opts[:no_verify] ? "unverified" : "verified"
+      out.puts "Stored #{state} credential for #{config.key} in #{resolver.store.path}"
+      0
+    rescue RemoteCLIClient::Error, RemoteCredentialResolver::Error, ConfigError => e
+      failure(e.message, err: err)
+    ensure
+      token = nil
+    end
+
+    def server_logout(server_key, out: $stdout, err: $stderr)
+      _registry, config, resolver = remote_credential_context(server_key, err: err)
+      return 1 unless config
+
+      removed = resolver.store.delete_token(config.key)
+      out.puts(removed ? "Removed stored credential for #{config.key}." : "No stored credential for #{config.key}.")
+      unless config.token_env.to_s.empty?
+        state = ENV[config.token_env].to_s.empty? ? "not set" : "still active"
+        out.puts "External source #{config.token_env} is #{state}; Tycho did not change it."
+      end
+      0
+    rescue ConfigError => e
+      failure(e.message, err: err)
+    end
+
+    def server_status(server_key = nil, opts = {}, out: $stdout, err: $stderr)
+      require_relative "registry"
+      require_relative "domain/remote_credential_store"
+
+      registry = Registry.new
+      configs = Array(registry.remote_servers)
+      unless server_key.to_s.empty?
+        configs = configs.select { |config| config.key == server_key.to_s }
+        return failure("Unknown remote server: #{server_key}", err: err) if configs.empty?
+      end
+      store = RemoteCredentialStore.new(registry: registry)
+      resolver = RemoteCredentialResolver.new(store: store, warning: ->(_message) {})
+      statuses = configs.map { |config| remote_credential_status(config, resolver) }
+
+      if opts[:json]
+        value = server_key.to_s.empty? ? statuses : statuses.first
+        out.puts JSON.pretty_generate(value)
+      elsif statuses.empty?
+        out.puts "No remote servers configured."
+      else
+        rows = statuses.map do |status|
+          [status[:key], status[:source], status[:state], status[:origin] || "—", status[:token_env] || "—"]
+        end
+        out.puts agent_table(%w[Key Source State Origin Token-env], rows)
+      end
+      0
+    rescue ConfigError => e
+      failure(e.message, err: err)
+    end
+
+    def server_verify(server_key, out: $stdout, err: $stderr)
+      _registry, config, resolver = remote_credential_context(server_key, err: err)
+      return 1 unless config
+
+      credential = resolver.resolve(config, allow_rejected: true, allow_origin_change: true)
+      return failure("Remote server #{config.key} has no credential to verify", err: err) if credential.token.to_s.empty?
+      if credential.source == "inline"
+        return failure("Run `tycho server migrate #{config.key}` before verifying its inline credential", err: err)
+      end
+
+      RemoteCLIClient.new(config, credential_resolver: resolver, credential: credential).request("GET", "/agents")
+      out.puts "Verified #{credential.source} credential for #{config.key} at #{resolver.canonical_origin(config.url)}"
+      0
+    rescue RemoteCLIClient::Error, RemoteCredentialResolver::Error, ConfigError => e
+      failure(e.message, err: err)
+    end
+
+    def server_migrate(server_key = nil, opts = {}, out: $stdout, err: $stderr)
+      require_relative "registry"
+      require_relative "domain/remote_credential_store"
+
+      return failure("Choose SERVER_KEY or --all, not both", err: err) if opts[:all] && !server_key.to_s.empty?
+      return failure("Missing SERVER_KEY or --all", err: err) unless opts[:all] || !server_key.to_s.empty?
+
+      registry = Registry.new
+      configs = if opts[:all]
+                  Array(registry.remote_servers).select { |config| !config.token.to_s.empty? }
+                else
+                  config = Array(registry.remote_servers).find { |candidate| candidate.key == server_key.to_s }
+                  return failure("Unknown remote server: #{server_key}", err: err) unless config
+                  return failure("Remote server #{config.key} has no inline token to migrate", err: err) if config.token.to_s.empty?
+                  [config]
+                end
+      resolver = RemoteCredentialResolver.new(store: RemoteCredentialStore.new(registry: registry))
+      configs.each do |config|
+        resolver.save(config, token: config.token, verified: false)
+        registry.remove_remote_server_inline_token!(config.key)
+        out.puts "Migrated #{config.key} to #{resolver.store.path} (unverified)."
+      end
+      out.puts "No inline remote tokens found." if configs.empty?
+      0
+    rescue ConfigError => e
+      failure(e.message, err: err)
+    end
+
+    def remote_credential_context(server_key, err:)
+      require_relative "registry"
+      require_relative "domain/remote_cli_client"
+      require_relative "domain/remote_credential_store"
+
+      registry = Registry.new
+      config = Array(registry.remote_servers).find { |candidate| candidate.key == server_key.to_s }
+      unless config
+        failure("Unknown remote server: #{server_key}", err: err)
+        return [registry, nil, nil]
+      end
+      store = RemoteCredentialStore.new(registry: registry)
+      resolver = RemoteCredentialResolver.new(store: store, warning: ->(message) { err.puts message })
+      [registry, config, resolver]
+    end
+
+    def remote_credential_status(config, resolver)
+      origin = resolver.canonical_origin(config.url)
+      stored = resolver.store.metadata(config.key)
+      token_env = config.token_env.to_s.strip
+      source, metadata, state = if !token_env.empty?
+                                  external = stored.fetch("external", {})
+                                  external_state = ENV[token_env].to_s.empty? ? "missing" : external.fetch("state", "unverified")
+                                  ["external", external, external_state]
+                                elsif !resolver.store.stored(config.key)["token"].to_s.empty?
+                                  item = stored.fetch("stored", {})
+                                  ["stored", item, item.fetch("state", "unverified")]
+                                elsif !config.token.to_s.empty?
+                                  ["inline", {}, "legacy"]
+                                else
+                                  ["none", {}, "missing"]
+                                end
+      bound_origin = metadata["origin"]
+      state = "origin_mismatch" if bound_origin && bound_origin != origin
+      {
+        key: config.key,
+        name: config.name,
+        url: config.url,
+        origin: bound_origin || origin,
+        source: source,
+        state: state,
+        token_env: token_env.empty? ? nil : token_env,
+        verified_at: metadata["verified_at"],
+        rejected_at: metadata["rejected_at"],
+        updated_at: metadata["updated_at"]
+      }
     end
 
     def debug_claude(opts = {}, out: $stdout, err: $stderr)

--- a/lib/hq/domain/remote_cli_client.rb
+++ b/lib/hq/domain/remote_cli_client.rb
@@ -6,6 +6,8 @@ require "openssl"
 require "socket"
 require "uri"
 
+require_relative "remote_credential_store"
+
 module HQ
   class RemoteCLIClient
     DEFAULT_OPEN_TIMEOUT = 5
@@ -26,15 +28,23 @@ module HQ
       config = Array(registry.remote_servers).find { |candidate| candidate.key == key }
       raise Error.new("Unknown remote server: #{key}", kind: :unknown_server) unless config
 
-      new(config, **options)
+      store = options.delete(:credential_store) || RemoteCredentialStore.new(registry: registry)
+      resolver = options.delete(:credential_resolver) || RemoteCredentialResolver.new(store: store)
+      new(config, credential_resolver: resolver, **options)
+    rescue RemoteCredentialResolver::Error => e
+      raise Error.new(e.message, kind: e.kind)
     end
 
-    attr_reader :server_key
+    attr_reader :server_key, :credential
 
-    def initialize(config, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT)
+    def initialize(config, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT,
+                   credential_resolver: nil, credential: nil)
       @server_key = config.key
+      @config = config
       @base_uri = URI.parse(config.url)
-      @token = config.resolved_token.to_s
+      @credential_resolver = credential_resolver
+      @credential = credential || resolve_credential(config)
+      @token = @credential.token.to_s
       @open_timeout = open_timeout
       @read_timeout = read_timeout
     end
@@ -89,10 +99,14 @@ module HQ
     def parse_response(response)
       status = response.code.to_i
       payload = parse_json(response.body)
-      return payload if status.between?(200, 299)
+      if status.between?(200, 299)
+        @credential_resolver&.verified!(@credential, @config)
+        return payload
+      end
 
       message = error_message(payload, response)
       if status == 401 || status == 403
+        @credential_resolver&.rejected!(@credential, @config)
         raise Error.new("Remote server #{server_key} authentication failed", kind: :authentication, status: status)
       end
       if status == 404 && message == "Not found"
@@ -123,6 +137,19 @@ module HQ
       return value.to_s if @token.empty?
 
       value.to_s.gsub(@token, "[REDACTED]")
+    end
+
+    def resolve_credential(config)
+      return @credential_resolver.resolve(config) if @credential_resolver
+
+      RemoteCredentialResolver::Credential.new(
+        server_key: config.key,
+        token: config.resolved_token.to_s,
+        source: "legacy",
+        state: "legacy"
+      )
+    rescue RemoteCredentialResolver::Error => e
+      raise Error.new(e.message, kind: e.kind)
     end
   end
 end

--- a/lib/hq/domain/remote_cli_client.rb
+++ b/lib/hq/domain/remote_cli_client.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "openssl"
+require "socket"
+require "uri"
+
+module HQ
+  class RemoteCLIClient
+    DEFAULT_OPEN_TIMEOUT = 5
+    DEFAULT_READ_TIMEOUT = 30
+
+    class Error < StandardError
+      attr_reader :kind, :status
+
+      def initialize(message, kind:, status: nil)
+        super(message)
+        @kind = kind
+        @status = status
+      end
+    end
+
+    def self.from_registry(server_key, registry:, **options)
+      key = server_key.to_s.strip
+      config = Array(registry.remote_servers).find { |candidate| candidate.key == key }
+      raise Error.new("Unknown remote server: #{key}", kind: :unknown_server) unless config
+
+      new(config, **options)
+    end
+
+    attr_reader :server_key
+
+    def initialize(config, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT)
+      @server_key = config.key
+      @base_uri = URI.parse(config.url)
+      @token = config.resolved_token.to_s
+      @open_timeout = open_timeout
+      @read_timeout = read_timeout
+    end
+
+    def request(method, path, body: nil)
+      uri = target_uri(path)
+      response = perform_request(method, uri, body)
+      parse_response(response)
+    rescue Net::OpenTimeout, Net::ReadTimeout
+      raise Error.new("Remote server #{server_key} timed out", kind: :timeout)
+    rescue SystemCallError, IOError, SocketError, OpenSSL::SSL::SSLError => e
+      raise Error.new("Remote server #{server_key} is unreachable: #{e.message}", kind: :unreachable)
+    end
+
+    private
+
+    def target_uri(path)
+      suffix = path.to_s
+      suffix = "/#{suffix}" unless suffix.start_with?("/")
+      uri = @base_uri.dup
+      uri.path = "#{@base_uri.path.to_s.sub(%r{/+\z}, "")}#{suffix}"
+      uri.query = nil
+      uri.fragment = nil
+      uri
+    end
+
+    def perform_request(method, uri, body)
+      request_class = {
+        "GET" => Net::HTTP::Get,
+        "POST" => Net::HTTP::Post,
+        "DELETE" => Net::HTTP::Delete
+      }.fetch(method.to_s.upcase) do
+        raise Error.new("Unsupported remote operation: #{method}", kind: :unsupported)
+      end
+      request = request_class.new(uri)
+      request["Accept"] = "application/json"
+      request["Authorization"] = "Bearer #{@token}" unless @token.empty?
+      if request.request_body_permitted?
+        request["Content-Type"] = "application/json"
+        request.body = JSON.generate(body || {})
+      end
+
+      Net::HTTP.start(
+        uri.hostname,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+        open_timeout: @open_timeout,
+        read_timeout: @read_timeout
+      ) { |http| http.request(request) }
+    end
+
+    def parse_response(response)
+      status = response.code.to_i
+      payload = parse_json(response.body)
+      return payload if status.between?(200, 299)
+
+      message = error_message(payload, response)
+      if status == 401 || status == 403
+        raise Error.new("Remote server #{server_key} authentication failed", kind: :authentication, status: status)
+      end
+      if status == 404 && message == "Not found"
+        raise Error.new("Remote server #{server_key} does not support this operation", kind: :unsupported, status: status)
+      end
+
+      raise Error.new(
+        "Remote server #{server_key} API error (HTTP #{status}): #{redact_token(message)}",
+        kind: :api,
+        status: status
+      )
+    rescue JSON::ParserError
+      raise Error.new("Remote server #{server_key} returned invalid JSON", kind: :api, status: status)
+    end
+
+    def parse_json(body)
+      value = JSON.parse(body.to_s)
+      value.is_a?(Hash) ? value : { "data" => value }
+    end
+
+    def error_message(payload, response)
+      message = payload["error"].to_s.strip
+      message = response.message.to_s if message.empty?
+      message
+    end
+
+    def redact_token(value)
+      return value.to_s if @token.empty?
+
+      value.to_s.gsub(@token, "[REDACTED]")
+    end
+  end
+end

--- a/lib/hq/domain/remote_credential_store.rb
+++ b/lib/hq/domain/remote_credential_store.rb
@@ -1,0 +1,339 @@
+# frozen_string_literal: true
+
+require "time"
+require "uri"
+
+require_relative "constants"
+require_relative "file_store"
+
+module HQ
+  class RemoteCredentialStore
+    SCHEMA_VERSION = 1
+    FILENAME = "remote_credentials.json"
+    MUTEX = Mutex.new
+
+    attr_reader :path
+
+    def self.default_path(registry: nil)
+      configured = HQ.env("REMOTE_CREDENTIALS_PATH").to_s.strip
+      return File.expand_path(configured) unless configured.empty?
+
+      config_path = registry&.path || HQ.default_config_path
+      File.join(File.dirname(File.expand_path(config_path)), FILENAME)
+    end
+
+    def initialize(path: nil, registry: nil, clock: -> { Time.now })
+      @path = File.expand_path(path || self.class.default_path(registry:))
+      @clock = clock
+    end
+
+    def stored(key)
+      server(key).fetch("stored", {}).dup
+    end
+
+    def external(key, token_env)
+      metadata = server(key).fetch("external", {})
+      return {} unless metadata["token_env"].to_s == token_env.to_s
+
+      metadata.dup
+    end
+
+    def save_token(key, token:, origin:, state: "unverified")
+      update do |data|
+        entry = server_entry(data, key)
+        previous = entry.fetch("stored", {})
+        now = timestamp
+        entry["stored"] = compact_hash(
+          "token" => token.to_s,
+          "origin" => origin.to_s,
+          "state" => state,
+          "created_at" => previous["created_at"] || now,
+          "updated_at" => now,
+          "verified_at" => state == "verified" ? now : nil,
+          "rejected_at" => nil
+        )
+      end
+    end
+
+    def delete_token(key)
+      removed = false
+      update do |data|
+        entry = server_entry(data, key, create: false)
+        next unless entry&.key?("stored")
+
+        entry.delete("stored")
+        removed = true
+        prune_server(data, key)
+      end
+      removed
+    end
+
+    def mark_verified(key, source:, origin:, token_env: nil)
+      current = source.to_s == "external" ? external(key, token_env) : stored(key)
+      if current["state"] == "verified" && current["origin"] == origin.to_s
+        return false
+      end
+
+      update_metadata(key, source:, token_env:) do |metadata|
+        now = timestamp
+        metadata["created_at"] ||= now
+        metadata["origin"] = origin.to_s
+        metadata["state"] = "verified"
+        metadata["updated_at"] = now
+        metadata["verified_at"] = now
+        metadata.delete("rejected_at")
+      end
+      true
+    end
+
+    def mark_rejected(key, source:, origin:, token_env: nil)
+      current = source.to_s == "external" ? external(key, token_env) : stored(key)
+      return false if current["state"] == "rejected" && current["origin"] == origin.to_s
+
+      update_metadata(key, source:, token_env:) do |metadata|
+        now = timestamp
+        metadata["created_at"] ||= now
+        metadata["origin"] ||= origin.to_s
+        metadata["state"] = "rejected"
+        metadata["updated_at"] = now
+        metadata["rejected_at"] = now
+      end
+      true
+    end
+
+    def remove_server(key)
+      removed = false
+      update do |data|
+        removed = !data.fetch("servers", {}).delete(key.to_s).nil?
+      end
+      removed
+    end
+
+    def metadata(key)
+      entry = server(key)
+      {
+        "stored" => redact(entry.fetch("stored", {})),
+        "external" => redact(entry.fetch("external", {}))
+      }
+    end
+
+    private
+
+    def server(key)
+      read.fetch("servers", {}).fetch(key.to_s, {})
+    end
+
+    def read
+      return empty_data unless File.exist?(@path)
+
+      File.chmod(0o600, @path)
+      data = FileStore.read_json(@path, fallback: empty_data)
+      data.is_a?(Hash) && data["servers"].is_a?(Hash) ? data : empty_data
+    end
+
+    def update
+      MUTEX.synchronize do
+        data = read
+        yield data
+        data["schema_version"] = SCHEMA_VERSION
+        data["servers"] ||= {}
+        FileStore.write_json(@path, data, backup: false)
+        FileUtils.rm_f(FileStore.backup_path(@path))
+        File.chmod(0o600, @path)
+      end
+    end
+
+    def update_metadata(key, source:, token_env:)
+      update do |data|
+        entry = server_entry(data, key)
+        field = source.to_s == "external" ? "external" : source.to_s
+        metadata = entry[field] ||= {}
+        metadata["token_env"] = token_env.to_s if field == "external"
+        yield metadata
+      end
+    end
+
+    def server_entry(data, key, create: true)
+      servers = data["servers"] ||= {}
+      return servers[key.to_s] unless create
+
+      servers[key.to_s] ||= {}
+    end
+
+    def prune_server(data, key)
+      entry = data.fetch("servers", {})[key.to_s]
+      data["servers"].delete(key.to_s) if entry&.empty?
+    end
+
+    def redact(metadata)
+      metadata.reject { |field, _value| field == "token" }
+    end
+
+    def compact_hash(hash)
+      hash.reject { |_key, value| value.nil? }
+    end
+
+    def empty_data
+      { "schema_version" => SCHEMA_VERSION, "servers" => {} }
+    end
+
+    def timestamp
+      @clock.call.iso8601
+    end
+  end
+
+  class RemoteCredentialResolver
+    Credential = Struct.new(:server_key, :token, :source, :state, :origin, :token_env, keyword_init: true)
+
+    class Error < StandardError
+      attr_reader :kind
+
+      def initialize(message, kind:)
+        super(message)
+        @kind = kind
+      end
+    end
+
+    attr_reader :store
+
+    def initialize(store:, env: ENV, warning: nil)
+      @store = store
+      @env = env
+      @warning = warning || ->(message) { warn(message) }
+    end
+
+    def resolve(config, allow_rejected: false, allow_origin_change: false)
+      token_env = config.respond_to?(:token_env) ? config.token_env.to_s.strip : ""
+      return external_credential(config, token_env, allow_rejected:, allow_origin_change:) unless token_env.empty?
+
+      stored = store.stored(config.key)
+      unless stored["token"].to_s.empty?
+        return credential_from(config, stored, source: "stored", allow_rejected:, allow_origin_change:)
+      end
+
+      inline = config.respond_to?(:token) ? config.token.to_s : ""
+      unless inline.empty?
+        @warning.call("Warning: remote server #{config.key} uses inline token from hq.yml; " \
+                      "run `tycho server migrate #{config.key}`. Inline token support will be removed in v0.11.0.")
+        return Credential.new(
+          server_key: config.key,
+          token: inline,
+          source: "inline",
+          state: "legacy",
+          origin: canonical_origin(config.url)
+        )
+      end
+
+      Credential.new(server_key: config.key, token: "", source: "none", state: "missing",
+                     origin: canonical_origin(config.url))
+    end
+
+    def save(config, token:, verified: false)
+      store.save_token(
+        config.key,
+        token: token,
+        origin: canonical_origin(config.url),
+        state: verified ? "verified" : "unverified"
+      )
+    end
+
+    def configured?(config)
+      token_env = config.respond_to?(:token_env) ? config.token_env.to_s.strip : ""
+      return !@env[token_env].to_s.empty? unless token_env.empty?
+
+      inline = config.respond_to?(:token) ? config.token.to_s : ""
+      !store.stored(config.key)["token"].to_s.empty? || !inline.empty?
+    end
+
+    def verified!(credential, config)
+      return if credential.token.to_s.empty? || %w[none inline transient].include?(credential.source)
+
+      store.mark_verified(
+        config.key,
+        source: credential.source,
+        origin: canonical_origin(config.url),
+        token_env: credential.token_env
+      )
+    end
+
+    def rejected!(credential, config)
+      return if credential.token.to_s.empty? || %w[none inline transient].include?(credential.source)
+
+      store.mark_rejected(
+        config.key,
+        source: credential.source,
+        origin: canonical_origin(config.url),
+        token_env: credential.token_env
+      )
+    end
+
+    def transient(config, token)
+      Credential.new(
+        server_key: config.key,
+        token: token.to_s,
+        source: "transient",
+        state: "unverified",
+        origin: canonical_origin(config.url)
+      )
+    end
+
+    def canonical_origin(url)
+      uri = URI.parse(url.to_s)
+      host = uri.hostname.to_s.downcase
+      host = "[#{host}]" if host.include?(":")
+      "#{uri.scheme.to_s.downcase}://#{host}:#{uri.port}"
+    rescue URI::InvalidURIError
+      raise Error.new("Invalid remote server origin", kind: :origin)
+    end
+
+    private
+
+    def external_credential(config, token_env, allow_rejected:, allow_origin_change:)
+      token = @env[token_env].to_s
+      if token.empty?
+        raise Error.new(
+          "Remote server #{config.key} requires environment variable #{token_env}",
+          kind: :missing_external
+        )
+      end
+
+      metadata = store.external(config.key, token_env)
+      credential_from(
+        config,
+        metadata.merge("token" => token),
+        source: "external",
+        token_env: token_env,
+        allow_rejected:,
+        allow_origin_change:
+      )
+    end
+
+    def credential_from(config, metadata, source:, token_env: nil, allow_rejected:, allow_origin_change:)
+      expected = canonical_origin(config.url)
+      bound = metadata["origin"].to_s
+      if !allow_origin_change && !bound.empty? && bound != expected
+        raise Error.new(
+          "Remote server #{config.key} origin changed from #{bound} to #{expected}; run `tycho server verify #{config.key}`",
+          kind: :origin_mismatch
+        )
+      end
+      state = metadata["state"].to_s
+      state = "unverified" if state.empty?
+      if state == "rejected" && !allow_rejected
+        raise Error.new(
+          "Remote server #{config.key} credential was rejected; run `tycho server login #{config.key}` or `tycho server verify #{config.key}`",
+          kind: :rejected
+        )
+      end
+
+      Credential.new(
+        server_key: config.key,
+        token: metadata["token"].to_s,
+        source: source,
+        state: state,
+        origin: bound.empty? ? nil : bound,
+        token_env: token_env
+      )
+    end
+  end
+end

--- a/lib/hq/registry.rb
+++ b/lib/hq/registry.rb
@@ -231,6 +231,22 @@ module HQ
       value
     end
 
+    def remove_remote_server_inline_token!(key)
+      value = key.to_s.strip
+      data = load_yaml(@path)
+      servers = Array(data["remote_servers"])
+      entry = servers.find { |server| server["key"].to_s == value }
+      raise ConfigError, "Unknown remote server: #{value}" unless entry
+
+      removed = entry.delete("token")
+      return false if removed.nil?
+
+      data["remote_servers"] = servers
+      write_yaml(@path, data)
+      load!
+      true
+    end
+
     def update_group_hidden!(group_name, hidden)
       name = group_name.to_s.strip
       raise ConfigError, "Missing group name" if name.empty?

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -30,6 +30,7 @@ require_relative "domain/push_subscription_store"
 require_relative "domain/pull_request_diff"
 require_relative "domain/pull_request_review"
 require_relative "domain/response_style_policy"
+require_relative "domain/remote_credential_store"
 require_relative "domain/schedule_daemon_supervisor"
 require_relative "domain/scheduler"
 require_relative "domain/skill_discovery"
@@ -264,6 +265,11 @@ module HQ
           end
 
           return ok(@resource_catalog.snapshot)
+        end
+        if method == "POST" && parts.length == 3 && parts[2] == "credentials"
+          result = service.save_remote_server_credential(parts[1], body)
+          @resource_catalog.reconcile(registry: service.registry, server_url: service.server_url)
+          return ok(result)
         end
         if method == "POST" && parts == ["servers"]
           result = service.add_remote_server(body)
@@ -684,6 +690,7 @@ module HQ
     end
 
     def reconcile(registry:, server_url:)
+      credential_resolver = RemoteCredentialResolver.new(store: RemoteCredentialStore.new(registry: registry))
       configs = [
         LocalConfig.new(key: "local", name: "Local", url: server_url.to_s)
       ] + Array(registry.remote_servers)
@@ -705,7 +712,7 @@ module HQ
             icon: index.zero? ? "home" : config.icon,
             url: config.url,
             local: index.zero?,
-            auth_configured: !config.resolved_token.to_s.empty?,
+            auth_configured: index.zero? ? false : credential_resolver.configured?(config),
             version: index.zero? ? HQ::VERSION : nil
           }
           persisted = @persisted_entries[config.key]
@@ -799,7 +806,8 @@ module HQ
         key: server_key,
         config: config,
         local_service: server_key == "local" ? local_service : nil,
-        token_override: token_override.to_s
+        token_override: token_override.to_s,
+        credential_resolver: RemoteCredentialResolver.new(store: RemoteCredentialStore.new(registry: registry))
       }
       refresh_payload(server_key, accepted: true)
     end
@@ -845,7 +853,8 @@ module HQ
         job.fetch(:config),
         open_timeout: OPEN_TIMEOUT,
         read_timeout: READ_TIMEOUT,
-        token_override: job[:token_override]
+        token_override: job[:token_override],
+        credential_resolver: job[:credential_resolver]
       )
       response = client.request("GET", "/resources")
       return legacy_snapshot(client) if response[:status].to_i == 404
@@ -1141,12 +1150,15 @@ module HQ
   class RemoteClient
     DEFAULT_TIMEOUT = 5
 
-    def initialize(config, timeout: DEFAULT_TIMEOUT, open_timeout: nil, read_timeout: nil, token_override: nil)
+    def initialize(config, timeout: DEFAULT_TIMEOUT, open_timeout: nil, read_timeout: nil, token_override: nil,
+                   credential_resolver: nil)
       @config = config
       @base_uri = URI.parse(config.url)
       @open_timeout = open_timeout || timeout
       @read_timeout = read_timeout || timeout
       @token_override = token_override.to_s
+      @credential_resolver = credential_resolver
+      @credential = resolve_credential
     end
 
     def request(method, path, body: nil, query: nil)
@@ -1180,7 +1192,7 @@ module HQ
     def perform_request(method, uri, body)
       request = request_for(method, uri)
       request["Accept"] = "application/json"
-      token = @token_override.empty? ? @config.resolved_token : @token_override
+      token = @credential.token.to_s
       request["Authorization"] = "Bearer #{token}" unless token.to_s.empty?
       if request.request_body_permitted?
         request["Content-Type"] = "application/json"
@@ -1213,7 +1225,8 @@ module HQ
 
     def response_payload(response)
       content_type = response["content-type"].to_s
-      if response.code.to_i == 401
+      if [401, 403].include?(response.code.to_i)
+        @credential_resolver&.rejected!(@credential, @config)
         return {
           status: 502,
           body: { error: "Remote server #{@config.key} rejected broker credentials" }
@@ -1222,6 +1235,8 @@ module HQ
 
       if content_type.start_with?("application/json")
         parsed = JSON.parse(response.body.to_s)
+        @credential_resolver&.verified!(@credential, @config) if response.code.to_i.between?(200, 299)
+        parsed = redact_value(parsed) if response.code.to_i >= 400
         return {
           status: response.code.to_i,
           body: parsed.is_a?(Hash) ? parsed : { data: parsed },
@@ -1232,7 +1247,7 @@ module HQ
       if response.code.to_i >= 400
         return {
           status: response.code.to_i,
-          body: { error: response.body.to_s.empty? ? response.message : response.body.to_s }
+          body: { error: redact_value(response.body.to_s.empty? ? response.message : response.body.to_s) }
         }
       end
 
@@ -1247,6 +1262,38 @@ module HQ
         status: response.code.to_i >= 400 ? response.code.to_i : 502,
         body: { error: "Remote server #{@config.key} returned invalid JSON" }
       }
+    end
+
+    def redact_value(value)
+      token = @credential.token.to_s
+      return value if token.empty?
+
+      case value
+      when Hash
+        value.transform_values { |item| redact_value(item) }
+      when Array
+        value.map { |item| redact_value(item) }
+      when String
+        value.gsub(token, "[REDACTED]")
+      else
+        value
+      end
+    end
+
+    def resolve_credential
+      if !@token_override.empty? && @credential_resolver
+        return @credential_resolver.transient(@config, @token_override)
+      end
+      return @credential_resolver.resolve(@config) if @credential_resolver
+
+      RemoteCredentialResolver::Credential.new(
+        server_key: @config.key,
+        token: @token_override.empty? ? @config.resolved_token : @token_override,
+        source: "legacy",
+        state: "legacy"
+      )
+    rescue RemoteCredentialResolver::Error => e
+      raise RemoteServer::Error.new(e.message, status: 502)
     end
 
     def proxy_response_headers(response)
@@ -1273,6 +1320,7 @@ module HQ
       @registry = registry
       @server_url = server_url.to_s
       @timeout = timeout
+      @credential_resolver = RemoteCredentialResolver.new(store: RemoteCredentialStore.new(registry: registry))
     end
 
     def servers
@@ -1290,7 +1338,8 @@ module HQ
       RemoteClient.new(
         config,
         timeout: @timeout,
-        token_override: remote_server_token(request)
+        token_override: remote_server_token(request),
+        credential_resolver: @credential_resolver
       ).request(method, path, body:, query: request&.query)
     end
 
@@ -1352,7 +1401,7 @@ module HQ
         icon: local ? "home" : (config.respond_to?(:icon) ? config.icon : "server"),
         url: config.url,
         local: local,
-        auth_configured: !config.resolved_token.to_s.empty?,
+        auth_configured: local ? false : @credential_resolver.configured?(config),
         version: local ? HQ::VERSION : nil
       }
     end
@@ -1458,8 +1507,37 @@ module HQ
       raise Error.new(e.message, status: e.message.start_with?("Unknown") ? 404 : 400)
     end
 
+    def save_remote_server_credential(key, body)
+      config = Array(@registry.remote_servers).find { |server| server.key == key.to_s }
+      raise Error.new("Unknown remote server: #{key}", status: 404) unless config
+      unless config.token_env.to_s.empty?
+        raise Error.new(
+          "Remote server #{key} uses external credential #{config.token_env}; update that source on this Tycho host",
+          status: 409
+        )
+      end
+
+      token = body["token"].to_s
+      raise Error.new("Remote token is required", status: 400) if token.empty?
+
+      store = RemoteCredentialStore.new(registry: @registry)
+      resolver = RemoteCredentialResolver.new(store: store)
+      response = RemoteClient.new(config, credential_resolver: resolver, token_override: token).request("GET", "/agents")
+      unless response[:status].to_i.between?(200, 299)
+        detail = response.dig(:body, "error") || response.dig(:body, :error) || response[:status]
+        raise Error.new("Remote server #{key} rejected the credential: #{detail}", status: 502)
+      end
+
+      resolver.save(config, token: token, verified: true)
+      {
+        credential: remote_credential_metadata(config, resolver),
+        servers: RemoteBroker.new(registry: @registry, server_url: @server_url).servers
+      }
+    end
+
     def remove_remote_server(key)
       removed = @registry.remove_remote_server!(key)
+      RemoteCredentialStore.new(registry: @registry).remove_server(key)
       broker = RemoteBroker.new(registry: @registry, server_url: @server_url)
       {
         removed: removed,
@@ -1467,6 +1545,19 @@ module HQ
       }
     rescue ConfigError => e
       raise Error.new(e.message, status: e.message.start_with?("Unknown") ? 404 : 400)
+    end
+
+    def remote_credential_metadata(config, resolver)
+      credential = resolver.resolve(config)
+      metadata = resolver.store.metadata(config.key).fetch(credential.source, {})
+      {
+        server_key: config.key,
+        source: credential.source,
+        state: credential.state,
+        origin: metadata["origin"],
+        verified_at: metadata["verified_at"],
+        rejected_at: metadata["rejected_at"]
+      }
     end
 
     def agents

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -770,7 +770,13 @@ async function connectLoopbackServer(url, name = "", token = "") {
   const server = data.server;
   state.servers = data.servers || state.servers;
   state.serverFormOpen = false;
-  storeRemoteServerToken(server?.key, token);
+  if (String(token || "").trim()) {
+    const credentialData = await brokerPost(`/servers/${encodeURIComponent(server?.key || "")}/credentials`, {
+      token: String(token),
+    });
+    state.servers = credentialData.servers || state.servers;
+    removeRemoteServerToken(server?.key);
+  }
   await requestServerResourceRefresh(server?.key || "local", { force: true });
   schedule();
   render();
@@ -1287,15 +1293,16 @@ async function saveRemoteServerToken(key, value) {
   if (!serverKey || serverKey === "local") throw new Error("Choose a remote server");
   if (!tokenValue) throw new Error("Enter a remote token");
 
-  await brokerGetWithHeaders(`/servers/${encodeURIComponent(serverKey)}/agents`, {
-    "X-Tycho-Remote-Server-Token": tokenValue,
+  const data = await brokerPost(`/servers/${encodeURIComponent(serverKey)}/credentials`, {
+    token: tokenValue,
   });
-  storeRemoteServerToken(serverKey, tokenValue);
+  state.servers = data.servers || state.servers;
+  removeRemoteServerToken(serverKey);
   state.serverTokenFormKey = "";
   await requestServerResourceRefresh(serverKey, { force: true });
   schedule();
   render();
-  showGrowl("Remote token saved for this browser", "done");
+  showGrowl("Remote token moved to this Tycho host", "done");
 }
 
 function apiHeaders() {
@@ -4370,10 +4377,10 @@ function renderServerTokenForm(server) {
       <label class="ui-field" for="${escapeAttr(fieldId)}">
         <span class="ui-field__label">Remote token</span>
         <input class="ui-input" id="${escapeAttr(fieldId)}" type="password" name="token" autocomplete="new-password" placeholder="Token for ${escapeAttr(server.name || server.key)}" aria-describedby="${escapeAttr(helpId)}" required>
-        <span class="ui-field__description" id="${escapeAttr(helpId)}">Stored only in this browser and sent to the selected Remote server.</span>
+        <span class="ui-field__description" id="${escapeAttr(helpId)}">Verified, stored on this Tycho host, then removed from this browser.</span>
       </label>
       <div class="server-connection-actions ui-form-actions">
-        <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Save token</span></button>
+        <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Move token</span></button>
       </div>
     </form>
   `;
@@ -4400,7 +4407,7 @@ function renderAddServerForm() {
         <label class="ui-field" for="server-token-input">
           <span class="ui-field__label">Remote token</span>
           <input class="ui-input" id="server-token-input" type="password" name="token" autocomplete="new-password" placeholder="Optional" aria-describedby="server-token-input-help">
-          <span class="ui-field__description" id="server-token-input-help">Optional. Stored only in this browser.</span>
+          <span class="ui-field__description" id="server-token-input-help">Optional. Verified and stored on this Tycho host.</span>
         </label>
       </div>
       <div class="server-connection-actions ui-form-actions">

--- a/test/cli_command_test.rb
+++ b/test/cli_command_test.rb
@@ -90,11 +90,38 @@ module CLICommandTest
         assert(projects.fetch(:status).success?, "expected remote project list: #{projects.fetch(:stderr)}")
         assert(JSON.parse(projects.fetch(:stdout)).fetch(0).fetch("key") == "demo",
                "expected remote project list payload")
+        missing_external = run_tycho(local_env.except("TYCHO_TEST_PEER_TOKEN"),
+                                     "project", "list", "--server", "peer")
+        assert(!missing_external.fetch(:status).success? &&
+               missing_external.fetch(:stderr).include?("requires environment variable TYCHO_TEST_PEER_TOKEN"),
+               "expected configured external credentials to fail without falling back")
         inline_auth = run_tycho(local_env.except("TYCHO_TEST_PEER_TOKEN"),
                                 "project", "list", "--server", "peer-inline", "--json")
         assert(inline_auth.fetch(:status).success? &&
                !inline_auth.fetch(:stdout).include?(token) && !inline_auth.fetch(:stderr).include?(token),
                "expected inline token auth without credential output")
+        assert(inline_auth.fetch(:stderr).include?("removed in v0.11.0"),
+               "expected the inline fallback to warn about its removal")
+
+        migrated = run_tycho(local_env, "server", "migrate", "peer-inline")
+        credential_path = File.join(local_dir, "remote_credentials.json")
+        migrated_config = YAML.safe_load_file(local_config)
+        assert(migrated.fetch(:status).success? && File.stat(credential_path).mode & 0o777 == 0o600 &&
+               !migrated_config.fetch("remote_servers").find { |item| item["key"] == "peer-inline" }.key?("token"),
+               "expected migration to move the inline token into a private credential file")
+        unverified = run_tycho(local_env, "server", "status", "peer-inline", "--json")
+        assert(JSON.parse(unverified.fetch(:stdout)).fetch("state") == "unverified",
+               "expected migrated credentials to start unverified")
+        verified = run_tycho(local_env, "server", "verify", "peer-inline")
+        assert(verified.fetch(:status).success?, "expected explicit credential verification: #{verified.fetch(:stderr)}")
+        logged_out = run_tycho(local_env, "server", "logout", "peer-inline")
+        assert(logged_out.fetch(:status).success? && logged_out.fetch(:stdout).include?("Removed stored credential"),
+               "expected logout to remove only the stored credential")
+        logged_in = run_tycho(local_env, "server", "login", "peer-inline", "--no-verify", stdin_data: "#{token}\n")
+        assert(logged_in.fetch(:status).success? && !logged_in.fetch(:stdout).include?(token) &&
+               !logged_in.fetch(:stderr).include?(token),
+               "expected hidden-input login to save without printing the credential")
+        run_tycho(local_env, "server", "verify", "peer-inline")
 
         project = run_tycho(local_env, "project", "show", "demo", "--server", "peer", "--json")
         assert(project.fetch(:status).success?, "expected remote project show: #{project.fetch(:stderr)}")
@@ -145,6 +172,15 @@ module CLICommandTest
         assert(!bad_auth.fetch(:status).success? && bad_auth.fetch(:stderr).include?("authentication failed") &&
                !bad_auth.fetch(:stderr).include?("wrong"),
                "expected an auth error without credentials")
+        rejected = run_tycho(local_env, "server", "status", "peer", "--json")
+        assert(JSON.parse(rejected.fetch(:stdout)).fetch("state") == "rejected",
+               "expected rejected external credentials to remain visible as metadata")
+        recovered = run_tycho(local_env, "server", "verify", "peer")
+        assert(recovered.fetch(:status).success?, "expected explicit verification to recover rejected credentials")
+        external_logout = run_tycho(local_env, "server", "logout", "peer")
+        assert(external_logout.fetch(:stdout).include?("External source TYCHO_TEST_PEER_TOKEN is still active") &&
+               !external_logout.fetch(:stdout).include?(token),
+               "expected logout to report but never modify or print the external source")
       end
 
       unreachable = run_tycho(local_env, "agent", "list", "--server", "peer")
@@ -444,8 +480,9 @@ module CLICommandTest
     HQ::ManagedAgent.define_method(:running?, original_running) if original_running
   end
 
-  def run_tycho(env, *args)
-    stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, EXECUTABLE, *args, chdir: ROOT)
+  def run_tycho(env, *args, stdin_data: "")
+    stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, EXECUTABLE, *args,
+                                            chdir: ROOT, stdin_data: stdin_data)
     { stdout: stdout, stderr: stderr, status: status }
   end
 

--- a/test/cli_command_test.rb
+++ b/test/cli_command_test.rb
@@ -4,12 +4,14 @@ require "fileutils"
 require "json"
 require "open3"
 require "rbconfig"
+require "socket"
 require "stringio"
 require "tmpdir"
 require "yaml"
 
 require_relative "../lib/hq/cli_command"
 require_relative "../lib/hq/domain/managed_agent"
+require_relative "../lib/hq/domain/remote_cli_client"
 
 module CLICommandTest
   ROOT = File.expand_path("..", __dir__)
@@ -19,12 +21,198 @@ module CLICommandTest
 
   def run!
     assert_project_commands_manage_full_lifecycle
+    assert_remote_server_commands_manage_full_agent_lifecycle
+    assert_remote_client_reports_timeout_and_unsupported_operation
     assert_github_commands_cover_device_login_status_and_logout
     assert_debug_claude_is_listed_in_usage
     assert_debug_claude_run_agent_uses_claude_defaults
     puts "cli_command_test: ok"
   end
 
+  def assert_remote_server_commands_manage_full_agent_lifecycle
+    Dir.mktmpdir("hq-cli-remote-test") do |dir|
+      port = available_port
+      token = "remote-cli-test-token"
+      target_dir = File.join(dir, "target")
+      local_dir = File.join(dir, "local")
+      workspace = File.join(target_dir, "workspace")
+      FileUtils.mkdir_p([workspace, local_dir])
+      fake_codex = File.join(dir, "fake-codex")
+      File.write(fake_codex, <<~SH)
+        #!/bin/sh
+        sleep 20
+      SH
+      FileUtils.chmod(0o755, fake_codex)
+
+      target_config = File.join(target_dir, "hq.yml")
+      target_prompts = File.join(target_dir, "system_prompts.yml")
+      File.write(target_config, <<~YAML)
+        projects:
+          - key: demo
+            name: Remote Demo
+            path: #{workspace}
+            agent: codex
+      YAML
+      File.write(target_prompts, "{}\n")
+
+      local_config = File.join(local_dir, "hq.yml")
+      local_prompts = File.join(local_dir, "system_prompts.yml")
+      File.write(local_config, <<~YAML)
+        projects: []
+        remote_servers:
+          - key: peer
+            name: Test Peer
+            url: http://127.0.0.1:#{port}
+            token_env: TYCHO_TEST_PEER_TOKEN
+          - key: peer-inline
+            name: Inline Test Peer
+            url: http://127.0.0.1:#{port}
+            token: #{token}
+      YAML
+      File.write(local_prompts, "{}\n")
+
+      server_env = {
+        "TYCHO_CONFIG_PATH" => target_config,
+        "TYCHO_SYSTEM_PROMPTS_PATH" => target_prompts,
+        "TYCHO_LOGS_ROOT" => File.join(target_dir, "logs"),
+        "TYCHO_REMOTE_TOKEN" => token,
+        "TYCHO_CODEX_BIN" => fake_codex
+      }
+      local_env = {
+        "TYCHO_CONFIG_PATH" => local_config,
+        "TYCHO_SYSTEM_PROMPTS_PATH" => local_prompts,
+        "TYCHO_LOGS_ROOT" => File.join(local_dir, "logs"),
+        "TYCHO_TEST_PEER_TOKEN" => token
+      }
+
+      with_remote_server(server_env, port, File.join(dir, "server.log")) do
+        projects = run_tycho(local_env, "project", "list", "--server", "peer", "--json")
+        assert(projects.fetch(:status).success?, "expected remote project list: #{projects.fetch(:stderr)}")
+        assert(JSON.parse(projects.fetch(:stdout)).fetch(0).fetch("key") == "demo",
+               "expected remote project list payload")
+        inline_auth = run_tycho(local_env.except("TYCHO_TEST_PEER_TOKEN"),
+                                "project", "list", "--server", "peer-inline", "--json")
+        assert(inline_auth.fetch(:status).success? &&
+               !inline_auth.fetch(:stdout).include?(token) && !inline_auth.fetch(:stderr).include?(token),
+               "expected inline token auth without credential output")
+
+        project = run_tycho(local_env, "project", "show", "demo", "--server", "peer", "--json")
+        assert(project.fetch(:status).success?, "expected remote project show: #{project.fetch(:stderr)}")
+        assert(JSON.parse(project.fetch(:stdout)).fetch("name") == "Remote Demo",
+               "expected normalized remote project detail")
+
+        created = run_tycho(local_env, "agent", "create", "demo", "Remote CLI lifecycle test",
+                            "--name", "Remote CLI test", "--server", "peer", "--json")
+        assert(created.fetch(:status).success?, "expected remote agent create: #{created.fetch(:stderr)}")
+        agent_key = JSON.parse(created.fetch(:stdout)).fetch("key")
+
+        listed = run_tycho(local_env, "agent", "list", "demo", "--server", "peer", "--json")
+        listed_payload = JSON.parse(listed.fetch(:stdout))
+        assert(listed_payload.any? { |agent| agent["key"] == agent_key },
+               "expected remote agent list to include created agent")
+        expected_agent_keys = %w[agent finished_at key last_exit_code last_run_at log_path model name pid project_key
+                                 prompt run_count running schedule_key started_at status workspace].sort
+        assert(listed_payload.fetch(0).keys.sort == expected_agent_keys,
+               "expected stable local/remote agent JSON fields")
+        status = run_tycho(local_env, "agent", "status", agent_key, "--server", "peer", "--json")
+        assert(JSON.parse(status.fetch(:stdout)).fetch("key") == agent_key,
+               "expected remote agent status payload")
+
+        started = run_tycho(local_env, "agent", "run", agent_key, "--server", "peer", "--json")
+        assert(started.fetch(:status).success? && JSON.parse(started.fetch(:stdout)).fetch("running"),
+               "expected remote agent run to start the target")
+        stopped = run_tycho(local_env, "agent", "stop", agent_key, "--server", "peer", "--json")
+        assert(stopped.fetch(:status).success? && !JSON.parse(stopped.fetch(:stdout)).fetch("running"),
+               "expected remote agent stop to stop the target")
+
+        sent = run_tycho(local_env, "agent", "send", agent_key, "Continue remotely",
+                         "--server", "peer", "--json")
+        assert(sent.fetch(:status).success? && JSON.parse(sent.fetch(:stdout)).fetch("running"),
+               "expected remote agent send to append and start")
+        run_tycho(local_env, "agent", "stop", agent_key, "--server", "peer", "--json")
+        archived = run_tycho(local_env, "agent", "archive", agent_key, "--server", "peer", "--json")
+        assert(archived.fetch(:status).success? && JSON.parse(archived.fetch(:stdout)).fetch("archived"),
+               "expected remote agent archive")
+
+        missing = run_tycho(local_env, "agent", "status", agent_key, "--server", "peer")
+        assert(!missing.fetch(:status).success? && missing.fetch(:stderr).include?("API error (HTTP 404)"),
+               "expected a clear remote API error")
+        unknown = run_tycho(local_env, "agent", "list", "--server", "unknown")
+        assert(!unknown.fetch(:status).success? && unknown.fetch(:stderr).include?("Unknown remote server: unknown"),
+               "expected a clear unknown-server error")
+        bad_auth = run_tycho(local_env.merge("TYCHO_TEST_PEER_TOKEN" => "wrong"),
+                             "agent", "list", "--server", "peer")
+        assert(!bad_auth.fetch(:status).success? && bad_auth.fetch(:stderr).include?("authentication failed") &&
+               !bad_auth.fetch(:stderr).include?("wrong"),
+               "expected an auth error without credentials")
+      end
+
+      unreachable = run_tycho(local_env, "agent", "list", "--server", "peer")
+      assert(!unreachable.fetch(:status).success? && unreachable.fetch(:stderr).include?("is unreachable"),
+             "expected a clear unreachable-server error")
+    end
+  end
+
+  def assert_remote_client_reports_timeout_and_unsupported_operation
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr.fetch(1)
+    config = HQ::RemoteServerConfig.new(key: "slow", name: "Slow", url: "http://127.0.0.1:#{port}", token: "", token_env: "")
+    thread = Thread.new do
+      socket = server.accept
+      sleep 0.2
+      socket.close
+    end
+    client = HQ::RemoteCLIClient.new(config, open_timeout: 0.05, read_timeout: 0.05)
+    begin
+      client.request("GET", "/agents")
+      raise "expected remote timeout"
+    rescue HQ::RemoteCLIClient::Error => e
+      assert(e.kind == :timeout && e.message.include?("timed out"), "expected a typed timeout error")
+    ensure
+      thread.join
+      server.close
+    end
+
+    begin
+      client.request("TRACE", "/agents")
+      raise "expected unsupported remote operation"
+    rescue HQ::RemoteCLIClient::Error => e
+      assert(e.kind == :unsupported && e.message.include?("Unsupported remote operation"),
+             "expected a typed unsupported-operation error")
+    end
+
+
+    token = "must-not-appear"
+    error_server = TCPServer.new("127.0.0.1", 0)
+    error_port = error_server.addr.fetch(1)
+    error_thread = Thread.new do
+      socket = error_server.accept
+      while (line = socket.gets)
+        break if line == "\r\n"
+      end
+      body = JSON.generate(error: "upstream echoed #{token}")
+      socket.write("HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\n" \
+                   "Content-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}")
+      socket.close
+    end
+    secret_config = HQ::RemoteServerConfig.new(
+      key: "error",
+      name: "Error",
+      url: "http://127.0.0.1:#{error_port}",
+      token: token,
+      token_env: ""
+    )
+    begin
+      HQ::RemoteCLIClient.new(secret_config).request("GET", "/agents")
+      raise "expected remote API error"
+    rescue HQ::RemoteCLIClient::Error => e
+      assert(!e.message.include?(token) && e.message.include?("[REDACTED]"),
+             "expected remote API errors to redact credentials")
+    ensure
+      error_thread.join
+      error_server.close
+    end
+    end
   def assert_github_commands_cover_device_login_status_and_logout
     auth = Class.new do
       attr_reader :logged_out
@@ -259,6 +447,53 @@ module CLICommandTest
   def run_tycho(env, *args)
     stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, EXECUTABLE, *args, chdir: ROOT)
     { stdout: stdout, stderr: stderr, status: status }
+  end
+
+  def available_port
+    server = TCPServer.new("127.0.0.1", 0)
+    server.addr.fetch(1)
+  ensure
+    server&.close
+  end
+
+  def with_remote_server(env, port, log_path)
+    log = File.open(log_path, "w")
+    pid = Process.spawn(
+      env,
+      RbConfig.ruby,
+      EXECUTABLE,
+      "serve",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      port.to_s,
+      chdir: ROOT,
+      out: log,
+      err: log
+    )
+    deadline = Time.now + 10
+    loop do
+      begin
+        socket = TCPSocket.new("127.0.0.1", port)
+        socket.close
+        break
+      rescue Errno::ECONNREFUSED
+        raise "remote test server did not start:\n#{File.read(log_path)}" if Time.now >= deadline
+
+        sleep 0.05
+      end
+    end
+    yield
+  ensure
+    if pid
+      begin
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      rescue Errno::ESRCH, Errno::ECHILD
+        nil
+      end
+    end
+    log&.close
   end
 
   def with_env(values)

--- a/test/remote_credential_store_test.rb
+++ b/test/remote_credential_store_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "json"
+require "tmpdir"
+
+require_relative "../lib/hq/registry"
+require_relative "../lib/hq/domain/remote_credential_store"
+
+module RemoteCredentialStoreTest
+  module_function
+
+  def run!
+    assert_store_is_private_and_metadata_is_redacted
+    assert_external_precedence_and_origin_binding
+    assert_rejection_requires_explicit_recovery
+    assert_inline_fallback_warns_about_v011_removal
+    puts "remote_credential_store_test: ok"
+  end
+
+  def assert_store_is_private_and_metadata_is_redacted
+    Dir.mktmpdir("tycho-remote-credentials") do |dir|
+      path = File.join(dir, "remote_credentials.json")
+      registry = Struct.new(:path).new(File.join(dir, "hq.yml"))
+      assert(HQ::RemoteCredentialStore.default_path(registry: registry) == path,
+             "expected remote_credentials.json beside the active hq.yml")
+      store = HQ::RemoteCredentialStore.new(path: path)
+      store.save_token("vps", token: "stored-secret", origin: "https://vps.example:443")
+
+      assert(File.exist?(path), "expected the credential file to be created")
+      assert(File.stat(path).mode & 0o777 == 0o600, "expected private credential-file permissions")
+      assert(JSON.parse(File.read(path)).dig("servers", "vps", "stored", "token") == "stored-secret",
+             "expected the token to persist under its stable server key")
+      assert(!store.metadata("vps").fetch("stored").key?("token"),
+             "expected status metadata to omit the token")
+    end
+  end
+
+  def assert_external_precedence_and_origin_binding
+    Dir.mktmpdir("tycho-remote-credentials") do |dir|
+      store = HQ::RemoteCredentialStore.new(path: File.join(dir, "remote_credentials.json"))
+      store.save_token("vps", token: "stored-secret", origin: "https://vps.example:443", state: "verified")
+      config = config_for(url: "HTTPS://VPS.Example/path", token_env: "TYCHO_TEST_MULTI_SERVER_TOKEN")
+      env = {}
+      resolver = HQ::RemoteCredentialResolver.new(store: store, env: env)
+
+      error = capture_error { resolver.resolve(config) }
+      assert(error.kind == :missing_external && error.message.include?(config.token_env),
+             "expected a missing configured external source to fail without stored-token fallback")
+
+      env[config.token_env] = "external-secret"
+      credential = resolver.resolve(config)
+      assert(credential.source == "external" && credential.token == "external-secret",
+             "expected token_env to select the external token for this server entry")
+      resolver.verified!(credential, config)
+      metadata = store.metadata("vps").fetch("external")
+      assert(metadata["origin"] == "https://vps.example:443" && metadata["state"] == "verified",
+             "expected the first successful external request to bind the normalized origin")
+
+      moved = config_for(url: "https://vps.example:8443/elsewhere", token_env: config.token_env)
+      error = capture_error { resolver.resolve(moved) }
+      assert(error.kind == :origin_mismatch && !error.message.include?(credential.token),
+             "expected scheme, host, or port changes to require re-authentication")
+      rebound = resolver.resolve(moved, allow_origin_change: true)
+      resolver.verified!(rebound, moved)
+      assert(resolver.resolve(moved).state == "verified",
+             "expected explicit verification to rebind an external credential to the new origin")
+
+      office = HQ::RemoteServerConfig.new(
+        key: "office",
+        name: "Office",
+        icon: "computer",
+        url: "https://office.example",
+        token: "",
+        token_env: "TYCHO_TEST_OFFICE_TOKEN"
+      )
+      env[office.token_env] = "office-secret"
+      assert(resolver.resolve(office).token == "office-secret" && resolver.resolve(moved).token == "external-secret",
+             "expected each server entry's explicit token_env to select its own token")
+    end
+  end
+
+  def assert_rejection_requires_explicit_recovery
+    Dir.mktmpdir("tycho-remote-credentials") do |dir|
+      store = HQ::RemoteCredentialStore.new(path: File.join(dir, "remote_credentials.json"))
+      resolver = HQ::RemoteCredentialResolver.new(store: store)
+      config = config_for
+      resolver.save(config, token: "stored-secret", verified: true)
+      credential = resolver.resolve(config)
+      resolver.rejected!(credential, config)
+
+      error = capture_error { resolver.resolve(config) }
+      assert(error.kind == :rejected, "expected rejected credentials to stop automatic use")
+      rejected = resolver.resolve(config, allow_rejected: true)
+      resolver.verified!(rejected, config)
+      assert(resolver.resolve(config).state == "verified", "expected explicit verification to recover the credential")
+      assert(store.delete_token(config.key), "expected logout to remove the stored token")
+      assert(resolver.resolve(config).source == "none", "expected logout to leave no stored credential")
+    end
+  end
+
+  def assert_inline_fallback_warns_about_v011_removal
+    warnings = []
+    config = config_for(token: "inline-secret")
+    Dir.mktmpdir("tycho-remote-credentials") do |dir|
+      resolver = HQ::RemoteCredentialResolver.new(
+        store: HQ::RemoteCredentialStore.new(path: File.join(dir, "remote_credentials.json")),
+        warning: ->(message) { warnings << message }
+      )
+      assert(resolver.resolve(config).source == "inline", "expected the temporary inline-token fallback")
+      assert(warnings.one? && warnings.first.include?("removed in v0.11.0") &&
+             warnings.first.include?("tycho server migrate vps"),
+             "expected a migration warning with the removal release")
+    end
+  end
+
+  def config_for(url: "https://vps.example/api", token: "", token_env: "")
+    HQ::RemoteServerConfig.new(
+      key: "vps",
+      name: "VPS",
+      icon: "server",
+      url: url,
+      token: token,
+      token_env: token_env
+    )
+  end
+
+  def capture_error
+    yield
+    raise "expected an error"
+  rescue HQ::RemoteCredentialResolver::Error => e
+    e
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+end
+
+RemoteCredentialStoreTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2683,6 +2683,17 @@ module RemoteServerTest
         assert(requests.all? { |request| request.dig(:headers, "authorization") == "Bearer target-secret" },
                "expected broker requests to use the provided browser-local token")
 
+        promoted = server.send(:route, service, "POST", "/servers/tycho-peer/credentials", {
+          "token" => "target-secret"
+        }, nil)
+        credential_path = File.join(dir, "remote_credentials.json")
+        assert(promoted[:status] == 200 && promoted.dig(:body, :credential, :state) == "verified",
+               "expected browser promotion to verify and persist the credential")
+        assert(File.stat(credential_path).mode & 0o777 == 0o600,
+               "expected browser-promoted credentials to use private file permissions")
+        assert(!promoted.dig(:body, :credential).to_s.include?("target-secret"),
+               "expected credential metadata to omit token values")
+
         updated = server.send(:route, service, "PATCH", "/servers/tycho-peer", {
           "name" => "Studio Mac",
           "icon" => "computer"
@@ -2714,18 +2725,21 @@ module RemoteServerTest
           method: "GET",
           path: "/servers/tycho-peer/agents",
           query: "",
-          headers: { "x-tycho-remote-server-token" => "target-secret" },
+          headers: {},
           body: ""
         )
         proxied = server.send(:route, service, "GET", "/servers/tycho-peer/agents", {}, proxy_request)
         assert(proxied.dig(:body, "agents", 0, "key") == "peer-agent-1",
-               "expected browser-local token header to authenticate broker proxy requests")
+               "expected the broker to use the Tycho-stored credential after browser promotion")
 
         deleted = server.send(:route, service, "DELETE", "/servers/tycho-peer", {}, nil)
         assert(deleted[:status] == 200, "expected Remote server delete route to succeed")
         persisted_after_delete = YAML.safe_load(File.read(config_path), aliases: true)
         assert(!persisted_after_delete.key?("remote_servers"),
                "expected deleted server to be removed from hq.yml")
+        credentials_after_delete = JSON.parse(File.read(credential_path))
+        assert(!credentials_after_delete.fetch("servers").key?("tycho-peer"),
+               "expected deleting a peer to remove its Tycho-stored credential")
       end
     end
   end
@@ -3888,7 +3902,8 @@ module RemoteServerTest
            js[:body].include?("SERVER_TOKENS_STORAGE_KEY") &&
            js[:body].include?("hq.remote.serverTokens") &&
            js[:body].include?("X-Tycho-Remote-Server-Token") &&
-           js[:body].include?("storeRemoteServerToken(server?.key, token)") &&
+           js[:body].include?('brokerPost(`/servers/${encodeURIComponent(server?.key || "")}/credentials`') &&
+           js[:body].include?("removeRemoteServerToken(server?.key)") &&
            js[:body].include?("removeRemoteServerToken(value)") &&
            js[:body].include?('brokerDelete(`/servers/${encodeURIComponent(value)}`') &&
            !js[:body].include?("hq.remote.customServers"),
@@ -3900,8 +3915,8 @@ module RemoteServerTest
     assert(js[:body].include?("data-toggle-server-token-form") &&
            js[:body].include?("function renderServerTokenForm") &&
            js[:body].include?("saveRemoteServerToken") &&
-           js[:body].include?("brokerGetWithHeaders") &&
-           js[:body].include?("Remote token saved for this browser") &&
+           js[:body].include?('brokerPost(`/servers/${encodeURIComponent(serverKey)}/credentials`') &&
+           js[:body].include?("Remote token moved to this Tycho host") &&
            js[:body].include?("Token needed here"),
            "expected Settings to let existing remote servers save a browser-local token")
     assert(js[:body].include?("function serverMetadataBadge") &&
@@ -3941,7 +3956,7 @@ module RemoteServerTest
            css[:body].include?("opacity: 0.68"),
            "expected stale peer projects and agents to stay subdued without replacing their status")
     assert(js[:body].include?('class="server-token-form ui-form-layout" data-ds-form="settings"') &&
-           js[:body].include?("Stored only in this browser and sent to the selected Remote server.") &&
+           js[:body].include?("Verified, stored on this Tycho host, then removed from this browser.") &&
            js[:body].include?('class="primary inline-icon-button ui-button" data-variant="brand" type="submit"'),
            "expected Remote token recovery to use the shared field, input, description, and semantic action contracts")
     assert(css[:body].include?(".server-action-menu > summary") &&


### PR DESCRIPTION
## Summary

- add direct `--server SERVER_KEY` targeting for project list/show and agent list/status/create/run/send/stop/archive
- add one Tycho-managed bearer credential per stable server key in atomic mode-`0600` `~/.tycho/config/remote_credentials.json`
- add `tycho server login`, `logout`, `status`, `verify`, and `migrate`, including secure prompt enrollment, offline enrollment, rejected-state recovery, explicit external overrides, and verified-origin guards
- let the CLI and local Remote UI broker share credential resolution; verified browser promotion removes the browser copy only after host persistence succeeds
- retain warned inline-token compatibility through v0.10.x and document removal in v0.11.0
- preserve local command behavior and normalized human/JSON output

Implements [Fizzy #123](https://fizzy.startkit.tech/1/cards/123).

## Validation

- `bin/test`
- `bundle exec ruby test/remote_credential_store_test.rb`
- `bundle exec ruby test/cli_command_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke` (isolated Chrome/Playwright run; passed on rerun after one unrelated autocomplete timing failure)
- `node --check lib/hq/remote_ui/assets/app.js`
- authenticated integration coverage for multiple explicit `token_env` mappings, external precedence, private-file migration, enrollment, verification/recovery, logout reporting, project reads, and the full disposable-agent lifecycle
- deterministic unknown-server, missing-external, origin-change, unreachable, timeout, authentication, unsupported-operation, API-error, rejection-state, and token-redaction coverage
- live `vps` read-only probe confirmed the server is reachable and unauthenticated requests are rejected cleanly; no test agent was created because no local `vps` credential is enrolled
- `git diff --check`

RuboCop is not installed in the repository bundle; the available shim cannot load the gem.