### PR TITLE
Close correction runner stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
-- Close the structured-output runner's unused stdin pipe so managed Codex
-  agents start without waiting for input or failing with a terminal I/O error.
+- Attach the structured-output runner's child stdin to the null device so
+  managed Codex agents start without waiting for input or failing with a
+  terminal I/O error.
 - Validate managed-agent structured output before success, request up to two
   same-session corrections for Codex and Claude-compatible harnesses, and
   preserve exhausted invalid responses in private diagnostic files while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+- Close the structured-output runner's unused stdin pipe so managed Codex
+  agents start without waiting for input or failing with a terminal I/O error.
 - Validate managed-agent structured output before success, request up to two
   same-session corrections for Codex and Claude-compatible harnesses, and
   preserve exhausted invalid responses in private diagnostic files while

--- a/lib/hq/domain/agent_correction_runner.rb
+++ b/lib/hq/domain/agent_correction_runner.rb
@@ -2,7 +2,6 @@
 
 require "fileutils"
 require "json"
-require "open3"
 require_relative "agent_structured_result"
 require_relative "agent_structured_output_validator"
 
@@ -67,19 +66,27 @@ module HQ
       FileUtils.rm_f(@config["last_message_path"]) unless @config["last_message_path"].to_s.empty?
       lines = []
       status = nil
-      Open3.popen2e(*command) do |stdin, stream, wait_thread|
-        stdin.close
-        stream.each_line do |line|
-          lines << line.chomp
-          @output.write(line)
-          @output.flush
-        end
-        status = wait_thread.value
+      stream, child_output = IO.pipe
+      pid = Process.spawn(*command, in: File::NULL, out: child_output, err: [:child, :out])
+      child_output.close
+      stream.each_line do |line|
+        lines << line.chomp
+        @output.write(line)
+        @output.flush
       end
+      _waited_pid, status = Process.wait2(pid)
       [lines, status.exitstatus || 1]
     rescue SystemCallError => e
       warn e.message
       [lines, 127]
+    ensure
+      stream&.close unless stream&.closed?
+      child_output&.close unless child_output&.closed?
+      begin
+        Process.wait(pid) if pid && !status
+      rescue Errno::ECHILD
+        nil
+      end
     end
 
     def candidate_for(lines)

--- a/lib/hq/domain/agent_correction_runner.rb
+++ b/lib/hq/domain/agent_correction_runner.rb
@@ -67,7 +67,8 @@ module HQ
       FileUtils.rm_f(@config["last_message_path"]) unless @config["last_message_path"].to_s.empty?
       lines = []
       status = nil
-      Open3.popen2e(*command) do |_stdin, stream, wait_thread|
+      Open3.popen2e(*command) do |stdin, stream, wait_thread|
+        stdin.close
         stream.each_line do |line|
           lines << line.chomp
           @output.write(line)

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -1503,6 +1503,10 @@ module ManagedAgentTest
       harness = File.join(dir, "direct-harness")
       File.write(harness, <<~SH)
         #!/bin/sh
+        if [ ! -c /dev/stdin ]; then
+          echo "managed child stdin was not the null device"
+          exit 42
+        fi
         printf '%s\n' '{"type":"assistant","session_id":"validation-session","message":{"role":"assistant","content":[{"type":"tool_use","name":"StructuredOutput","input":{"status":"success","summary":"Validated through runner.","inquiry_json":"null","attachments_json":"null"}}]}}'
         exit 0
       SH

--- a/test/structured_output_validation_test.rb
+++ b/test/structured_output_validation_test.rb
@@ -14,7 +14,7 @@ module StructuredOutputValidationTest
   SCHEMA_PATH = File.expand_path("../config/schemas/agent_result.json", __dir__)
 
   def run!
-    assert_runner_closes_child_stdin
+    assert_runner_uses_null_child_stdin
     assert_first_pass_success
     assert_malformed_json_feedback
     assert_multiple_schema_violations
@@ -23,11 +23,11 @@ module StructuredOutputValidationTest
     puts "structured_output_validation_test: ok"
   end
 
-  def assert_runner_closes_child_stdin
-    with_runner("codex", "requires_stdin_eof", correction_limit: 2) do |result|
+  def assert_runner_uses_null_child_stdin
+    with_runner("codex", "requires_null_stdin", correction_limit: 2) do |result|
       assert(result[:exit_code].zero?,
-             "expected runner to close unused child stdin before reading output: #{result[:output]}")
-      assert(result[:invocations].length == 1, "expected stdin EOF check to run once")
+             "expected runner to attach unused child stdin to the null device: #{result[:output]}")
+      assert(result[:invocations].length == 1, "expected null stdin check to run once")
     end
   end
 
