### PR TITLE
Add speech mode shortcut

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1680,6 +1680,45 @@ def write_smoke_script(path)
 
         await page.goto(`${baseUrl}/ui#agent/${encodeURIComponent(agentKey)}`, { waitUntil: "networkidle" });
         await page.waitForSelector("#prompt-input", { state: "visible", timeout: 10_000 });
+        await page.evaluate(() => {
+          window.SpeechRecognition = class SmokeSpeechRecognition {
+            start() { window.__speechRecognitionStarted = (window.__speechRecognitionStarted || 0) + 1; }
+            stop() {}
+          };
+          state.renderedViewHtml = "";
+          render();
+          const hiddenComposer = document.createElement("form");
+          hiddenComposer.id = "composer";
+          hiddenComposer.hidden = true;
+          hiddenComposer.dataset.agentKey = "hidden-speech-composer";
+          hiddenComposer.innerHTML = '<textarea id="prompt-input"></textarea>';
+          els.view.append(hiddenComposer);
+          document.activeElement?.blur();
+        });
+        await page.keyboard.press("Meta+Shift+.");
+        const speechShortcutContract = await page.evaluate((key) => {
+          const recognition = state.speechRecognition;
+          recognition?.onresult?.({
+            resultIndex: 0,
+            results: [{ isFinal: true, 0: { transcript: "spoken smoke" } }],
+          });
+          return {
+            started: window.__speechRecognitionStarted,
+            selectedAgentKey: state.speechComposerKey,
+            focusedPrompt: document.activeElement?.id === "prompt-input" && document.activeElement?.closest("#composer")?.dataset.agentKey === key,
+            transcript: document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] #prompt-input`)?.value,
+            shortcutHint: document.querySelector("[data-toggle-speech-mode]")?.getAttribute("aria-label"),
+          };
+        }, agentKey);
+        if (speechShortcutContract.started !== 1 ||
+            speechShortcutContract.selectedAgentKey !== agentKey ||
+            !speechShortcutContract.focusedPrompt ||
+            speechShortcutContract.transcript !== "spoken smoke" ||
+            !speechShortcutContract.shortcutHint?.includes("Shift+.")) {
+          throw new Error(`Speech shortcut did not select and focus the visible composer: ${JSON.stringify(speechShortcutContract)}`);
+        }
+        if (captureDir) await page.screenshot({ path: path.join(captureDir, "speech-shortcut-desktop.png") });
+        await page.evaluate(() => stopSpeechMode());
         await page.waitForSelector("#header-schedule-menu:not(.hidden)", { state: "visible", timeout: 10_000 });
         const scheduleHeaderGeometry = await page.evaluate(() => {
           const scheduleTrigger = document.querySelector("[data-header-schedule-menu] > summary").getBoundingClientRect();

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1719,6 +1719,84 @@ def write_smoke_script(path)
         }
         if (captureDir) await page.screenshot({ path: path.join(captureDir, "speech-shortcut-desktop.png") });
         await page.evaluate(() => stopSpeechMode());
+        const speechGuardContract = await page.evaluate((key) => {
+          const shortcut = (overrides = {}) => {
+            let prevented = false;
+            return {
+              handled: handleSpeechModeShortcut({
+                metaKey: true,
+                ctrlKey: false,
+                shiftKey: true,
+                altKey: false,
+                code: "Period",
+                repeat: false,
+                isComposing: false,
+                preventDefault: () => { prevented = true; },
+                ...overrides,
+              }),
+              prevented,
+            };
+          };
+          const activeComposer = document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"]`);
+          const otherAgent = { ...findAgent(key), key: "speech-other", name: "Speech other", running: false, status: "idle" };
+          state.agents.push(otherAgent);
+          const otherComposer = activeComposer.cloneNode(true);
+          otherComposer.dataset.agentKey = otherAgent.key;
+          els.view.append(otherComposer);
+          const disabledComposer = activeComposer.cloneNode(true);
+          disabledComposer.dataset.agentKey = otherAgent.key;
+          disabledComposer.dataset.agentRunning = "true";
+          els.view.append(disabledComposer);
+          const externalInput = document.createElement("input");
+          const editable = document.createElement("div");
+          editable.contentEditable = "true";
+          const dialog = document.createElement("div");
+          dialog.setAttribute("role", "dialog");
+          dialog.textContent = "Speech guard dialog";
+          document.body.append(externalInput, editable, dialog);
+          const results = {};
+          externalInput.focus();
+          results.textInput = shortcut();
+          editable.focus();
+          results.contentEditable = shortcut();
+          document.activeElement?.blur();
+          results.repeat = shortcut({ repeat: true });
+          results.composing = shortcut({ isComposing: true });
+          results.dialog = shortcut();
+          dialog.remove();
+          const constructor = window.SpeechRecognition;
+          const webkitConstructor = window.webkitSpeechRecognition;
+          Object.defineProperties(window, {
+            SpeechRecognition: { configurable: true, value: undefined },
+            webkitSpeechRecognition: { configurable: true, value: undefined },
+          });
+          results.unsupported = shortcut();
+          Object.defineProperties(window, {
+            SpeechRecognition: { configurable: true, value: constructor },
+            webkitSpeechRecognition: { configurable: true, value: webkitConstructor },
+          });
+          document.activeElement?.blur();
+          results.multiple = shortcut();
+          results.focusedVisibleComposer = document.activeElement === document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] #prompt-input`);
+          results.disabledIgnored = !speechEligibleComposer(disabledComposer);
+          results.activeKey = state.speechComposerKey;
+          stopSpeechMode();
+          state.agents = state.agents.filter((agent) => agent.key !== otherAgent.key);
+          otherComposer.remove();
+          disabledComposer.remove();
+          externalInput.remove();
+          editable.remove();
+          return results;
+        }, agentKey);
+        if (speechGuardContract.textInput.handled || speechGuardContract.textInput.prevented ||
+            speechGuardContract.contentEditable.handled || speechGuardContract.contentEditable.prevented ||
+            speechGuardContract.repeat.handled || speechGuardContract.composing.handled ||
+            speechGuardContract.dialog.handled || speechGuardContract.dialog.prevented ||
+            speechGuardContract.unsupported.handled || speechGuardContract.unsupported.prevented ||
+            !speechGuardContract.multiple.handled || !speechGuardContract.focusedVisibleComposer ||
+            !speechGuardContract.disabledIgnored || speechGuardContract.activeKey !== agentKey) {
+          throw new Error(`Speech shortcut guards or composer selection failed: ${JSON.stringify(speechGuardContract)}`);
+        }
         await page.waitForSelector("#header-schedule-menu:not(.hidden)", { state: "visible", timeout: 10_000 });
         const scheduleHeaderGeometry = await page.evaluate(() => {
           const scheduleTrigger = document.querySelector("[data-header-schedule-menu] > summary").getBoundingClientRect();

--- a/docs/research/speech-mode-shortcut.md
+++ b/docs/research/speech-mode-shortcut.md
@@ -1,0 +1,14 @@
+# Speech mode shortcut
+
+Tycho uses `Cmd+Shift+.` on macOS and `Ctrl+Shift+.` on Windows and Linux to focus the eligible visible conversation composer and start Speech mode. It deliberately avoids bare character shortcuts, `accesskey`, and well-known browser, operating-system, and editor combinations such as `Cmd/Ctrl+K`, `Cmd/Ctrl+Shift+S`, `Cmd/Ctrl+Shift+M`, and `F` keys.
+
+The shortcut is document-level only when one eligible composer can be selected: an already focused composer wins; otherwise Tycho uses the composer for the active agent route, and otherwise the sole visible composer. It does nothing for hidden, inert, disabled, running-agent, or inquiry composers; while a non-composer text input or contenteditable element is focused; while a non-composer dialog is open; during IME composition; on a key repeat; or when speech recognition is unsupported. The Speech button displays the shortcut in its accessible name and title, and has `aria-keyshortcuts` so assistive technology can announce it.
+
+The choice follows W3C guidance: WCAG 2.1 SC 2.1.4 requires a modifier or another safeguard for a global character shortcut; the ARIA Authoring Practices say shortcuts should augment ordinary keyboard access, preserve predictable focus, and be shown on the target control; and ARIA 1.3 says authors should not inhibit operating-system, browser, or assistive-technology functionality. The implementation uses `KeyboardEvent.code === "Period"` with the platform primary modifier and ignores `repeat` and `isComposing`, as defined by the UI Events keyboard model.
+
+Primary sources:
+
+- [WCAG 2.1, Success Criterion 2.1.4](https://www.w3.org/TR/WCAG21/#character-key-shortcuts)
+- [WAI-ARIA Authoring Practices: Keyboard Shortcuts](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#keyboard-shortcuts)
+- [WAI-ARIA 1.3: aria-keyshortcuts](https://www.w3.org/TR/wai-aria-1.3/#aria-keyshortcuts)
+- [UI Events: KeyboardEvent](https://w3c.github.io/uievents/#interface-keyboardevent)

--- a/docs/research/speech-mode-shortcut.md
+++ b/docs/research/speech-mode-shortcut.md
@@ -1,6 +1,6 @@
 # Speech mode shortcut
 
-Tycho uses `Cmd+Shift+.` on macOS and `Ctrl+Shift+.` on Windows and Linux to focus the eligible visible conversation composer and start Speech mode. It deliberately avoids bare character shortcuts, `accesskey`, and well-known browser, operating-system, and editor combinations such as `Cmd/Ctrl+K`, `Cmd/Ctrl+Shift+S`, `Cmd/Ctrl+Shift+M`, and `F` keys.
+Tycho uses `Cmd+Shift+.` on macOS and `Ctrl+Shift+.` on Windows and Linux to focus the eligible visible conversation composer and start Speech mode. It deliberately avoids bare character shortcuts, `accesskey`, and well-known browser, operating-system, and editor combinations such as `Cmd/Ctrl+K`, `Cmd/Ctrl+Shift+S`, `Cmd/Ctrl+Shift+M`, and `F` keys. We compared the shortcut with the official Chrome and Firefox desktop shortcut lists plus Apple and Microsoft system lists: those lists reserve the familiar conflicting combinations but do not assign the selected combination. This cannot reserve the chord against every application or extension, so Tycho also confines it to an eligible composer and leaves all other contexts alone.
 
 The shortcut is document-level only when one eligible composer can be selected: an already focused composer wins; otherwise Tycho uses the composer for the active agent route, and otherwise the sole visible composer. It does nothing for hidden, inert, disabled, running-agent, or inquiry composers; while a non-composer text input or contenteditable element is focused; while a non-composer dialog is open; during IME composition; on a key repeat; or when speech recognition is unsupported. The Speech button displays the shortcut in its accessible name and title, and has `aria-keyshortcuts` so assistive technology can announce it.
 
@@ -12,3 +12,7 @@ Primary sources:
 - [WAI-ARIA Authoring Practices: Keyboard Shortcuts](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#keyboard-shortcuts)
 - [WAI-ARIA 1.3: aria-keyshortcuts](https://www.w3.org/TR/wai-aria-1.3/#aria-keyshortcuts)
 - [UI Events: KeyboardEvent](https://w3c.github.io/uievents/#interface-keyboardevent)
+- [Chrome keyboard shortcuts](https://support.google.com/chrome/answer/157179)
+- [Firefox keyboard shortcuts](https://support.mozilla.org/kb/keyboard-shortcuts-perform-firefox-tasks-quickly)
+- [Apple macOS keyboard shortcuts](https://support.apple.com/en-us/102650)
+- [Windows keyboard shortcuts](https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec)

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -582,6 +582,8 @@ const state = {
   fullScreenComposerKeys: new Set(),
   fullScreenInquiryKeys: new Set(),
   composerDraftSaveTimers: new Map(),
+  speechRecognition: null,
+  speechComposerKey: "",
   attachmentDetails: {},
   attachmentImageUrls: {},
   attachmentImageErrors: {},
@@ -1235,6 +1237,24 @@ function platformShortcutModifier() {
 
 function agentSwitcherShortcutLabel() {
   return `${platformShortcutModifier()}+K`;
+}
+
+function speechModeShortcutLabel() {
+  return `${platformShortcutModifier()}+Shift+.`;
+}
+
+function speechRecognitionConstructor() {
+  return window.SpeechRecognition || window.webkitSpeechRecognition || null;
+}
+
+function speechModeAvailable() {
+  return typeof speechRecognitionConstructor() === "function";
+}
+
+function speechModeShortcut(event) {
+  const macPlatform = /Mac|iPhone|iPad|iPod/.test(window.navigator.platform || "");
+  const primaryModifier = macPlatform ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
+  return primaryModifier && event.shiftKey && !event.altKey && event.code === "Period";
 }
 
 function shortcutModifierKey(event) {
@@ -5302,6 +5322,7 @@ function renderAgentComposer(agent, skills, options = {}) {
             ${renderPromptAttachmentButton(agent)}
             ${renderAttachmentToggle(agent)}
             ${renderAgentViewToggle(agent, options)}
+            ${renderSpeechModeButton(agent)}
             <button class="skill-toggle-button" type="button" data-toggle-skills aria-label="Insert skill" title="Insert skill" ${agentIsRunning(agent) ? "disabled" : ""}>${iconSvg("squareSlash")}</button>
           </div>
           <div class="send-actions">
@@ -5598,6 +5619,109 @@ function agentComposerAction(agent) {
   }
 
   return `<button class="primary ui-button" data-variant="brand" type="submit" data-agent-key="${escapeAttr(agent.key)}">Send prompt</button>`;
+}
+
+function renderSpeechModeButton(agent) {
+  const available = speechModeAvailable();
+  const active = state.speechComposerKey === agent.key;
+  const disabled = agentIsRunning(agent) || !available;
+  const label = active ? "Stop speech mode" : "Start speech mode";
+  const hint = `${label} (${speechModeShortcutLabel()})`;
+  const unavailable = available ? "" : " Speech recognition is unavailable in this browser.";
+  return `<button class="skill-toggle-button speech-mode-button" type="button" data-toggle-speech-mode aria-label="${escapeAttr(hint)}" title="${escapeAttr(hint + unavailable)}" aria-keyshortcuts="${escapeAttr(speechModeShortcutLabel().replace("Cmd", "Meta").replace("Ctrl", "Control"))}" aria-pressed="${active ? "true" : "false"}" ${disabled ? "disabled" : ""}>${active ? "Listening" : "Speech"}</button>`;
+}
+
+function composerIsVisible(composer) {
+  return composer?.isConnected && !composer.closest("[inert], [hidden], .hidden, details:not([open])") && composer.getClientRects().length > 0;
+}
+
+function speechEligibleComposer(composer) {
+  if (!composerIsVisible(composer) || composer.dataset.agentRunning === "true") return false;
+  const agent = findAgent(composer.dataset.agentKey);
+  const prompt = composer.querySelector("#prompt-input");
+  return Boolean(agent && prompt && !prompt.disabled && !agentIsRunning(agent));
+}
+
+function speechTargetComposer() {
+  if (els.quickAgentDialog?.open || els.confirmationDialog?.open) return null;
+  const openDialog = Array.from(document.querySelectorAll("dialog[open], [role='dialog']"))
+    .find((dialog) => dialog.getClientRects().length > 0);
+  if (openDialog && !openDialog.matches("[data-composer-modal]")) return null;
+  const activeComposer = document.activeElement?.closest?.("#composer");
+  if (speechEligibleComposer(activeComposer)) return activeComposer;
+
+  const visible = Array.from(els.view.querySelectorAll("#composer")).filter(speechEligibleComposer);
+  if (visible.length === 1) return visible[0];
+
+  const route = parseRoute();
+  return visible.find((composer) => composer.dataset.agentKey === route?.key) || null;
+}
+
+function insertSpeechTranscript(input, transcript) {
+  const value = input.value || "";
+  const start = input.selectionStart ?? value.length;
+  const end = input.selectionEnd ?? start;
+  const spacing = start > 0 && !/\s$/.test(value.slice(0, start)) ? " " : "";
+  input.value = `${value.slice(0, start)}${spacing}${transcript}${value.slice(end)}`;
+  const cursor = start + spacing.length + transcript.length;
+  input.setSelectionRange(cursor, cursor);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function stopSpeechMode() {
+  const recognition = state.speechRecognition;
+  state.speechRecognition = null;
+  state.speechComposerKey = "";
+  recognition?.stop();
+  document.querySelectorAll("[data-toggle-speech-mode]").forEach((button) => {
+    button.textContent = "Speech";
+    button.setAttribute("aria-label", `Start speech mode (${speechModeShortcutLabel()})`);
+    button.setAttribute("aria-pressed", "false");
+  });
+}
+
+function startSpeechMode(composer) {
+  if (!speechEligibleComposer(composer) || !speechModeAvailable()) return false;
+  if (state.speechComposerKey === composer.dataset.agentKey) {
+    stopSpeechMode();
+    return true;
+  }
+
+  stopSpeechMode();
+  const input = composer.querySelector("#prompt-input");
+  const Recognition = speechRecognitionConstructor();
+  const recognition = new Recognition();
+  recognition.continuous = true;
+  recognition.interimResults = false;
+  recognition.onresult = (event) => {
+    const transcript = Array.from(event.results)
+      .slice(event.resultIndex)
+      .filter((result) => result.isFinal)
+      .map((result) => result[0]?.transcript || "")
+      .join(" ")
+      .trim();
+    if (transcript && input.isConnected) insertSpeechTranscript(input, transcript);
+  };
+  recognition.onend = () => {
+    if (state.speechRecognition === recognition) stopSpeechMode();
+  };
+  recognition.onerror = () => {
+    if (state.speechRecognition === recognition) stopSpeechMode();
+  };
+  state.speechRecognition = recognition;
+  state.speechComposerKey = composer.dataset.agentKey;
+  input.focus({ preventScroll: true });
+  recognition.start();
+  return true;
+}
+
+function handleSpeechModeShortcut(event) {
+  if (!speechModeShortcut(event) || event.repeat || event.isComposing) return false;
+  if (isTextEntryFocused() && !document.activeElement?.closest?.("#composer")) return false;
+  const composer = speechTargetComposer();
+  if (!composer || !speechModeAvailable()) return false;
+  event.preventDefault();
+  return startSpeechMode(composer);
 }
 
 function touchKeyboardLikely() {
@@ -11574,6 +11698,12 @@ els.view.addEventListener("click", (event) => {
     return;
   }
 
+  const speechModeToggle = event.target.closest("[data-toggle-speech-mode]");
+  if (speechModeToggle) {
+    startSpeechMode(speechModeToggle.closest("#composer"));
+    return;
+  }
+
   const composerFullScreenToggle = event.target.closest("[data-toggle-composer-full-screen]");
   if (composerFullScreenToggle) {
     const key = composerFullScreenToggle.dataset.toggleComposerFullScreen;
@@ -14029,6 +14159,8 @@ if (els.confirmationDialog) {
 
 document.addEventListener("keydown", (event) => {
   if (shortcutModifierKey(event)) setShortcutModifierActive(true);
+
+  if (handleSpeechModeShortcut(event)) return;
 
   if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "k") {
     event.preventDefault();

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1231,8 +1231,11 @@ function findAttachmentResource(id) {
 }
 
 function platformShortcutModifier() {
-  const platform = window.navigator.platform || "";
-  return /Mac|iPhone|iPad|iPod/.test(platform) ? "Cmd" : "Ctrl";
+  return macPlatform() ? "Cmd" : "Ctrl";
+}
+
+function macPlatform() {
+  return /Mac|iPhone|iPad|iPod/.test(window.navigator.platform || "");
 }
 
 function agentSwitcherShortcutLabel() {
@@ -1252,8 +1255,7 @@ function speechModeAvailable() {
 }
 
 function speechModeShortcut(event) {
-  const macPlatform = /Mac|iPhone|iPad|iPod/.test(window.navigator.platform || "");
-  const primaryModifier = macPlatform ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
+  const primaryModifier = macPlatform() ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
   return primaryModifier && event.shiftKey && !event.altKey && event.code === "Period";
 }
 
@@ -5673,10 +5675,17 @@ function stopSpeechMode() {
   state.speechRecognition = null;
   state.speechComposerKey = "";
   recognition?.stop();
+  updateSpeechModeControls();
+}
+
+function updateSpeechModeControls() {
   document.querySelectorAll("[data-toggle-speech-mode]").forEach((button) => {
-    button.textContent = "Speech";
-    button.setAttribute("aria-label", `Start speech mode (${speechModeShortcutLabel()})`);
-    button.setAttribute("aria-pressed", "false");
+    const active = button.closest("#composer")?.dataset.agentKey === state.speechComposerKey;
+    const label = active ? "Stop speech mode" : "Start speech mode";
+    button.textContent = active ? "Listening" : "Speech";
+    button.setAttribute("aria-label", `${label} (${speechModeShortcutLabel()})`);
+    button.setAttribute("title", `${label} (${speechModeShortcutLabel()})`);
+    button.setAttribute("aria-pressed", active ? "true" : "false");
   });
 }
 
@@ -5711,8 +5720,15 @@ function startSpeechMode(composer) {
   state.speechRecognition = recognition;
   state.speechComposerKey = composer.dataset.agentKey;
   input.focus({ preventScroll: true });
-  recognition.start();
-  return true;
+  try {
+    recognition.start();
+    updateSpeechModeControls();
+    return true;
+  } catch (_error) {
+    stopSpeechMode();
+    showGrowl("Speech recognition could not start in this browser", "need");
+    return false;
+  }
 }
 
 function handleSpeechModeShortcut(event) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4470,6 +4470,8 @@ module RemoteServerTest
            "expected Agent detail composer action to switch by running state")
     assert(js[:body].include?("function speechModeShortcutLabel"),
            "expected Remote UI to expose a platform-aware speech shortcut label")
+    assert(js[:body].include?("function macPlatform"),
+           "expected platform detection to be shared by speech and existing shortcut labels")
     assert(js[:body].include?("return `${platformShortcutModifier()}+Shift+.`;"),
            "expected speech mode to use Cmd/Ctrl+Shift+. rather than a browser-reserved shortcut")
     assert(js[:body].include?("function handleSpeechModeShortcut"),
@@ -4486,6 +4488,8 @@ module RemoteServerTest
            "expected speech shortcut to defer to every other visible dialog")
     assert(js[:body].include?("function startSpeechMode(composer)"),
            "expected the visible Speech control and shortcut to share one activation path")
+    assert(js[:body].include?("function updateSpeechModeControls"),
+           "expected active Speech controls to update without waiting for a full render")
     assert(js[:body].include?("data-toggle-speech-mode"),
            "expected composers to expose a discoverable Speech mode control")
     assert(js[:body].include?("aria-keyshortcuts="),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4468,6 +4468,28 @@ module RemoteServerTest
            "expected Skill toggle to be disabled while the agent is running")
     assert(js[:body].include?("function agentComposerAction"),
            "expected Agent detail composer action to switch by running state")
+    assert(js[:body].include?("function speechModeShortcutLabel"),
+           "expected Remote UI to expose a platform-aware speech shortcut label")
+    assert(js[:body].include?("return `${platformShortcutModifier()}+Shift+.`;"),
+           "expected speech mode to use Cmd/Ctrl+Shift+. rather than a browser-reserved shortcut")
+    assert(js[:body].include?("function handleSpeechModeShortcut"),
+           "expected a document-level speech-mode shortcut handler")
+    assert(js[:body].include?("event.repeat || event.isComposing"),
+           "expected speech shortcut to ignore held keys and IME composition")
+    assert(js[:body].include?("isTextEntryFocused() && !document.activeElement?.closest?.(\"#composer\")"),
+           "expected speech shortcut not to hijack other text inputs or contenteditable controls")
+    assert(js[:body].include?("function speechTargetComposer"),
+           "expected speech shortcut to select an eligible visible composer")
+    assert(js[:body].include?("els.quickAgentDialog?.open || els.confirmationDialog?.open"),
+           "expected speech shortcut to defer to open dialogs")
+    assert(js[:body].include?("dialog[open], [role='dialog']"),
+           "expected speech shortcut to defer to every other visible dialog")
+    assert(js[:body].include?("function startSpeechMode(composer)"),
+           "expected the visible Speech control and shortcut to share one activation path")
+    assert(js[:body].include?("data-toggle-speech-mode"),
+           "expected composers to expose a discoverable Speech mode control")
+    assert(js[:body].include?("aria-keyshortcuts="),
+           "expected Speech mode control to expose its shortcut to assistive technology")
     assert(js[:body].include?('class="danger ui-button" data-variant="danger" type="button" data-agent-action="stop" data-agent-key="${escapeAttr(agent.key)}">Stop agent'),
            "expected running agents to replace Send prompt with Stop agent")
     assert(js[:body].include?('enterkeyhint="enter"'),


### PR DESCRIPTION
Implements Fizzy #127.

Adds the documented Cmd/Ctrl+Shift+. shortcut, a discoverable Speech control, safe composer targeting, and isolated desktop-browser coverage.

Validation: `bin/test`, `bundle exec ruby test/remote_server_test.rb`, `bin/remote-ui-smoke`, syntax checks, `git diff --check`, and gitleaks.