### PR TITLE
Add agent CLI onboarding guidance

### DIFF
--- a/lib/hq/domain/onboarding.rb
+++ b/lib/hq/domain/onboarding.rb
@@ -8,6 +8,29 @@ module HQ
     WELCOME_PROJECT_KEY = "welcome"
     WELCOME_PROJECT_NAME = "Welcome Sandbox"
     WELCOME_PROJECT_GROUP = "Getting Started"
+    AGENT_CLI_GUIDES = {
+      "codex" => {
+        name: "Codex",
+        install_command: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+        verify_command: "codex --version",
+        setup: "Run `codex` in a project and choose a sign-in method. Complete the browser step on a device you trust; do not paste credentials into Tycho.",
+        documentation_url: "https://developers.openai.com/codex/cli/"
+      },
+      "claude" => {
+        name: "Claude Code",
+        install_command: "curl -fsSL https://claude.ai/install.sh | bash",
+        verify_command: "claude --version",
+        setup: "Run `claude` in a project and complete the sign-in flow for your Anthropic account, Claude subscription, or approved cloud provider. Keep credentials out of shell history and Tycho.",
+        documentation_url: "https://docs.anthropic.com/en/docs/claude-code/getting-started"
+      },
+      "opencode" => {
+        name: "OpenCode",
+        install_command: "curl -fsSL https://opencode.ai/install | bash",
+        verify_command: "opencode --version",
+        setup: "Run `opencode`, then use `/connect` to choose and configure a provider. Authenticate on the server or a trusted device without sharing API keys with Tycho.",
+        documentation_url: "https://dev.opencode.ai/docs/"
+      }
+    }.freeze
 
     module_function
 
@@ -30,6 +53,13 @@ module HQ
         path: ensure_welcome_workspace!,
         agent: agent.to_s
       }
+    end
+
+    def agent_cli_guides
+      HQ::BUILTIN_HARNESSES.filter_map do |harness|
+        guide = AGENT_CLI_GUIDES[harness]
+        guide && guide.merge(key: harness)
+      end
     end
 
     def current_directory_candidate(cwd = Dir.pwd)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -3442,7 +3442,8 @@ module HQ
       {
         active: @projects.empty?,
         welcome_project_key: Onboarding::WELCOME_PROJECT_KEY,
-        welcome_workspace_path: Onboarding.welcome_workspace_path
+        welcome_workspace_path: Onboarding.welcome_workspace_path,
+        agent_cli_guides: Onboarding.agent_cli_guides
       }
     end
 

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1724,6 +1724,96 @@ select {
   color: var(--accent);
 }
 