@@ -157,14 +157,13 @@ module StructuredOutputValidationTest
         "tool_work" => count.zero?
       }
       File.open(state_path, "a") { |file| file.puts(JSON.generate(entry)) }
-      if scenario == "requires_stdin_eof"
-        readable = IO.select([$stdin], nil, nil, 0.25)
-        unless readable && $stdin.read.empty?
-          warn "child stdin did not reach EOF"
+      if scenario == "requires_null_stdin"
+        unless $stdin.stat.ftype == "characterSpecial" && $stdin.read.empty?
+          warn "child stdin was not the null device"
           exit 42
         end
       end
-      fixture_name = if %w[first_pass requires_stdin_eof].include?(scenario) ||
+      fixture_name = if %w[first_pass requires_null_stdin].include?(scenario) ||
                         (scenario == "corrected" && count.positive?)
                        "valid.json"
                      elsif scenario == "corrected"

--- a/test/structured_output_validation_test.rb
+++ b/test/structured_output_validation_test.rb
@@ -14,12 +14,21 @@ module StructuredOutputValidationTest
   SCHEMA_PATH = File.expand_path("../config/schemas/agent_result.json", __dir__)
 
   def run!
+    assert_runner_closes_child_stdin
     assert_first_pass_success
     assert_malformed_json_feedback
     assert_multiple_schema_violations
     assert_successful_correction_for_supported_harnesses
     assert_retry_exhaustion_preserves_invalid_response
     puts "structured_output_validation_test: ok"
+  end
+
+  def assert_runner_closes_child_stdin
+    with_runner("codex", "requires_stdin_eof", correction_limit: 2) do |result|
+      assert(result[:exit_code].zero?,
+             "expected runner to close unused child stdin before reading output: #{result[:output]}")
+      assert(result[:invocations].length == 1, "expected stdin EOF check to run once")
+    end
   end
 
   def assert_first_pass_success
@@ -148,7 +157,15 @@ module StructuredOutputValidationTest
         "tool_work" => count.zero?
       }
       File.open(state_path, "a") { |file| file.puts(JSON.generate(entry)) }
-      fixture_name = if scenario == "first_pass" || (scenario == "corrected" && count.positive?)
+      if scenario == "requires_stdin_eof"
+        readable = IO.select([$stdin], nil, nil, 0.25)
+        unless readable && $stdin.read.empty?
+          warn "child stdin did not reach EOF"
+          exit 42
+        end
+      end
+      fixture_name = if %w[first_pass requires_stdin_eof].include?(scenario) ||
+                        (scenario == "corrected" && count.positive?)
                        "valid.json"
                      elsif scenario == "corrected"
                        "multiple_violations.json"


### PR DESCRIPTION
## Summary

- attach managed Codex and Claude child stdin directly to the null device because prompts are passed through argv
- preserve merged, streaming stdout/stderr and correction-runner process-group behavior without Open3 creating an stdin pipe
- prevent detached managed Codex launches from failing with `Errno::EIO` before emitting JSON
- cover both the correction runner and the complete `ManagedAgent -> correction runner -> harness` launch seam

This fixes a regression introduced by #60 while continuing Fizzy #126: https://fizzy.startkit.tech/1/cards/126

## Root cause

`AgentCorrectionRunner#execute` introduced an `Open3.popen2e` wrapper around each managed harness. That changed fd 0 from Tycho inherited input to an Open3 pipe. Closing Open3s parent writer was sufficient in isolated controls but not in the production detached managed-agent path, where Codex could still fail before its JSON stream with `Input/output error @ io_fillbuf - fd:0 <STDIN> (Errno::EIO)`.

The runner now creates only an output pipe and launches the harness with `in: File::NULL`. This matches the passing direct `</dev/null` control and makes the no-stdin contract explicit.

## Verification

- regression tests fail against the former Open3 implementation because child fd 0 is not the null device
- `ruby test/structured_output_validation_test.rb`
- `ruby test/managed_agent_test.rb`
- production-style detached `ManagedAgent` launch using Codex `gpt-5.6-sol`, medium reasoning, danger-full-access, a 6.6 KB prompt containing prior literal EIO summaries, and the production result schema; Codex emitted its JSON stream and valid final structured result
- real Codex correction-runner control with the production schema
- `bin/test`
- Ruby syntax checks
- `git diff --check`

No configuration, schema, UI, or dependency changes.