+.onboarding-cli-guide {
+  display: grid;
+  gap: 12px;
+  margin-top: 28px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-soft);
+}
+
+.onboarding-cli-guide h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.onboarding-cli-guide .eyebrow {
+  margin: 0;
+}
+
+.onboarding-cli-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.onboarding-cli-option {
+  min-height: var(--touch-target);
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  background: var(--panel);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.onboarding-cli-option:hover,
+.onboarding-cli-option:focus-visible,
+.onboarding-cli-option.selected {
+  border-color: var(--accent);
+}
+
+.onboarding-cli-option.selected {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--panel));
+}
+
+.onboarding-cli-ready,
+.onboarding-cli-instructions {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.onboarding-cli-ready {
+  padding: 12px;
+  border-left: 3px solid var(--success);
+  color: var(--text);
+  background: color-mix(in srgb, var(--success) 8%, var(--panel));
+}
+
+.onboarding-cli-ready span {
+  color: var(--muted);
+}
+
+.onboarding-cli-instructions p {
+  margin: 0;
+}
+
+.onboarding-cli-instructions code {
+  display: block;
+  overflow-x: auto;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text);
+  background: var(--bg);
+  white-space: pre-wrap;
+}
+
+.onboarding-cli-docs {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 700;
+}
+
 .onboarding-actions {
   display: flex;
   flex-wrap: wrap;
@@ -1763,6 +1853,10 @@ select {
 }
 
 @media (max-width: 640px) {
+  .onboarding-cli-options {
+    grid-template-columns: 1fr;
+  }
+
   .onboarding-workspace code {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -573,6 +573,7 @@ const state = {
   hiddenSettings: null,
   responseStyle: null,
   setup: null,
+  onboardingGuide: "",
   settingsSection: "connection",
   conversations: {},
   loadingConversations: {},
@@ -3866,6 +3867,14 @@ function onboardingActive() {
 
 function renderOnboarding() {
   const setup = state.setup || {};
+  const guides = Array.isArray(setup.onboarding?.agent_cli_guides) ? setup.onboarding.agent_cli_guides : [];
+  const availableHarnesses = new Map(Array.isArray(setup.harnesses)
+    ? setup.harnesses.map((harness) => [harness.name, harness])
+    : []);
+  const selectedGuide = guides.find((guide) => guide.key === state.onboardingGuide)
+    || guides.find((guide) => !availableHarnesses.get(guide.key)?.ready)
+    || guides[0];
+  if (selectedGuide) state.onboardingGuide = selectedGuide.key;
   const welcomePath = setup.onboarding?.welcome_workspace_path || "~/.tycho/workspaces/welcome";
   const title = "Coding agent orchestrations using your own harness";
   const subtitle = "Each session with coding agent lives inside a project workspace.";
@@ -3877,6 +3886,7 @@ function renderOnboarding() {
         <h1>${escapeHtml(title)}</h1>
         <p>${escapeHtml(subtitle)}</p>
         <p class="onboarding-outcome">Creates an isolated starter project you can inspect, run, and remove safely.</p>
+        ${selectedGuide ? renderOnboardingCliGuide(selectedGuide, availableHarnesses.get(selectedGuide.key)) : ""}
         <div class="onboarding-actions">
           <button class="primary inline-icon-button ui-button" data-variant="brand" type="button" data-create-welcome-sandbox>${iconSvg("folder")}<span>Create Welcome Sandbox</span></button>
         </div>
@@ -3888,6 +3898,42 @@ function renderOnboarding() {
       </div>
     </section>
   `);
+}
+
+function renderOnboardingCliGuide(guide, harness) {
+  const ready = Boolean(harness?.ready);
+  const path = harness?.path || harness?.detail || "";
+  const guideOptions = Array.isArray(state.setup?.onboarding?.agent_cli_guides)
+    ? state.setup.onboarding.agent_cli_guides
+    : [];
+  return `
+    <section class="onboarding-cli-guide" aria-labelledby="onboarding-cli-title">
+      <p class="eyebrow">Step 1 · Choose an agent CLI</p>
+      <h2 id="onboarding-cli-title">Install or confirm your agent CLI</h2>
+      <div class="onboarding-cli-options" aria-label="Agent CLI">
+        ${guideOptions.map((option) => `
+          <button class="onboarding-cli-option${option.key === guide.key ? " selected" : ""}" type="button" aria-pressed="${option.key === guide.key}" data-select-onboarding-cli="${escapeAttr(option.key)}">
+            ${escapeHtml(option.name)}
+          </button>
+        `).join("")}
+      </div>
+      ${ready ? `
+        <div class="onboarding-cli-ready" role="status">
+          <strong>${escapeHtml(guide.name)} is ready</strong>
+          <span>${path ? `Found at ${escapeHtml(path)}.` : "Tycho can run this CLI."} No installation is needed.</span>
+        </div>
+      ` : `
+        <div class="onboarding-cli-instructions">
+          <p>Run this on the server in a terminal:</p>
+          <code>${escapeHtml(guide.install_command)}</code>
+          <p>Then verify the installation:</p>
+          <code>${escapeHtml(guide.verify_command)}</code>
+          <p>${escapeHtml(guide.setup)}</p>
+        </div>
+      `}
+      <a class="onboarding-cli-docs" href="${escapeAttr(guide.documentation_url)}" target="_blank" rel="noreferrer">Open official ${escapeHtml(guide.name)} documentation <span aria-hidden="true">↗</span></a>
+    </section>
+  `;
 }
 
 function focusFilterInput(tab, inputId) {
@@ -11288,6 +11334,14 @@ els.view.addEventListener("click", (event) => {
 
   if (event.target.closest("[data-create-welcome-sandbox]")) {
     createWelcomeSandbox();
+    return;
+  }
+
+  const onboardingCliButton = event.target.closest("[data-select-onboarding-cli]");
+  if (onboardingCliButton) {
+    state.onboardingGuide = onboardingCliButton.dataset.selectOnboardingCli || "";
+    render();
+    document.querySelector("[data-select-onboarding-cli].selected")?.focus({ preventScroll: true });
     return;
   }
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -46,6 +46,7 @@ module RemoteServerTest
     assert_remote_setup_uses_shared_executable_resolution
     assert_remote_setup_handles_utf8_harness_output_under_ascii_external
     assert_remote_welcome_onboarding_creates_project
+    assert_remote_welcome_onboarding_exposes_agent_cli_guides
     assert_remote_setup_warns_when_public_url_has_no_token
     assert_remote_server_restart_route_schedules_restart
     assert_remote_broker_lists_configured_servers
@@ -2182,6 +2183,27 @@ module RemoteServerTest
     end
   end
 
+  def assert_remote_welcome_onboarding_exposes_agent_cli_guides
+    with_remote_temp_store do |dir|
+      config_path = File.join(dir, "hq.yml")
+      prompts_path = File.join(dir, "system_prompts.yml")
+      File.write(config_path, "projects: []\n")
+      File.write(prompts_path, "custom: Default prompt.\n")
+      registry = HQ::Registry.new(path: config_path, system_prompts_path: prompts_path)
+      setup = HQ::RemoteService.new(registry: registry).setup
+      guides = setup.dig(:onboarding, :agent_cli_guides)
+
+      assert(guides.map { |guide| guide[:key] } == %w[codex claude opencode],
+             "expected onboarding CLI guides for each built-in harness")
+      guides.each do |guide|
+        assert(guide[:install_command].to_s.length.positive?, "expected #{guide[:key]} install command")
+        assert(guide[:verify_command].to_s.end_with?("--version"), "expected #{guide[:key]} verification command")
+        assert(guide[:setup].to_s.length.positive?, "expected #{guide[:key]} setup guidance")
+        assert(guide[:documentation_url].to_s.start_with?("https://"), "expected #{guide[:key]} official docs URL")
+      end
+    end
+  end
+
   def assert_remote_server_restart_route_schedules_restart
     output = StringIO.new
     server = HQ::RemoteServer.new(
@@ -3270,6 +3292,8 @@ module RemoteServerTest
            "expected informational agent list icons to match their status pills")
     assert(css[:body].include?(".growl"), "expected Remote UI to style growl notifications")
     assert(css[:body].include?(".agent-sort-menu"), "expected Remote UI to style agent sort dropdowns")
+    assert(css[:body].include?(".onboarding-cli-guide") && css[:body].include?(".onboarding-cli-options"),
+           "expected Remote UI to style the onboarding CLI guide")
     assert(css[:body].include?(".agent-sort-trigger"), "expected Remote UI to style icon-only sort triggers")
     assert(css[:body].include?(".agent-sort-option"), "expected Remote UI to style text sort options")
     assert(css[:body].include?(".agent-ledger") &&
@@ -4285,6 +4309,17 @@ module RemoteServerTest
            "expected push setup to replace expired or VAPID-mismatched browser subscriptions")
     assert(js[:body].include?("function renderAgentForm"),
            "expected Remote UI to render create/edit agent forms")
+    assert(js[:body].include?("function renderOnboardingCliGuide") &&
+           js[:body].include?("data-select-onboarding-cli") &&
+           js[:body].include?("agent_cli_guides"),
+           "expected onboarding to render selectable server-provided CLI installation guides")
+    assert(js[:body].include?("No installation is needed.") &&
+           js[:body].include?("aria-pressed") &&
+           js[:body].include?("target=\"_blank\" rel=\"noreferrer\""),
+           "expected onboarding CLI guidance to expose readiness, keyboard semantics, and safe official-doc links")
+    assert(js[:body].include?("[data-select-onboarding-cli].selected") &&
+           js[:body].include?("?.focus({ preventScroll: true })"),
+           "expected onboarding CLI selection to retain keyboard focus after rendering")
     assert(!js[:body].include?('name="workspace"'),
            "expected Remote UI agent forms to omit editable workspace fields")
     assert(!js[:body].include?('formData.get("workspace")'),


### PR DESCRIPTION
## Summary
- add server-provided Codex, Claude Code, and OpenCode installation and first-auth guides to Remote UI onboarding
- reuse shared harness readiness so installed CLIs skip installation instructions
- cover guide payload, UI accessibility hooks, full tests, and desktop/mobile browser smoke

## Verification
- `bin/test`
- `bin/remote-ui-smoke`
- fresh-server browser checks at 1440px and 390px, including keyboard CLI selection

Fizzy #128: https://fizzy.startkit.tech/1/cards/128