### PR TITLE
Add auditable session usage and cost metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Runtime artifacts are written to `~/.tycho/logs/`, including app state files suc
 - `bundle exec bin/tycho serve [--host 127.0.0.1] [--port 7373]`: start the local Remote Sessions JSON API and web UI for managed-agent control.
 - `bundle exec bin/tycho project <key> [options]` and `project create|show|update|archive`: manage project configuration from the CLI.
 - `bundle exec bin/tycho schedule [list|daemon --once|daemon --dry-run]`: list schedules, run the scheduled-agent daemon, or run a single scheduler tick.
+- `bundle exec bin/tycho metrics query [filters] [--json]` and `metrics backfill [--timezone ZONE]`: query or idempotently rebuild normalized run/native-session usage metrics.
 - `bin/test`: run the public CI-equivalent Ruby syntax and regression suite.
 - `bin/remote-ui-smoke`: start a throwaway Remote UI server with temp config/log roots, create a fixture agent, and run a Chrome/Playwright smoke check for composer refresh preservation and mobile dock layout.
 - `bundle exec ruby -c bin/tycho`: syntax-check the main executable before opening a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Domain and process-management code lives under `lib/hq/domain/`:
 - `project.rb` represents a configured project and handles workspace and git metadata.
 - `managed_agent.rb` manages Codex and Claude-compatible agent execution, logs, messages, structured results, and inquiry state.
 - `agent_store.rb` persists managed agents.
+- `usage_metrics.rb` exposes versioned, idempotent managed-run/native-session metrics, provider normalization, query, and backfill through focused files under `usage_metrics/`.
 - `agent_log_parser.rb` parses raw Codex JSON streams and `chat.log` blocks into conversation, system, and chat entries.
 - `agent_chat_log.rb` builds chat viewport content from two sources: `memory.jsonl` for historical conversation and `raw.log` for live streaming during active runs. It also generates `conversation.log` and `system.log` as human-readable artifacts.
 - `agent_memory.rb` maintains a canonical `*.memory.jsonl` event log per agent, bootstrapping from existing messages and bounding how much history is replayed back into prompts.
@@ -39,6 +40,8 @@ bundle install
 bin/tycho
 bundle exec bin/tycho
 bundle exec bin/tycho project <key> [options]
+bundle exec bin/tycho metrics query [filters] [--json]
+bundle exec bin/tycho metrics backfill [--timezone ZONE]
 bin/test
 bundle exec ruby -c bin/tycho
 bundle exec ruby test/registry_test.rb

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Homebrew and source installs use the same user-scoped defaults:
 | Runtime state and logs | `~/.tycho/logs/` |
 | Project logs | `~/.tycho/logs/projects/` |
 | Agent logs and artifacts | `~/.tycho/logs/agents/` |
+| Normalized usage metrics | `~/.tycho/logs/usage_metrics.json` |
 | Browser push state | `~/.tycho/logs/push_*.json` and `~/.tycho/logs/web_push_vapid.json` |
 | GitHub App session | `~/.tycho/config/github_auth.json` with mode `0600` |
 
@@ -373,6 +374,18 @@ in v0.11.0. `--json` is supported by project list/show and every agent command
 above. Errors distinguish unknown server keys, missing external sources,
 origin changes, unreachable servers, timeouts, rejected credentials,
 unsupported endpoints, and other Remote API responses without printing tokens.
+
+Query normalized run, native-session, token, and estimated-cost metrics without
+scanning raw logs:
+
+```bash
+tycho metrics backfill --timezone Asia/Jakarta
+tycho metrics query --from 2026-07-06 --to 2026-08-07 --timezone Asia/Jakarta
+tycho metrics query --server vps --from 2026-07-06 --to 2026-08-07 --timezone UTC --json
+```
+
+Ranges are start-inclusive and end-exclusive. Unknown telemetry and prices stay
+unknown rather than becoming zero. See [Usage metrics](docs/USAGE_METRICS.md).
 
 The Remote UI always includes the local server and combines agents and projects
 from every configured peer into the same Agents list. Use the server filter to

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -31,6 +31,7 @@ Key references:
 - [WEB_PUSH_PLAN.md](./WEB_PUSH_PLAN.md) — planned browser push notifications for Remote UI, including the hard HTTPS-over-Tailscale requirement.
 - [SCHEDULED_RUNS.md](./SCHEDULED_RUNS.md) — planned cron-like scheduled runs, `tycho schedule daemon`, command targets, and prompt/message tradeoffs.
 - [MODEL_ARGUMENTS_PLAN.md](./MODEL_ARGUMENTS_PLAN.md) — planned managed-agent `model` and `reasoning_effort` configuration, command mapping, and TUI/Remote UI display.
+- [USAGE_METRICS.md](./USAGE_METRICS.md) — normalized run/native-session schema, provider cost semantics, query/backfill operations, archive behavior, and recovery.
 
 ## Key Decisions
 
@@ -71,6 +72,7 @@ Key references:
 | Scheduled runs | Dedicated `tycho schedule daemon`, definitions in `~/.tycho/config/schedules.yml`, runtime state in `~/.tycho/logs/schedules.json`, validated standard cron syntax | Scheduled work should continue independently from the TUI and Remote UI while still reusing existing agent execution paths |
 | Temporary session loops | Remote UI can adopt an idle conversation as a normal recurring schedule, run it immediately with schedule context, and stop it at a configured cutoff | Review-waiting sessions need lightweight polling without losing their existing context or creating a separate agent |
 | Run cost provenance | Persist harness and model on each managed-agent run; raw-log cost rebuilds use that per-run metadata and leave legacy runs unpriced when provenance is missing | Historical estimates must not silently apply the agent's current model price to older runs |
+| Usage metrics | Persist idempotent v1 run records and provider-scoped native-session aggregates in one atomic, locked store; normalize Codex cumulative counters and Claude-compatible per-run/modelUsage telemetry; query active and archived history through the same CLI/API module | Historical reporting must remain auditable without raw-log joins, guessed prices/models/session IDs, or conflating runs, native sessions, and managed agents |
 | Schedule daemon freshness | `tycho schedule daemon` writes heartbeat state to `~/.tycho/logs/scheduler_daemon.json`; UI surfaces derive running/stale/stopped from heartbeat age and process liveness, and report untracked running daemons without heartbeat state | Users need to know whether cron work is actually ticking, not only whether definitions are valid |
 | Schedule command scope | Agent-only schedules; each schedule owns one persistent managed agent session and accepts only inline messages or files under `schedules/` | Preserve recurring context without adding arbitrary shell execution or loose existing-agent targets |
 | Schedule statuses | Schedules expose `scheduled`, `paused`, or `stopped`; last outcome and error reason are tracked separately. `no_action_needed` is reserved for observational checks where no action was necessary, while completed actions and deliverables use `success` | Keep healthy no-op checks quiet without hiding meaningful completed work from unread state and notifications |
@@ -290,7 +292,7 @@ verify the bottle.
 
 ### Observability
 
-- [ ] Structured event metrics for agent run timings and lifecycle events
+- [x] Structured run/native-session usage, cost, timing, completeness, and lifecycle metrics
 - [ ] In-app log filter / search for `~/.tycho/logs/hq.log`
 - [ ] Agent run timeline view
 
@@ -356,6 +358,7 @@ verify the bottle.
 - [x] Finalized-run estimated session-cost snapshots on latest and historical Summary pages, including Codex token-delta estimates from an auditable OpenAI model rate card, explicit rebuild backfill, and no startup log scan
 - [ ] Dedicated mobile activity/log detail page
 - [x] Full mobile agent create/edit form
+- [x] First-class run/native-session usage metrics, idempotent historical backfill, archive manifests, and CLI/Remote API reporting
 
 ## Known Issues
 

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -402,6 +402,8 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | `POST` | `/agents/{key}/clone` | Clone one managed agent, optionally archiving the source. |
 | `POST` | `/agents/{key}/archive` | Archive one idle managed agent. |
 | `POST` | `/agents/{key}/loop-schedule` | Adopt one idle agent as a temporary recurring schedule and run it immediately. |
+| `GET` | `/metrics` | Query normalized run and native-session metrics with inclusive `from`, exclusive `to`, timezone, and attribution filters. |
+| `POST` | `/metrics/backfill` | Idempotently backfill metrics from durable manifests and optional legacy raw telemetry. |
 | `GET` | `/settings/session-loops` | Read Loop session interval, cutoff, and prompt-template defaults. |
 | `PATCH` | `/settings/session-loops` | Save Loop session defaults in `hq.yml`. |
 | `GET` | `/push/config` | Read browser push readiness and VAPID public key. |

--- a/docs/USAGE_METRICS.md
+++ b/docs/USAGE_METRICS.md
@@ -30,11 +30,11 @@ Writes take an exclusive file lock and use a mode-`0600`, fsynced atomic rename 
 
 ## Provider and cost semantics
 
-Codex `turn.completed.usage` is cumulative inside a native session. Tycho stores the raw cumulative counters, sorts runs by stable start/identity, and derives each run from the preceding snapshot. A missing baseline, incomplete snapshot, or decreasing counter makes that run's token delta and price unknown; Tycho does not clamp or substitute zero.
+Codex `turn.completed.usage` is cumulative inside a native session. Tycho stores the raw cumulative counters, sorts runs by stable start/identity, and derives each run from the preceding snapshot. A missing baseline, incomplete snapshot, decreasing counter, or trimmed manifest history makes that run's token delta and price unknown; Tycho does not clamp or substitute zero.
 
 Claude-compatible `result` events are per-run. Tycho stores `total_cost_usd`, usage counters, and every exact `modelUsage` entry independently of the configured model. A session may therefore retain a configured alias and multiple observed models. OpenCode step costs are summed per run.
 
-All stored monetary values use `semantics: estimate_not_invoice`. Harness-reported costs remain harness estimates. Codex uses the versioned OpenAI list-price table in `OpenAIModelPricing`. Missing models, prices, token counters, session IDs, or telemetry remain `null` with a reason. `known_estimated_cost_usd` sums priced runs, while median and maximum session cost include only sessions whose runs are both fully priced and complete.
+All stored monetary values use `semantics: estimate_not_invoice`. Harness-reported costs remain harness estimates. Codex uses the versioned OpenAI list-price table in `OpenAIModelPricing`. Missing models, prices, token counters, session IDs, or telemetry remain `null` with a reason. `known_estimated_cost_usd` sums priced runs, while median and maximum session cost include sessions only when every run has a known cost. Missing non-cost metadata does not hide an otherwise fully priced session.
 
 ## Query and backfill
 

--- a/docs/USAGE_METRICS.md
+++ b/docs/USAGE_METRICS.md
@@ -1,0 +1,72 @@
+---
+name: USAGE_METRICS
+description: Normalized managed-run and native-session usage metrics
+type: reference
+---
+
+# Usage metrics
+
+Tycho writes one normalized record when a managed run finalizes. The public entry point is `HQ::UsageMetrics`; callers do not parse raw harness logs or inspect active and archived agent trees themselves.
+
+## Storage and identity
+
+The owner-readable store is `~/.tycho/logs/usage_metrics.json`. Its root schema is versioned:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-08T00:00:00.000000Z",
+  "runs": { "<stable-run-id>": {} },
+  "sessions": { "<provider-scoped-session-key>": {} },
+  "recovery": { "discarded_run_count": 0, "warnings": [] }
+}
+```
+
+New runs persist a UUID in the managed-agent manifest. Legacy runs use a deterministic v1 identity derived from the durable agent identity, start time, log offset, and a hashed source reference. Upserts replace the same identity and rebuild affected derived values, so finalization, retrying a backfill, or resuming a native session cannot duplicate a run.
+
+Each run keeps project/group/agent attribution, exact harness plus adapter, configured model, observed models, per-model attribution, native session ID when reported, UTC start/finish, duration, status, token counters, estimated cost, price source/version, completeness, inference, unknown reasons, and sanitized provenance hashes. Provenance never stores prompts, credentials, tool inputs, tool outputs, or raw paths. Query output follows the same rule.
+
+Writes take an exclusive file lock and use a mode-`0600`, fsynced atomic rename with a backup. Reads take a shared lock. Schema 0 records migrate to schema 1 in memory; unsupported future versions fail explicitly. If the primary JSON is truncated, Tycho reads the last atomic backup and reports recovery. Invalid records inside an otherwise valid document are discarded and counted rather than silently converted.
+
+## Provider and cost semantics
+
+Codex `turn.completed.usage` is cumulative inside a native session. Tycho stores the raw cumulative counters, sorts runs by stable start/identity, and derives each run from the preceding snapshot. A missing baseline, incomplete snapshot, or decreasing counter makes that run's token delta and price unknown; Tycho does not clamp or substitute zero.
+
+Claude-compatible `result` events are per-run. Tycho stores `total_cost_usd`, usage counters, and every exact `modelUsage` entry independently of the configured model. A session may therefore retain a configured alias and multiple observed models. OpenCode step costs are summed per run.
+
+All stored monetary values use `semantics: estimate_not_invoice`. Harness-reported costs remain harness estimates. Codex uses the versioned OpenAI list-price table in `OpenAIModelPricing`. Missing models, prices, token counters, session IDs, or telemetry remain `null` with a reason. `known_estimated_cost_usd` sums priced runs, while median and maximum session cost include only sessions whose runs are both fully priced and complete.
+
+## Query and backfill
+
+Query a local or configured remote Tycho server:
+
+```bash
+tycho metrics query \
+  --from 2026-07-06 \
+  --to 2026-08-07 \
+  --timezone Asia/Jakarta \
+  --project tycho \
+  --harness codex,claude \
+  --json
+
+tycho metrics query --server vps --from 2026-07-06 --to 2026-08-07 --timezone UTC
+```
+
+`from` is inclusive and `to` is exclusive. Offset-free dates/times require the named IANA timezone; values with `Z` or an explicit numeric offset are absolute. Filters accept comma-separated values for group, project, agent, harness, configured/observed model, and status.
+
+The Remote API equivalents are `GET /metrics` with the same query parameters and `POST /metrics/backfill`.
+
+Backfill is best effort and idempotent:
+
+```bash
+tycho metrics backfill --timezone Asia/Jakarta --json
+tycho metrics backfill --durable-only --json
+```
+
+Backfill reads active and archived manifests first. Legacy raw telemetry is an optional fallback and requires an explicit timezone for offset-free historical headers. It preserves exact emitted IDs/models/prices, labels fields inferred from deterministic filenames or event shapes, assigns a stable anonymous identity when no agent manifest exists, and never guesses a model, price, or session ID. Repeating the command should report every prior record as unchanged.
+
+## Archive and recovery
+
+Agent and project archive operations keep global metrics in place and mark matching records `archived: true`, so active and archived runs use one query path and totals do not move. Each agent archive also receives `agent_manifest.json` and a v1 `usage_metrics.json` snapshot beside its logs. The manifest preserves the exact harness/model/run attribution present at archive time.
+
+If a write is interrupted, rerun the query and inspect the top-level `recovery` object. A backup-recovery warning means the last atomic primary was invalid; rerun `metrics backfill` to restore any missing finalized records. For an unsupported schema version, preserve the primary and backup, upgrade Tycho, and do not hand-edit unknown monetary or model fields into place.

--- a/docs/reports/usage-2026-07-06-to-2026-08-06.md
+++ b/docs/reports/usage-2026-07-06-to-2026-08-06.md
@@ -23,17 +23,17 @@ The checked-in query envelope and exact summary are in [usage-2026-07-06-to-2026
 | Managed agents | 193 |
 | Distinct native sessions | 193 |
 | Runs without a native session ID | 72 |
-| Average runs per native session | 11.56 |
+| Average runs per native session | 11.19 |
 | Known estimated cost | $2,850.0494 |
 | Priced runs | 1,499 |
 | Unpriced runs | 733 |
 | Priced run coverage | 67.2% |
-| Complete priced sessions | 2 |
-| Incomplete or unpriced sessions | 191 |
-| Median complete session cost | $4.4468 |
-| Maximum complete session cost | $8.2458 |
+| Fully priced sessions | 93 |
+| Unpriced or partially priced sessions | 100 |
+| Median priced session cost | $6.8795 |
+| Maximum priced session cost | $407.1918 |
 
-Costs are estimates, not invoices. The known total sums runs with a reported or reproducibly priced estimate. Median and maximum exclude every unpriced or otherwise incomplete session; only two sessions meet that stricter standard.
+Costs are estimates, not invoices. The known total sums runs with a reported or reproducibly priced estimate. Median and maximum include a session only when every run has a known cost; missing non-cost metadata does not exclude a priced session. Average runs per session counts only the 2,160 starts associated with a native session, not the 72 orphan starts.
 
 ## Provider coverage
 

--- a/docs/reports/usage-2026-07-06-to-2026-08-06.md
+++ b/docs/reports/usage-2026-07-06-to-2026-08-06.md
@@ -1,0 +1,57 @@
+# Managed-agent usage: 2026-07-06 through 2026-08-06
+
+This report covers calendar dates July 6 through August 6 in `Asia/Jakarta`, expressed as the half-open interval `[2026-07-06, 2026-08-07)`. It was rebuilt after an idempotent historical backfill and queries only the normalized metrics interface. The reporting query does not scan raw logs.
+
+Reproduce it with:
+
+```bash
+bundle exec bin/tycho metrics backfill --timezone Asia/Jakarta --json
+bundle exec bin/tycho metrics query \
+  --from 2026-07-06 \
+  --to 2026-08-07 \
+  --timezone Asia/Jakarta \
+  --json
+```
+
+The checked-in query envelope and exact summary are in [usage-2026-07-06-to-2026-08-06.query.json](./usage-2026-07-06-to-2026-08-06.query.json).
+
+## Summary
+
+| Measure | Result |
+|---|---:|
+| Run starts | 2,232 |
+| Managed agents | 193 |
+| Distinct native sessions | 193 |
+| Runs without a native session ID | 72 |
+| Average runs per native session | 11.56 |
+| Known estimated cost | $2,850.0494 |
+| Priced runs | 1,499 |
+| Unpriced runs | 733 |
+| Priced run coverage | 67.2% |
+| Complete priced sessions | 2 |
+| Incomplete or unpriced sessions | 191 |
+| Median complete session cost | $4.4468 |
+| Maximum complete session cost | $8.2458 |
+
+Costs are estimates, not invoices. The known total sums runs with a reported or reproducibly priced estimate. Median and maximum exclude every unpriced or otherwise incomplete session; only two sessions meet that stricter standard.
+
+## Provider coverage
+
+| Adapter | Runs | Native sessions | Priced runs | Known estimated cost |
+|---|---:|---:|---:|---:|
+| Claude-compatible | 1,480 | 97 | 1,472 | $2,823.9456 |
+| Codex | 669 | 90 | 19 | $25.9040 |
+| OpenCode | 8 | 3 | 8 | $0.1998 |
+| Unknown harness | 75 | 3 | 0 | unknown |
+
+Most unpriced Codex history lacks an archived configured model, so Tycho preserves its token telemetry without choosing a price. The 75 unknown-harness starts have durable timestamps but no provider event shape; 72 also lack a native session ID. They remain run starts with explicit unknown reasons instead of disappearing or becoming zero-cost runs.
+
+## Reconciliation with the prior report
+
+The prior ad-hoc report cited 2,156 run starts and 181 native sessions. The normalized interface reports 2,232 starts and 193 sessions:
+
+- The run count is 76 higher. Seventy-five are telemetry-empty starts that the old provider-event scan omitted; the normalized schema retains them with unknown harness/status/price fields. One residual run reflects a difference in the old scan or its exact cutoff. The prior report artifact is not present in this repository, so attributing that last run would require recreating the old raw-log query; this report deliberately does not do that.
+- The native-session count is 12 higher. Three belong to runs whose exact session IDs survived even though their harness did not. The remaining difference comes from counting exact provider-scoped native IDs rather than using managed-agent or priced-run proxies. Managed-agent count is reported separately to prevent the prior conflation.
+- The earlier finding that archived Claude-compatible history lacked exact configured model labels remains visible as incomplete provenance. Observed `modelUsage` attribution is retained where emitted, but Tycho does not promote it into a guessed configured model or invent a price.
+
+The new figures are reproducible from the persisted v1 metric records. Backfill was rerun after completion and returned zero creates/updates, confirming idempotence.

--- a/docs/reports/usage-2026-07-06-to-2026-08-06.query.json
+++ b/docs/reports/usage-2026-07-06-to-2026-08-06.query.json
@@ -1,0 +1,28 @@
+{
+  "interface": "tycho metrics query",
+  "schema_version": 1,
+  "query": {
+    "from": "2026-07-06",
+    "to": "2026-08-07",
+    "timezone": "Asia/Jakarta",
+    "range_semantics": "from_inclusive_to_exclusive",
+    "filters": {}
+  },
+  "command": "bundle exec bin/tycho metrics query --from 2026-07-06 --to 2026-08-07 --timezone Asia/Jakarta --json",
+  "summary": {
+    "run_starts": 2232,
+    "managed_agents": 193,
+    "distinct_native_sessions": 193,
+    "runs_without_native_session": 72,
+    "average_runs_per_session": 11.564766839378239,
+    "known_estimated_cost_usd": 2850.0493570296,
+    "median_complete_session_cost_usd": 4.446837700000001,
+    "max_complete_session_cost_usd": 8.24582975,
+    "priced_run_count": 1499,
+    "unpriced_run_count": 733,
+    "priced_run_coverage": 0.671594982078853,
+    "complete_priced_session_count": 2,
+    "incomplete_or_unpriced_session_count": 191,
+    "cost_semantics": "estimate_not_invoice"
+  }
+}

--- a/docs/reports/usage-2026-07-06-to-2026-08-06.query.json
+++ b/docs/reports/usage-2026-07-06-to-2026-08-06.query.json
@@ -14,15 +14,15 @@
     "managed_agents": 193,
     "distinct_native_sessions": 193,
     "runs_without_native_session": 72,
-    "average_runs_per_session": 11.564766839378239,
+    "average_runs_per_session": 11.191709844559586,
     "known_estimated_cost_usd": 2850.0493570296,
-    "median_complete_session_cost_usd": 4.446837700000001,
-    "max_complete_session_cost_usd": 8.24582975,
+    "median_priced_session_cost_usd": 6.8794935,
+    "max_priced_session_cost_usd": 407.19176695,
     "priced_run_count": 1499,
     "unpriced_run_count": 733,
     "priced_run_coverage": 0.671594982078853,
-    "complete_priced_session_count": 2,
-    "incomplete_or_unpriced_session_count": 191,
+    "priced_session_count": 93,
+    "unpriced_or_partially_priced_session_count": 100,
     "cost_semantics": "estimate_not_invoice"
   }
 }

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -16,6 +16,7 @@ require_relative "domain/file_store"
 require_relative "domain/github_api_client"
 require_relative "domain/scheduler"
 require_relative "domain/agent_store"
+require_relative "domain/usage_metrics"
 
 module HQ
   module CLICommand
@@ -524,6 +525,54 @@ module HQ
       register "debug", Debug do |prefix|
         prefix.register "claude", DebugClaude
       end
+
+      class Metrics < Dry::CLI::Command
+        desc "Query or backfill usage metrics"
+
+        def call(**)
+          exit CLICommand.usage("Missing metrics command", err: err)
+        end
+      end
+
+      class MetricsQuery < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Query normalized run and native-session usage metrics"
+        option :from, desc: "Inclusive range start (date/time)"
+        option :to, desc: "Exclusive range end (date/time)"
+        option :timezone, default: "UTC", desc: "IANA timezone for offset-free boundaries"
+        option :group, desc: "Group filter (comma-separated)"
+        option :project, desc: "Project filter (comma-separated)"
+        option :agent, desc: "Agent filter (comma-separated)"
+        option :harness, desc: "Harness filter (comma-separated)"
+        option :model, desc: "Configured or observed model filter (comma-separated)"
+        option :status, desc: "Run status filter (comma-separated)"
+        remote_options
+        usage_template "metrics query [--from TIME] [--to TIME] [--timezone ZONE] [filters] [--json]"
+
+        def call(**opts)
+          exit CLICommand.query_metrics(opts, out: out, err: err)
+        end
+      end
+
+      class MetricsBackfill < Dry::CLI::Command
+        extend CommandMetadata
+
+        desc "Idempotently backfill normalized usage metrics"
+        option :timezone, desc: "IANA timezone for legacy offset-free run headers"
+        option :durable_only, type: :boolean, default: false, desc: "Do not inspect legacy raw telemetry"
+        remote_options
+        usage_template "metrics backfill [--timezone ZONE] [--durable-only] [--json]"
+
+        def call(**opts)
+          exit CLICommand.backfill_metrics(opts, out: out, err: err)
+        end
+      end
+
+      register "metrics", Metrics do |prefix|
+        prefix.register "query", MetricsQuery
+        prefix.register "backfill", MetricsBackfill
+      end
     end
 
     PROJECT_COMMANDS = [
@@ -568,6 +617,10 @@ module HQ
     DEBUG_COMMANDS = [
       Commands::DebugClaude
     ].freeze
+    METRICS_COMMANDS = [
+      Commands::MetricsQuery,
+      Commands::MetricsBackfill
+    ].freeze
     COMMAND_NAME = "tycho"
     RUNTIME_COMMANDS = [
       "  #{COMMAND_NAME} serve [daemon] [--host 127.0.0.1] [--port 7373]",
@@ -586,6 +639,7 @@ module HQ
       *SCHEDULE_COMMANDS.map { |command| "  #{COMMAND_NAME} #{format(command.usage_template, schedule_key: "<schedule-key>")}" },
       *GITHUB_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
       *SERVER_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
+      *METRICS_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
       *DEBUG_COMMANDS.map { |command| "  #{COMMAND_NAME} #{command.usage_template}" },
       "",
       "Run without a command to open the interactive Tycho TUI."
@@ -669,6 +723,29 @@ module HQ
       failure(e.message, err:)
     rescue Interrupt
       failure("GitHub login cancelled.", err:)
+    end
+
+    def query_metrics(opts = {}, out: $stdout, err: $stderr)
+      return remote_query_metrics(opts, out:, err:) if remote_requested?(opts)
+
+      result = UsageMetrics.query(metric_filters(opts))
+      print_metrics(result, json: opts[:json], out:)
+      0
+    rescue ArgumentError => e
+      failure(e.message, err:)
+    end
+
+    def backfill_metrics(opts = {}, out: $stdout, err: $stderr)
+      return remote_backfill_metrics(opts, out:, err:) if remote_requested?(opts)
+
+      result = UsageMetrics.backfill({
+        "timezone" => opts[:timezone],
+        "include_raw" => opts[:durable_only] != true
+      })
+      print_backfill(result, json: opts[:json], out:)
+      0
+    rescue ArgumentError, ConfigError => e
+      failure(e.message, err:)
     end
 
     def github_status(out: $stdout, err: $stderr, auth: GitHubAuth.default)
@@ -1505,6 +1582,84 @@ module HQ
 
     def remote_requested?(opts)
       !opts[:server].to_s.strip.empty?
+    end
+
+    def metric_filters(opts)
+      %i[from to timezone group project agent harness model status].each_with_object({}) do |key, result|
+        value = opts[key]
+        result[key.to_s] = value unless value.to_s.strip.empty?
+      end
+    end
+
+    def print_metrics(result, json:, out:)
+      if json
+        out.puts JSON.pretty_generate(result)
+        return
+      end
+
+      summary = result.fetch("summary")
+      rows = [
+        ["Run starts", summary.fetch("run_starts").to_s],
+        ["Managed agents", summary.fetch("managed_agents").to_s],
+        ["Native sessions", summary.fetch("distinct_native_sessions").to_s],
+        ["Average runs/session", format_metric_number(summary["average_runs_per_session"])],
+        ["Known estimated cost", format_metric_cost(summary["known_estimated_cost_usd"])],
+        ["Median complete session", format_metric_cost(summary["median_complete_session_cost_usd"])],
+        ["Maximum complete session", format_metric_cost(summary["max_complete_session_cost_usd"])],
+        ["Priced / unpriced runs", "#{summary.fetch("priced_run_count")} / #{summary.fetch("unpriced_run_count")}"],
+        ["Priced coverage", format_metric_percent(summary["priced_run_coverage"])]
+      ]
+      out.puts agent_table(%w[Metric Value], rows)
+      out.puts "Range: #{result.dig("query", "from") || "unbounded"} <= start < " \
+               "#{result.dig("query", "to") || "unbounded"} (#{result.dig("query", "timezone")})"
+      out.puts "Costs are estimates, not invoices. Unknown and incomplete session costs are excluded from median/max."
+    end
+
+    def print_backfill(result, json:, out:)
+      if json
+        out.puts JSON.pretty_generate(result)
+        return
+      end
+
+      rows = %w[created updated unchanged manifest_run_count raw_fallback_run_count skipped_run_count].map do |key|
+        [key.tr("_", " ").capitalize, result.fetch(key, 0).to_s]
+      end
+      out.puts agent_table(%w[Backfill Count], rows)
+      Array(result["warnings"]).each { |warning| out.puts "Warning: #{warning}" }
+    end
+
+    def format_metric_number(value)
+      value.nil? ? "unknown" : format("%.2f", value)
+    end
+
+    def format_metric_cost(value)
+      value.nil? ? "unknown" : format("$%.4f estimated", value)
+    end
+
+    def format_metric_percent(value)
+      value.nil? ? "unknown" : format("%.1f%%", value * 100)
+    end
+
+    def remote_query_metrics(opts, out:, err:)
+      query = URI.encode_www_form(metric_filters(opts))
+      path = query.empty? ? "/metrics" : "/metrics?#{query}"
+      result = remote_client(opts[:server]).request("GET", path)
+      print_metrics(result, json: opts[:json], out:)
+      0
+    rescue RemoteCLIClient::Error, ArgumentError => e
+      failure(e.message, err:)
+    end
+
+    def remote_backfill_metrics(opts, out:, err:)
+      result = remote_client(opts[:server]).request(
+        "POST",
+        "/metrics/backfill",
+        body: { "timezone" => opts[:timezone], "durable_only" => opts[:durable_only] == true }
+      )
+      print_backfill(result, json: opts[:json], out:)
+      0
+    rescue RemoteCLIClient::Error, ArgumentError => e
+      failure(e.message, err:)
     end
 
     def remote_client(server_key)

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -1604,15 +1604,15 @@ module HQ
         ["Native sessions", summary.fetch("distinct_native_sessions").to_s],
         ["Average runs/session", format_metric_number(summary["average_runs_per_session"])],
         ["Known estimated cost", format_metric_cost(summary["known_estimated_cost_usd"])],
-        ["Median complete session", format_metric_cost(summary["median_complete_session_cost_usd"])],
-        ["Maximum complete session", format_metric_cost(summary["max_complete_session_cost_usd"])],
+        ["Median priced session", format_metric_cost(summary["median_priced_session_cost_usd"])],
+        ["Maximum priced session", format_metric_cost(summary["max_priced_session_cost_usd"])],
         ["Priced / unpriced runs", "#{summary.fetch("priced_run_count")} / #{summary.fetch("unpriced_run_count")}"],
         ["Priced coverage", format_metric_percent(summary["priced_run_coverage"])]
       ]
       out.puts agent_table(%w[Metric Value], rows)
       out.puts "Range: #{result.dig("query", "from") || "unbounded"} <= start < " \
                "#{result.dig("query", "to") || "unbounded"} (#{result.dig("query", "timezone")})"
-      out.puts "Costs are estimates, not invoices. Unknown and incomplete session costs are excluded from median/max."
+      out.puts "Costs are estimates, not invoices. Sessions with any unpriced run are excluded from median/max."
     end
 
     def print_backfill(result, json:, out:)

--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -33,8 +33,11 @@ module HQ
       format(scheduled_system_prompt_template, title:)
     end
 
-    def initialize(projects)
+    def initialize(projects, usage_metrics_store: nil)
       @projects = projects
+      @usage_metrics_store = usage_metrics_store || UsageMetrics.store(
+        path: File.join(File.dirname(AGENTS_FILE), "usage_metrics.json")
+      )
     end
 
     def load
@@ -50,11 +53,14 @@ module HQ
       schedule_keys = schedule_keys_by_agent
       agents = Array(FileStore.read_json(AGENTS_FILE, fallback: [])).map do |hash|
         agent = ManagedAgent.from_hash(hash)
+        agent.usage_metrics_store = @usage_metrics_store
         changed = true if hash != agent.to_hash
         if agent.schedule_key.nil? && schedule_keys.key?(agent.key)
           agent.associate_schedule!(schedule_keys.fetch(agent.key))
           changed = true
         end
+        project = project_for(agent.project_key)
+        changed = agent.reconcile_project_group!(project.group) || changed if project
         before_hash = agent.to_hash
         was_running = running_for_poll_event?(agent)
         agent.poll!
@@ -100,6 +106,7 @@ module HQ
         key: key,
         name: "#{project.name} #{template.name.downcase} #{suffix}",
         project_key: project.key,
+        project_group: project.group,
         template_key: template.key,
         workspace: project.path,
         prompt: template.prompt,
@@ -113,7 +120,7 @@ module HQ
         color_index: next_color_index(existing)
       )
       seed_memory_system_prompts!(agent, project, template.prompt)
-      agent
+      attach_usage_metrics_store(agent)
     end
 
     def create_scheduled(project, schedule_key:, name:, system_message: nil, existing_agents: load)
@@ -125,6 +132,7 @@ module HQ
         key: key,
         name: scheduled_agent_name(project, schedule_key:, name:),
         project_key: project.key,
+        project_group: project.group,
         template_key: "scheduled",
         workspace: project.path,
         prompt: prompt,
@@ -139,7 +147,7 @@ module HQ
         schedule_key: schedule_key
       )
       seed_memory_system_prompts!(agent, project, prompt)
-      agent
+      attach_usage_metrics_store(agent)
     end
 
     def add_scheduled_message!(agent, schedule_key:, message:, due_at: nil)
@@ -158,10 +166,11 @@ module HQ
     def clone_agent(agent, existing_agents: load)
       now = Time.now
       key = next_agent_key(agent.project_key, existing_agents, now:)
-      ManagedAgent.new(
+      attach_usage_metrics_store(ManagedAgent.new(
         key: key,
         name: agent.name,
         project_key: agent.project_key,
+        project_group: agent.project_group,
         template_key: agent.template_key,
         workspace: agent.workspace,
         prompt: agent.prompt,
@@ -173,7 +182,7 @@ module HQ
         response_style: agent.response_style,
         skills: agent.skills,
         color_index: next_color_index(existing_agents)
-      )
+      ))
     end
 
     def ensure_project_context_prompt!(agent, project)
@@ -188,6 +197,11 @@ module HQ
     end
 
     private
+
+    def attach_usage_metrics_store(agent)
+      agent.usage_metrics_store = @usage_metrics_store
+      agent
+    end
 
     def schedule_keys_by_agent
       ScheduleStore.new.load.each_with_object({}) do |(schedule_key, state), result|

--- a/lib/hq/domain/constants.rb
+++ b/lib/hq/domain/constants.rb
@@ -72,6 +72,7 @@ module HQ
 
   LOGS_DIR = USER_LOGS_DIR
   AGENTS_FILE = File.join(LOGS_DIR, "managed_agents.json")
+  USAGE_METRICS_FILE = File.join(LOGS_DIR, "usage_metrics.json")
   REMOTE_RESOURCES_FILE = File.join(LOGS_DIR, "remote_resources.json")
   SCHEDULES_FILE = env_present("SCHEDULES_PATH", default_schedules_path)
   SCHEDULES_STATE_FILE = env_present("SCHEDULES_STATE_PATH", File.join(LOGS_DIR, "schedules.json"))

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -1015,7 +1015,8 @@ module HQ
         file.puts
       end
 
-      record_run!(AgentRun.new(
+      failed_run = record_run!(AgentRun.new(
+        run_id: SecureRandom.uuid,
         started_at: @started_at,
         finished_at: @finished_at,
         exit_code: @last_exit_code,
@@ -1026,6 +1027,14 @@ module HQ
         model: @model,
         log_start_offset: log_start_offset
       ))
+      if @usage_metrics_store
+        UsageMetrics.record_run(
+          agent: self,
+          run: failed_run,
+          usage_entries: [],
+          metrics_store: @usage_metrics_store
+        )
+      end
       @structured_result = nil
       @summary = message
       HQ.logger.warn("Agent") { "Failed to start #{@key}: #{message}" }
@@ -1803,13 +1812,12 @@ module HQ
       usage_entries = system.select { |entry| entry.type == :usage }
       @cost_snapshot = AgentCostSnapshot.advance(agent: self, run:, usage_entries:)
       if @usage_metrics_store
-        metric = UsageMetrics::Normalizer.new(
+        UsageMetrics.record_run(
           agent: self,
           run:,
           usage_entries:,
-          source: "managed_run_finalization"
-        ).record
-        @usage_metrics_store.upsert(metric)
+          metrics_store: @usage_metrics_store
+        )
       end
 
       conversation.each do |entry|

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -16,6 +16,8 @@ require_relative "../parser"
 require_relative "agent_chat_log"
 require_relative "process_liveness"
 require_relative "agent_cost_snapshot"
+require_relative "file_store"
+require_relative "usage_metrics"
 require "digest"
 require "securerandom"
 require "shellwords"
@@ -54,7 +56,7 @@ module HQ
 
     AgentRun = Struct.new(
       :started_at, :finished_at, :exit_code, :status, :log_path, :command, :session_id, :response_style_source,
-      :agent, :model, :log_start_offset,
+      :agent, :model, :log_start_offset, :run_id,
       keyword_init: true
     ) do
       def self.from_hash(hash)
@@ -72,7 +74,8 @@ module HQ
           response_style_source: hash["response_style_source"],
           agent: hash["agent"],
           model: hash["model"],
-          log_start_offset: log_start_offset
+          log_start_offset: log_start_offset,
+          run_id: hash["run_id"]
         )
       end
 
@@ -90,6 +93,7 @@ module HQ
         result["agent"] = agent unless agent.to_s.empty?
         result["model"] = model unless model.to_s.empty?
         result["log_start_offset"] = log_start_offset if log_start_offset.is_a?(Integer) && log_start_offset >= 0
+        result["run_id"] = run_id unless run_id.to_s.empty?
         result
       end
     end
@@ -125,18 +129,23 @@ module HQ
     attr_reader :key, :name, :project_key, :template_key, :workspace, :prompt, :created_at, :started_at,
                 :finished_at, :pid, :last_exit_code, :log_path, :runs, :sandbox_mode, :agent, :messages, :skills,
                 :model, :reasoning_effort, :response_style, :session_id, :session_bootstrapped, :color_index, :summary,
-                :structured_result, :schedule_key, :cost_snapshot
+                :structured_result, :schedule_key, :cost_snapshot, :project_group
     attr_writer :summary, :structured_result, :cost_snapshot
+
+    def usage_metrics_store=(store)
+      @usage_metrics_store = store
+    end
 
     def initialize(key:, name:, project_key:, template_key:, workspace:, prompt:, created_at: nil, started_at: nil,
                    finished_at: nil, pid: nil, last_exit_code: nil, log_path: nil, runs: nil,
                    stop_requested_at: nil, sandbox_mode: "danger-full-access", agent: "codex", messages: nil,
                    model: nil, reasoning_effort: nil, response_style: nil, skills: nil, unread: false, session_id: nil,
                    session_bootstrapped: nil, color_index: nil, summary: nil, structured_result: nil, schedule_key: nil,
-                   cost_snapshot: nil, total_run_count: nil)
+                   cost_snapshot: nil, total_run_count: nil, project_group: nil)
       @key = key
       @name = name
       @project_key = project_key
+      @project_group = project_group.to_s
       @template_key = template_key
       @workspace = workspace
       @prompt = prompt
@@ -199,6 +208,12 @@ module HQ
 
     def self.from_hash(hash)
       runs = Array(hash["runs"]).map { |run| AgentRun.from_hash(run) }
+      runs.each do |run|
+        next unless run.run_id.to_s.empty?
+
+        components = [hash["key"], run.started_at&.utc&.iso8601(6), run.log_start_offset].map(&:to_s)
+        run.run_id = Digest::SHA256.hexdigest("usage-run-v1\0#{components.join("\0")}")
+      end
       launch_settings = launch_settings_from_runs(runs)
       model = hash["model"].to_s.strip.empty? ? launch_settings[:model] : hash["model"]
       reasoning_effort = if hash["reasoning_effort"].to_s.strip.empty?
@@ -235,7 +250,8 @@ module HQ
         structured_result: hash["structured_result"],
         schedule_key: hash["schedule_key"],
         cost_snapshot: hash["cost_snapshot"],
-        total_run_count: hash["total_run_count"]
+        total_run_count: hash["total_run_count"],
+        project_group: hash["project_group"]
       )
     end
 
@@ -359,6 +375,7 @@ module HQ
       result["structured_result"] = @structured_result if @structured_result.is_a?(Hash) && !@structured_result.empty?
       result["schedule_key"] = @schedule_key unless @schedule_key.to_s.empty?
       result["cost_snapshot"] = @cost_snapshot if @cost_snapshot.is_a?(Hash) && !@cost_snapshot.empty?
+      result["project_group"] = @project_group unless @project_group.empty?
       result
     end
 
@@ -372,6 +389,14 @@ module HQ
 
     def associate_schedule!(schedule_key)
       @schedule_key = normalize_schedule_key(schedule_key)
+    end
+
+    def reconcile_project_group!(value)
+      normalized = value.to_s
+      return false if @project_group == normalized
+
+      @project_group = normalized
+      true
     end
 
     def display_name
@@ -449,7 +474,8 @@ module HQ
         response_style_source: response_style_source,
         agent: @agent,
         model: @model,
-        log_start_offset: log_start_offset
+        log_start_offset: log_start_offset,
+        run_id: SecureRandom.uuid
       ))
       @structured_result = nil
       @summary = nil
@@ -623,13 +649,18 @@ module HQ
 
     def archive_logs!(root = AGENT_ARCHIVE_DIR)
       present = log_files.select { |path| File.exist?(path) }
-      return nil if present.empty?
-
       destination = LogPaths.agent_archive_destination(root, @key)
       FileUtils.mkdir_p(destination)
       present.each do |path|
         FileUtils.mv(path, File.join(destination, File.basename(path)))
       end
+      @usage_metrics_store&.mark_agent_archived(@key)
+      FileStore.write_json(File.join(destination, "agent_manifest.json"), to_hash)
+      archived_metrics = Array(@usage_metrics_store&.runs).select { |record| record["agent_key"] == @key }
+      FileStore.write_json(
+        File.join(destination, "usage_metrics.json"),
+        { "schema_version" => UsageMetrics::Store::SCHEMA_VERSION, "runs" => archived_metrics }
+      )
       destination
     end
 
@@ -1771,6 +1802,15 @@ module HQ
       conversation, system = Parser.parse_stream(current_run_log_lines, agent_type: @agent)
       usage_entries = system.select { |entry| entry.type == :usage }
       @cost_snapshot = AgentCostSnapshot.advance(agent: self, run:, usage_entries:)
+      if @usage_metrics_store
+        metric = UsageMetrics::Normalizer.new(
+          agent: self,
+          run:,
+          usage_entries:,
+          source: "managed_run_finalization"
+        ).record
+        @usage_metrics_store.upsert(metric)
+      end
 
       conversation.each do |entry|
         next unless entry.role == "assistant"

--- a/lib/hq/domain/project_archiver.rb
+++ b/lib/hq/domain/project_archiver.rb
@@ -59,6 +59,7 @@ module HQ
         @registry.path,
         @registry.archived_projects_path,
         AGENTS_FILE,
+        File.join(File.dirname(AGENTS_FILE), "usage_metrics.json"),
         SCHEDULES_FILE,
         SCHEDULES_STATE_FILE
       ]
@@ -84,6 +85,8 @@ module HQ
           FileUtils.mkdir_p(File.dirname(path))
           FileUtils.mv(archived, path)
         end
+        FileUtils.rm_f(File.join(destination, "agent_manifest.json"))
+        FileUtils.rm_f(File.join(destination, "usage_metrics.json"))
         Dir.rmdir(destination) if Dir.exist?(destination) && Dir.empty?(destination)
       end
     end

--- a/lib/hq/domain/usage_metrics.rb
+++ b/lib/hq/domain/usage_metrics.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "usage_metrics/store"
+require_relative "usage_metrics/normalizer"
+require_relative "usage_metrics/query"
+
+module HQ
+  module UsageMetrics
+    module_function
+
+    def store(path: USAGE_METRICS_FILE, lock_path: nil)
+      Store.new(path:, lock_path:)
+    end
+
+    def record_run(agent:, run:, usage_entries:, source: "managed_run_finalization", inference: {})
+      record = Normalizer.new(agent:, run:, usage_entries:, source:, inference:).record
+      store.upsert(record)
+      record
+    end
+
+    def query(filters = {}, metrics_store: store)
+      Query.new(metrics_store:).call(filters)
+    end
+
+    def backfill(options = {}, metrics_store: store)
+      require_relative "usage_metrics/backfill"
+      Backfill.new(metrics_store:).call(options)
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics.rb
+++ b/lib/hq/domain/usage_metrics.rb
@@ -12,9 +12,9 @@ module HQ
       Store.new(path:, lock_path:)
     end
 
-    def record_run(agent:, run:, usage_entries:, source: "managed_run_finalization", inference: {})
+    def record_run(agent:, run:, usage_entries:, source: "managed_run_finalization", inference: {}, metrics_store: store)
       record = Normalizer.new(agent:, run:, usage_entries:, source:, inference:).record
-      store.upsert(record)
+      metrics_store.upsert(record)
       record
     end
 

--- a/lib/hq/domain/usage_metrics/backfill.rb
+++ b/lib/hq/domain/usage_metrics/backfill.rb
@@ -1,0 +1,397 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "time"
+
+require_relative "../file_store"
+require_relative "../log_paths"
+require_relative "../managed_agent"
+require_relative "../../parser"
+require_relative "../../registry"
+require_relative "query"
+
+module HQ
+  module UsageMetrics
+    class Backfill
+      Segment = Struct.new(:started_at, :start_offset, :lines, :index, keyword_init: true)
+      HistoricalAgent = Struct.new(
+        :key, :project_key, :project_group, :agent, :model, :session_id, :runs,
+        keyword_init: true
+      )
+
+      def initialize(metrics_store:)
+        @metrics_store = metrics_store
+      end
+
+      def call(options = {})
+        options = stringify(options || {})
+        @registry = options["registry"] || Registry.new
+        @projects = @registry.projects
+        @timezone = options["timezone"].to_s
+        @include_raw = options.fetch("include_raw", true) != false
+        @stats = Hash.new(0)
+        @warnings = []
+        @records = []
+
+        manifests = durable_manifests(options)
+        claimed = ingest_manifests(manifests)
+        ingest_raw_fallback(claimed, options) if @include_raw
+        @metrics_store.upsert_many(@records).each { |outcome, count| @stats[outcome] += count }
+
+        {
+          "status" => "success",
+          "created" => @stats[:created],
+          "updated" => @stats[:updated],
+          "unchanged" => @stats[:unchanged],
+          "manifest_run_count" => @stats[:manifest_runs],
+          "raw_fallback_run_count" => @stats[:raw_runs],
+          "skipped_run_count" => @stats[:skipped],
+          "warnings" => @warnings.uniq
+        }
+      end
+
+      private
+
+      def durable_manifests(options)
+        explicit = options["manifests"]
+        return Array(explicit) if explicit
+
+        manifests = []
+        if File.exist?(AGENTS_FILE)
+          Array(FileStore.read_json(AGENTS_FILE, fallback: [])).each do |hash|
+            manifests << { "agent" => ManagedAgent.from_hash(hash), "archived" => false, "directory" => nil }
+          end
+        end
+        Dir.glob(File.join(AGENT_ARCHIVE_DIR, "*", "agent_manifest.json")).sort.each do |path|
+          hash = FileStore.read_json(path, fallback: nil)
+          next unless hash.is_a?(Hash)
+
+          manifests << {
+            "agent" => ManagedAgent.from_hash(hash),
+            "archived" => true,
+            "directory" => File.dirname(path)
+          }
+        end
+        manifests
+      end
+
+      def ingest_manifests(manifests)
+        claimed = {}
+        manifests.each do |entry|
+          agent = entry.fetch("agent")
+          archived = entry["archived"] == true
+          reconcile_group!(agent)
+          grouped_runs(agent, entry["directory"]).each do |path, runs|
+            segments = segments_for(path)
+            runs.each do |run|
+              segment = matching_segment(segments, run)
+              usage = usage_entries(segment&.lines, agent.agent)
+              run.session_id ||= session_id_from(segment&.lines, agent.agent)
+              inference = {
+                "archived" => archived,
+                "source_identity" => source_identity(path, segment),
+                "unknown_reasons" => manifest_unknowns(run, segment),
+                "codex_baseline_known" => manifest_baseline_known?(agent, run)
+              }
+              ingest(agent, run, usage, source: "durable_agent_manifest", inference:)
+              @stats[:manifest_runs] += 1
+              claimed[[File.expand_path(path), segment.index]] = true if segment
+            end
+          end
+        rescue StandardError => error
+          @warnings << "Skipped one durable manifest after #{error.class}"
+          @stats[:skipped] += 1
+        end
+        claimed
+      end
+
+      def ingest_raw_fallback(claimed, options)
+        if @timezone.empty?
+          @warnings << "Raw-log fallback skipped because an explicit timezone was not supplied"
+          return
+        end
+
+        raw_paths(options).each do |path|
+          segments_for(path).each do |segment|
+            next if claimed[[File.expand_path(path), segment.index]]
+
+            ingest_raw_segment(path, segment)
+          end
+        rescue StandardError => error
+          @warnings << "Skipped one raw telemetry file after #{error.class}"
+          @stats[:skipped] += 1
+        end
+      end
+
+      def ingest_raw_segment(path, segment)
+        harness = infer_harness(segment.lines)
+        harness_unknown = harness.nil?
+        harness ||= "unknown"
+
+        agent_key, agent_key_inferred = agent_key_for(path)
+        project = project_for_agent_key(agent_key) || project_for_raw_name(path)
+        project_key = project&.key.to_s
+        group = project&.group.to_s
+        session_id = session_id_from(segment.lines, harness)
+        usage = usage_entries(segment.lines, harness)
+        finish = inferred_finish(segment.started_at, usage)
+        run = ManagedAgent::AgentRun.new(
+          started_at: segment.started_at,
+          finished_at: finish,
+          status: inferred_status(segment.lines, harness),
+          session_id: session_id,
+          agent: harness,
+          model: nil,
+          log_start_offset: segment.start_offset
+        )
+        agent = HistoricalAgent.new(
+          key: agent_key,
+          project_key: project_key,
+          project_group: group,
+          agent: harness,
+          model: nil,
+          session_id: session_id,
+          runs: [run]
+        )
+        inferred_fields = %w[started_at]
+        inferred_fields.concat(%w[harness status]) unless harness_unknown
+        inferred_fields << "agent_key" if agent_key_inferred
+        inferred_fields.concat(%w[project_key group]) if project
+        unknowns = []
+        unknowns << "Harness attribution was unavailable" if harness_unknown
+        unknowns << "Run status was unavailable" if harness_unknown
+        unknowns << "Agent identity was unavailable; a stable anonymous identity was assigned" if agent_key_inferred
+        unknowns << "Project attribution was unavailable" unless project
+        unknowns << "Configured model was not preserved in a durable manifest"
+        unknowns << "Run finish time was not reported" unless finish
+        inference = {
+          "archived" => archived_path?(path),
+          "source_identity" => source_identity(path, segment),
+          "inferred_fields" => inferred_fields,
+          "unknown_reasons" => unknowns,
+          "codex_baseline_known" => false
+        }
+        ingest(agent, run, usage, source: "legacy_raw_telemetry_fallback", inference:)
+        @stats[:raw_runs] += 1
+      end
+
+      def ingest(agent, run, usage, source:, inference:)
+        record = Normalizer.new(agent:, run:, usage_entries: usage, source:, inference:).record
+        @records << record
+      end
+
+      def grouped_runs(agent, archived_directory)
+        agent.runs.group_by do |run|
+          if archived_directory
+            File.join(archived_directory, File.basename(run.log_path.to_s.empty? ? agent.raw_log_path : run.log_path))
+          else
+            run.log_path.to_s.empty? ? agent.raw_log_path : run.log_path
+          end
+        end.reject { |path, _runs| path.to_s.empty? || !File.file?(path) }
+      end
+
+      def matching_segment(segments, run)
+        by_offset = segments.find { |segment| run.log_start_offset && segment.start_offset == run.log_start_offset }
+        return by_offset if by_offset
+        return nil unless run.started_at
+
+        segments.find { |segment| (segment.started_at - run.started_at).abs < 1 }
+      end
+
+      def segments_for(path)
+        return [] unless File.file?(path)
+
+        segments = []
+        current = nil
+        offset = 0
+        File.foreach(path) do |line|
+          if (match = line.match(/\A=== \[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] start ===\s*\z/))
+            segments << current if current
+            started_at = parse_legacy_time(match[1])
+            current = Segment.new(started_at:, start_offset: offset + line.bytesize, lines: [], index: segments.length)
+          elsif current
+            current.lines << line.chomp
+          end
+          offset += line.bytesize
+        end
+        segments << current if current
+        segments.compact
+      end
+
+      def parse_legacy_time(text)
+        if @timezone.empty?
+          Time.parse(text)
+        else
+          Query.parse_boundary(text, timezone: @timezone)
+        end
+      end
+
+      def usage_entries(lines, harness)
+        return [] if lines.nil?
+
+        adapter = HQ.harness_adapter(harness)
+        Array(lines).filter_map do |line|
+          next unless line.to_s.lstrip.start_with?("{")
+
+          event = JSON.parse(line)
+          metadata = case adapter
+                     when "codex"
+                       next unless event["type"] == "turn.completed"
+                       {
+                         "event_type" => "turn.completed",
+                         "usage" => event["usage"],
+                         "model" => event["model"]
+                       }
+                     when "claude"
+                       next unless event["type"] == "result"
+                       {
+                         "event_type" => "result",
+                         "total_cost_usd" => event["total_cost_usd"],
+                         "usage" => event["usage"],
+                         "model_usage" => event["modelUsage"] || event["model_usage"],
+                         "model" => event["model"],
+                         "duration_ms" => event["duration_ms"]
+                       }
+                     when "opencode"
+                       next unless event["type"] == "step_finish"
+                       {
+                         "event_type" => "step_finish",
+                         "total_cost_usd" => event["total_cost_usd"] || event.dig("part", "cost"),
+                         "usage" => event["usage"] || event.dig("part", "tokens"),
+                         "model" => event["model"] || event.dig("part", "model")
+                       }
+                     end
+          next unless metadata
+
+          Parser::SystemEntry.new(type: :usage, content: "usage", timestamp: nil, tool_name: nil,
+                                  metadata: metadata.compact)
+        rescue JSON::ParserError
+          nil
+        end
+      end
+
+      def session_id_from(lines, harness)
+        Array(lines).each do |line|
+          event = JSON.parse(line) if line.to_s.lstrip.start_with?("{")
+          next unless event.is_a?(Hash)
+          id = case HQ.harness_adapter(harness)
+               when "codex" then event["thread_id"] || event["session_id"] || (event["id"] if event["type"] == "thread.started")
+               when "opencode" then event["session_id"] || event["sessionID"] || event["sessionId"] || event.dig("session", "id")
+               else event["session_id"]
+               end
+          return id.to_s unless id.to_s.empty?
+        rescue JSON::ParserError
+          next
+        end
+        nil
+      end
+
+      def infer_harness(lines)
+        event_types = Array(lines).filter_map do |line|
+          next unless line.to_s.lstrip.start_with?("{")
+
+          JSON.parse(line)["type"]
+        rescue JSON::ParserError
+          nil
+        end
+        return "opencode" if event_types.any? { |type| %w[step_start step_finish text].include?(type) }
+        return "claude" if event_types.any? { |type| %w[assistant user result].include?(type) }
+        return "codex" if event_types.any? { |type| type.to_s.start_with?("thread.", "turn.", "item.") }
+
+        nil
+      end
+
+      def inferred_status(lines, harness)
+        events = Array(lines).filter_map do |line|
+          JSON.parse(line) if line.to_s.lstrip.start_with?("{")
+        rescue JSON::ParserError
+          nil
+        end
+        adapter = HQ.harness_adapter(harness)
+        if adapter == "codex"
+          return "failed" if events.any? { |event| %w[turn.failed error].include?(event["type"]) }
+          return "succeeded" if events.any? { |event| event["type"] == "turn.completed" }
+        elsif adapter == "claude"
+          result = events.reverse.find { |event| event["type"] == "result" }
+          return result["is_error"] ? "failed" : "succeeded" if result
+        elsif adapter == "opencode"
+          return "succeeded" if events.any? { |event| event["type"] == "step_finish" }
+        end
+        "unknown"
+      end
+
+      def inferred_finish(started_at, usage)
+        duration = usage.reverse.filter_map { |entry| numeric(entry.metadata&.dig("duration_ms")) }.first
+        duration ? started_at + (duration / 1000.0) : nil
+      end
+
+      def manifest_baseline_known?(agent, run)
+        return nil unless HQ.harness_adapter(run.agent.to_s.empty? ? agent.agent : run.agent) == "codex"
+
+        prior = agent.runs.take_while { |candidate| candidate != run }
+                     .count { |candidate| candidate.session_id.to_s == run.session_id.to_s }
+        prior.zero?
+      end
+
+      def manifest_unknowns(run, segment)
+        reasons = []
+        reasons << "Raw telemetry for the durable run was unavailable" unless segment
+        reasons << "Run finish time was not recorded" unless run.finished_at
+        reasons
+      end
+
+      def reconcile_group!(agent)
+        project = @projects.find { |candidate| candidate.key == agent.project_key }
+        agent.reconcile_project_group!(project.group) if project && agent.respond_to?(:reconcile_project_group!)
+      end
+
+      def project_for_agent_key(agent_key)
+        @projects.select { |project| agent_key.to_s.start_with?("#{project.key}-agent-") }.max_by { |project| project.key.length }
+      end
+
+      def project_for_raw_name(path)
+        name = File.basename(path)
+        @projects.select { |project| name.start_with?("#{project.key}-") }.max_by { |project| project.key.length }
+      end
+
+      def agent_key_for(path)
+        if archived_path?(path)
+          directory = File.basename(File.dirname(path))
+          match = directory.match(/\A\d{8}-\d{6}-(.+)\z/)
+          return [match[1], false] if match
+        end
+
+        digest = Digest::SHA256.hexdigest(File.expand_path(path))[0, 24]
+        ["unknown-agent-#{digest}", true]
+      end
+
+      def archived_path?(path)
+        File.expand_path(path).start_with?(File.expand_path(AGENT_ARCHIVE_DIR) + File::SEPARATOR)
+      end
+
+      def raw_paths(options)
+        explicit = options["raw_paths"]
+        return Array(explicit).map(&:to_s).uniq.sort if explicit
+
+        Dir.glob(File.join(AGENT_LOGS_DIR, "*.raw.log")) +
+          Dir.glob(File.join(AGENT_ARCHIVE_DIR, "*", "*.raw.log"))
+      end
+
+      def source_identity(path, segment)
+        Digest::SHA256.hexdigest([File.expand_path(path), segment&.start_offset].join("\0"))
+      end
+
+      def numeric(value)
+        number = Float(value)
+        number if number.finite? && number >= 0
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def stringify(value)
+        value.each_with_object({}) { |(key, entry), result| result[key.to_s] = entry }
+      end
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics/backfill.rb
+++ b/lib/hq/domain/usage_metrics/backfill.rb
@@ -9,11 +9,15 @@ require_relative "../log_paths"
 require_relative "../managed_agent"
 require_relative "../../parser"
 require_relative "../../registry"
+require_relative "provider_telemetry"
 require_relative "query"
+require_relative "values"
 
 module HQ
   module UsageMetrics
     class Backfill
+      include Values
+
       Segment = Struct.new(:started_at, :start_offset, :lines, :index, keyword_init: true)
       HistoricalAgent = Struct.new(
         :key, :project_key, :project_group, :agent, :model, :session_id, :runs,
@@ -33,6 +37,7 @@ module HQ
         @stats = Hash.new(0)
         @warnings = []
         @records = []
+        @existing_identity_index = existing_identity_index
 
         manifests = durable_manifests(options)
         claimed = ingest_manifests(manifests)
@@ -178,7 +183,22 @@ module HQ
 
       def ingest(agent, run, usage, source:, inference:)
         record = Normalizer.new(agent:, run:, usage_entries: usage, source:, inference:).record
+        if run.run_id.to_s.empty? && (existing = @existing_identity_index[identity_coordinates(record)])
+          record["run_id"] = existing.fetch("run_id")
+          record["identity_kind"] = existing["identity_kind"] || "deterministic_backfill_v1"
+        end
         @records << record
+      end
+
+      def existing_identity_index
+        grouped = @metrics_store.runs.select { |run| run["identity_kind"].to_s.start_with?("deterministic_backfill") }
+                                .group_by { |run| identity_coordinates(run) }
+        grouped.filter_map { |coordinates, runs| [coordinates, runs.first] if runs.length == 1 }.to_h
+      end
+
+      def identity_coordinates(record)
+        [record["agent_key"], record["started_at"], record.dig("provenance", "log_start_offset"),
+         record["harness_adapter"]]
       end
 
       def grouped_runs(agent, archived_directory)
@@ -188,7 +208,7 @@ module HQ
           else
             run.log_path.to_s.empty? ? agent.raw_log_path : run.log_path
           end
-        end.reject { |path, _runs| path.to_s.empty? || !File.file?(path) }
+        end.reject { |path, _runs| path.to_s.empty? }
       end
 
       def matching_segment(segments, run)
@@ -230,38 +250,12 @@ module HQ
       def usage_entries(lines, harness)
         return [] if lines.nil?
 
-        adapter = HQ.harness_adapter(harness)
+        provider = ProviderTelemetry.for(harness)
         Array(lines).filter_map do |line|
           next unless line.to_s.lstrip.start_with?("{")
 
           event = JSON.parse(line)
-          metadata = case adapter
-                     when "codex"
-                       next unless event["type"] == "turn.completed"
-                       {
-                         "event_type" => "turn.completed",
-                         "usage" => event["usage"],
-                         "model" => event["model"]
-                       }
-                     when "claude"
-                       next unless event["type"] == "result"
-                       {
-                         "event_type" => "result",
-                         "total_cost_usd" => event["total_cost_usd"],
-                         "usage" => event["usage"],
-                         "model_usage" => event["modelUsage"] || event["model_usage"],
-                         "model" => event["model"],
-                         "duration_ms" => event["duration_ms"]
-                       }
-                     when "opencode"
-                       next unless event["type"] == "step_finish"
-                       {
-                         "event_type" => "step_finish",
-                         "total_cost_usd" => event["total_cost_usd"] || event.dig("part", "cost"),
-                         "usage" => event["usage"] || event.dig("part", "tokens"),
-                         "model" => event["model"] || event.dig("part", "model")
-                       }
-                     end
+          metadata = provider.usage_metadata(event)
           next unless metadata
 
           Parser::SystemEntry.new(type: :usage, content: "usage", timestamp: nil, tool_name: nil,
@@ -272,15 +266,12 @@ module HQ
       end
 
       def session_id_from(lines, harness)
+        provider = ProviderTelemetry.for(harness)
         Array(lines).each do |line|
           event = JSON.parse(line) if line.to_s.lstrip.start_with?("{")
           next unless event.is_a?(Hash)
-          id = case HQ.harness_adapter(harness)
-               when "codex" then event["thread_id"] || event["session_id"] || (event["id"] if event["type"] == "thread.started")
-               when "opencode" then event["session_id"] || event["sessionID"] || event["sessionId"] || event.dig("session", "id")
-               else event["session_id"]
-               end
-          return id.to_s unless id.to_s.empty?
+          id = provider.session_id(event)
+          return id if id
         rescue JSON::ParserError
           next
         end
@@ -308,17 +299,7 @@ module HQ
         rescue JSON::ParserError
           nil
         end
-        adapter = HQ.harness_adapter(harness)
-        if adapter == "codex"
-          return "failed" if events.any? { |event| %w[turn.failed error].include?(event["type"]) }
-          return "succeeded" if events.any? { |event| event["type"] == "turn.completed" }
-        elsif adapter == "claude"
-          result = events.reverse.find { |event| event["type"] == "result" }
-          return result["is_error"] ? "failed" : "succeeded" if result
-        elsif adapter == "opencode"
-          return "succeeded" if events.any? { |event| event["type"] == "step_finish" }
-        end
-        "unknown"
+        ProviderTelemetry.for(harness).infer_status(events)
       end
 
       def inferred_finish(started_at, usage)
@@ -328,6 +309,7 @@ module HQ
 
       def manifest_baseline_known?(agent, run)
         return nil unless HQ.harness_adapter(run.agent.to_s.empty? ? agent.agent : run.agent) == "codex"
+        return false unless agent.respond_to?(:run_count) && agent.run_count == agent.runs.length
 
         prior = agent.runs.take_while { |candidate| candidate != run }
                      .count { |candidate| candidate.session_id.to_s == run.session_id.to_s }
@@ -379,19 +361,9 @@ module HQ
       end
 
       def source_identity(path, segment)
-        Digest::SHA256.hexdigest([File.expand_path(path), segment&.start_offset].join("\0"))
+        Digest::SHA256.hexdigest([File.basename(path), segment&.start_offset].join("\0"))
       end
 
-      def numeric(value)
-        number = Float(value)
-        number if number.finite? && number >= 0
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-      def stringify(value)
-        value.each_with_object({}) { |(key, entry), result| result[key.to_s] = entry }
-      end
     end
   end
 end

--- a/lib/hq/domain/usage_metrics/normalizer.rb
+++ b/lib/hq/domain/usage_metrics/normalizer.rb
@@ -5,10 +5,14 @@ require "json"
 require "time"
 
 require_relative "../../harness_registry"
+require_relative "provider_telemetry"
+require_relative "values"
 
 module HQ
   module UsageMetrics
     class Normalizer
+      include Values
+
       TOKEN_KEYS = %w[
         input_tokens cached_input_tokens cache_creation_input_tokens cache_read_input_tokens
         output_tokens reasoning_output_tokens
@@ -23,8 +27,9 @@ module HQ
       end
 
       def record
-        adapter = HQ.harness_adapter(harness)
-        normalized = adapter == "codex" ? codex_usage : per_run_usage(adapter)
+        provider = ProviderTelemetry.for(harness)
+        adapter = provider.adapter
+        normalized = provider.codex? ? codex_usage(provider) : per_run_usage(provider)
         native_session_id = present(@run.session_id) || present(@agent.session_id)
         inferred_fields = Array(@inference["inferred_fields"]).map(&:to_s).uniq
         unknown_reasons = Array(normalized.fetch("unknown_reasons"))
@@ -74,8 +79,8 @@ module HQ
 
       private
 
-      def codex_usage
-        entry = final_entry("turn.completed")
+      def codex_usage(provider)
+        entry = final_entry(provider.event_type)
         snapshot = token_hash(metadata(entry)["usage"])
         observed = observed_models(entry)
         reasons = []
@@ -91,19 +96,14 @@ module HQ
         }
       end
 
-      def per_run_usage(adapter)
-        entry_type = adapter == "opencode" ? "step_finish" : "result"
-        entries = @usage_entries.select { |entry| event_type(entry) == entry_type }
+      def per_run_usage(provider)
+        adapter = provider.adapter
+        entries = @usage_entries.select { |entry| event_type(entry) == provider.event_type }
         final = entries.last
         tokens = token_hash(metadata(final)["usage"], require_codex_core: false)
         attribution = adapter == "claude" ? claude_model_attribution(final) : []
         observed = (observed_models(final) + attribution.filter_map { |item| item["observed_model"] }).uniq.sort
-        cost = if adapter == "opencode"
-                 values = entries.filter_map { |entry| numeric(metadata(entry)["total_cost_usd"]) }
-                 values.empty? ? nil : values.sum
-               else
-                 numeric(metadata(final)["total_cost_usd"])
-               end
+        cost = provider.reported_cost(entries) { |entry| numeric(metadata(entry)["total_cost_usd"]) }
         reason = if final.nil?
                    "#{adapter_label(adapter)} did not report usage telemetry"
                  elsif cost.nil?
@@ -282,26 +282,6 @@ module HQ
 
       def utc_iso(value)
         value&.utc&.iso8601(6)
-      end
-
-      def numeric(value)
-        number = Float(value)
-        number if number.finite? && number >= 0
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-      def present(value)
-        text = value.to_s.strip
-        text unless text.empty?
-      end
-
-      def stringify(value)
-        case value
-        when Hash then value.each_with_object({}) { |(key, entry), result| result[key.to_s] = stringify(entry) }
-        when Array then value.map { |entry| stringify(entry) }
-        else value
-        end
       end
 
       def canonical(value)

--- a/lib/hq/domain/usage_metrics/normalizer.rb
+++ b/lib/hq/domain/usage_metrics/normalizer.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "time"
+
+require_relative "../../harness_registry"
+
+module HQ
+  module UsageMetrics
+    class Normalizer
+      TOKEN_KEYS = %w[
+        input_tokens cached_input_tokens cache_creation_input_tokens cache_read_input_tokens
+        output_tokens reasoning_output_tokens
+      ].freeze
+
+      def initialize(agent:, run:, usage_entries:, source:, inference: {})
+        @agent = agent
+        @run = run
+        @usage_entries = Array(usage_entries)
+        @source = source.to_s
+        @inference = stringify(inference || {})
+      end
+
+      def record
+        adapter = HQ.harness_adapter(harness)
+        normalized = adapter == "codex" ? codex_usage : per_run_usage(adapter)
+        native_session_id = present(@run.session_id) || present(@agent.session_id)
+        inferred_fields = Array(@inference["inferred_fields"]).map(&:to_s).uniq
+        unknown_reasons = Array(normalized.fetch("unknown_reasons"))
+        unknown_reasons << "Native session ID was not reported" unless native_session_id
+        unknown_reasons << "Observed model was not reported" if normalized.fetch("observed_models").empty?
+        unknown_reasons << "Configured model was not recorded" unless configured_model
+        unknown_reasons.concat(Array(@inference["unknown_reasons"]))
+        identity = run_identity
+
+        {
+          "schema_version" => 1,
+          "run_id" => identity,
+          "identity_kind" => present(@run.run_id) ? "persisted_uuid" : "deterministic_backfill_v1",
+          "agent_key" => @agent.key.to_s,
+          "project_key" => @agent.project_key.to_s,
+          "group" => present(@agent.respond_to?(:project_group) ? @agent.project_group : nil),
+          "harness" => harness,
+          "harness_adapter" => adapter,
+          "configured_model" => configured_model,
+          "observed_models" => normalized.fetch("observed_models"),
+          "model_attribution" => normalized.fetch("model_attribution"),
+          "native_session_id" => native_session_id,
+          "session_key" => native_session_id ? session_key(adapter, native_session_id) : nil,
+          "started_at" => utc_iso(@run.started_at),
+          "finished_at" => utc_iso(@run.finished_at),
+          "duration_ms" => duration_ms,
+          "status" => present(@run.status) || "unknown",
+          "exit_code" => @run.exit_code,
+          "tokens" => normalized["tokens"],
+          "cumulative_tokens" => normalized["cumulative_tokens"],
+          "codex_baseline_known" => codex_baseline_known?(adapter, native_session_id),
+          "estimated_cost" => normalized.fetch("estimated_cost"),
+          "completeness" => {
+            "telemetry" => normalized.fetch("telemetry_completeness"),
+            "tokens" => normalized["tokens"] ? "complete" : "unknown",
+            "pricing" => normalized.dig("estimated_cost", "amount_usd").nil? ? "unpriced" : "priced",
+            "session" => native_session_id ? "known" : "unknown",
+            "model" => normalized.fetch("observed_models").empty? ? configured_model ? "configured_only" : "unknown" : "observed",
+            "overall" => unknown_reasons.empty? ? "complete" : "partial",
+            "unknown_reasons" => unknown_reasons.compact.uniq,
+            "inferred_fields" => inferred_fields
+          },
+          "provenance" => provenance,
+          "archived" => @inference["archived"] == true
+        }
+      end
+
+      private
+
+      def codex_usage
+        entry = final_entry("turn.completed")
+        snapshot = token_hash(metadata(entry)["usage"])
+        observed = observed_models(entry)
+        reasons = []
+        reasons << "Codex did not report a complete cumulative token snapshot" unless snapshot
+        {
+          "tokens" => nil,
+          "cumulative_tokens" => snapshot,
+          "observed_models" => observed,
+          "model_attribution" => observed.map { |model| { "observed_model" => model } },
+          "estimated_cost" => unavailable_cost("Codex cost is calculated after cumulative-token normalization"),
+          "telemetry_completeness" => entry ? snapshot ? "complete" : "partial" : "unknown",
+          "unknown_reasons" => reasons
+        }
+      end
+
+      def per_run_usage(adapter)
+        entry_type = adapter == "opencode" ? "step_finish" : "result"
+        entries = @usage_entries.select { |entry| event_type(entry) == entry_type }
+        final = entries.last
+        tokens = token_hash(metadata(final)["usage"], require_codex_core: false)
+        attribution = adapter == "claude" ? claude_model_attribution(final) : []
+        observed = (observed_models(final) + attribution.filter_map { |item| item["observed_model"] }).uniq.sort
+        cost = if adapter == "opencode"
+                 values = entries.filter_map { |entry| numeric(metadata(entry)["total_cost_usd"]) }
+                 values.empty? ? nil : values.sum
+               else
+                 numeric(metadata(final)["total_cost_usd"])
+               end
+        reason = if final.nil?
+                   "#{adapter_label(adapter)} did not report usage telemetry"
+                 elsif cost.nil?
+                   "#{adapter_label(adapter)} did not report a run cost"
+                 end
+        {
+          "tokens" => tokens,
+          "cumulative_tokens" => nil,
+          "observed_models" => observed,
+          "model_attribution" => attribution,
+          "estimated_cost" => cost_payload(
+            cost,
+            "#{adapter}_reported_estimate",
+            {
+              "source" => "#{adapter}_reported_total",
+              "version" => nil,
+              "version_unknown_reason" => "The harness did not report a pricing version"
+            },
+            reason
+          ),
+          "telemetry_completeness" => if final.nil?
+                                        "unknown"
+                                      elsif tokens && !cost.nil?
+                                        "complete"
+                                      elsif tokens || !cost.nil?
+                                        "partial"
+                                      else
+                                        "unknown"
+                                      end,
+          "unknown_reasons" => [reason, ("Token telemetry was not reported" unless tokens)].compact
+        }
+      end
+
+      def claude_model_attribution(entry)
+        usage = metadata(entry)["model_usage"]
+        return [] unless usage.is_a?(Hash)
+
+        usage.map do |model, values|
+          details = values.is_a?(Hash) ? stringify(values) : {}
+          tokens = token_hash(details, require_codex_core: false)
+          amount = numeric(details["costUSD"] || details["cost_usd"] || details["total_cost_usd"])
+          {
+            "observed_model" => present(model),
+            "tokens" => tokens,
+            "estimated_cost_usd" => amount,
+            "currency" => amount.nil? ? nil : "USD",
+            "cost_source" => amount.nil? ? nil : "claude_model_usage",
+            "pricing_version" => nil,
+            "pricing_version_unknown_reason" => "Claude modelUsage did not report a pricing version",
+            "reason_unavailable" => amount.nil? ? "Claude modelUsage did not report attributed cost" : nil
+          }
+        end.sort_by { |item| item.fetch("observed_model", "") }
+      end
+
+      def observed_models(entry)
+        model = present(metadata(entry)["model"])
+        model ? [model] : []
+      end
+
+      def provenance
+        events = @usage_entries.map do |entry|
+          safe = safe_usage_metadata(metadata(entry))
+          {
+            "event_type" => event_type(entry),
+            "event_sha256" => Digest::SHA256.hexdigest(JSON.generate(canonical(safe))),
+            "fields" => safe.keys.sort
+          }
+        end
+        {
+          "source" => @source,
+          "event_count" => events.length,
+          "events" => events,
+          "log_start_offset" => @run.respond_to?(:log_start_offset) ? @run.log_start_offset : nil
+        }
+      end
+
+      def safe_usage_metadata(value)
+        allowed = %w[
+          event_type total_cost_usd usage model model_usage subtype is_error duration_ms duration_api_ms
+          num_turns session_id
+        ]
+        value.select { |key, _entry| allowed.include?(key.to_s) }
+      end
+
+      def run_identity
+        existing = present(@run.respond_to?(:run_id) ? @run.run_id : nil)
+        return existing if existing
+
+        components = [@agent.key, utc_iso(@run.started_at), @run.respond_to?(:log_start_offset) ? @run.log_start_offset : nil,
+                      @inference["source_identity"]].map(&:to_s)
+        Digest::SHA256.hexdigest("usage-run-v1\0#{components.join("\0")}")
+      end
+
+      def session_key(adapter, native_session_id)
+        Digest::SHA256.hexdigest("native-session-v1\0#{adapter}\0#{native_session_id}")
+      end
+
+      def codex_baseline_known?(adapter, native_session_id)
+        return nil unless adapter == "codex"
+        return false unless native_session_id
+        return @inference["codex_baseline_known"] if @inference.key?("codex_baseline_known")
+
+        prior = Array(@agent.runs)[0...-1].count { |candidate| candidate.session_id.to_s == native_session_id }
+        prior.zero?
+      end
+
+      def configured_model
+        present(@run.respond_to?(:model) ? @run.model : nil) || present(@agent.respond_to?(:model) ? @agent.model : nil)
+      end
+
+      def harness
+        present(@run.respond_to?(:agent) ? @run.agent : nil) || @agent.agent.to_s
+      end
+
+      def final_entry(type)
+        @usage_entries.reverse.find { |entry| event_type(entry) == type }
+      end
+
+      def event_type(entry)
+        metadata(entry)["event_type"].to_s
+      end
+
+      def metadata(entry)
+        return {} unless entry.respond_to?(:metadata) && entry.metadata.is_a?(Hash)
+
+        stringify(entry.metadata)
+      end
+
+      def token_hash(value, require_codex_core: true)
+        return nil unless value.is_a?(Hash)
+
+        aliases = {
+          "input_tokens" => ["input_tokens", "inputTokens"],
+          "cached_input_tokens" => ["cached_input_tokens", "cachedInputTokens"],
+          "cache_creation_input_tokens" => ["cache_creation_input_tokens", "cacheCreationInputTokens"],
+          "cache_read_input_tokens" => ["cache_read_input_tokens", "cacheReadInputTokens"],
+          "output_tokens" => ["output_tokens", "outputTokens"],
+          "reasoning_output_tokens" => ["reasoning_output_tokens", "reasoningOutputTokens"]
+        }
+        result = TOKEN_KEYS.each_with_object({}) do |key, tokens|
+          raw = aliases.fetch(key).filter_map { |candidate| value[candidate] }.first
+          number = numeric(raw)
+          tokens[key] = number unless number.nil?
+        end
+        required = require_codex_core ? %w[input_tokens cached_input_tokens output_tokens] : %w[input_tokens output_tokens]
+        return nil unless required.all? { |key| result.key?(key) }
+
+        result
+      end
+
+      def duration_ms
+        return nil unless @run.started_at && @run.finished_at
+
+        milliseconds = ((@run.finished_at - @run.started_at) * 1000).round
+        milliseconds >= 0 ? milliseconds : nil
+      end
+
+      def cost_payload(amount, source, pricing, reason)
+        {
+          "amount_usd" => amount,
+          "currency" => amount.nil? ? nil : "USD",
+          "semantics" => "estimate_not_invoice",
+          "source" => amount.nil? ? "unpriced" : source,
+          "pricing" => pricing,
+          "reason_unavailable" => reason
+        }
+      end
+
+      def unavailable_cost(reason)
+        cost_payload(nil, "unpriced", nil, reason)
+      end
+
+      def adapter_label(adapter)
+        adapter == "opencode" ? "OpenCode" : adapter.capitalize
+      end
+
+      def utc_iso(value)
+        value&.utc&.iso8601(6)
+      end
+
+      def numeric(value)
+        number = Float(value)
+        number if number.finite? && number >= 0
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def present(value)
+        text = value.to_s.strip
+        text unless text.empty?
+      end
+
+      def stringify(value)
+        case value
+        when Hash then value.each_with_object({}) { |(key, entry), result| result[key.to_s] = stringify(entry) }
+        when Array then value.map { |entry| stringify(entry) }
+        else value
+        end
+      end
+
+      def canonical(value)
+        case value
+        when Hash then value.keys.sort.to_h { |key| [key, canonical(value[key])] }
+        when Array then value.map { |entry| canonical(entry) }
+        else value
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics/provider_telemetry.rb
+++ b/lib/hq/domain/usage_metrics/provider_telemetry.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require_relative "../../harness_registry"
+
+module HQ
+  module UsageMetrics
+    class ProviderTelemetry
+      class Base
+        attr_reader :adapter, :event_type
+
+        def initialize(adapter:, event_type: nil)
+          @adapter = adapter
+          @event_type = event_type
+        end
+
+        def usage_metadata(_event)
+          nil
+        end
+
+        def session_id(event)
+          value = event["session_id"]
+          value.to_s unless value.to_s.empty?
+        end
+
+        def infer_status(_events)
+          "unknown"
+        end
+
+        def reported_cost(_entries)
+          nil
+        end
+
+        def codex?
+          false
+        end
+      end
+
+      class Codex < Base
+        def initialize
+          super(adapter: "codex", event_type: "turn.completed")
+        end
+
+        def usage_metadata(event)
+          return nil unless event["type"] == event_type
+
+          { "event_type" => event_type, "usage" => event["usage"], "model" => event["model"] }.compact
+        end
+
+        def session_id(event)
+          value = event["thread_id"] || event["session_id"] || (event["id"] if event["type"] == "thread.started")
+          value.to_s unless value.to_s.empty?
+        end
+
+        def infer_status(events)
+          return "failed" if events.any? { |event| %w[turn.failed error].include?(event["type"]) }
+          return "succeeded" if events.any? { |event| event["type"] == event_type }
+
+          "unknown"
+        end
+
+        def codex?
+          true
+        end
+      end
+
+      class Claude < Base
+        def initialize
+          super(adapter: "claude", event_type: "result")
+        end
+
+        def usage_metadata(event)
+          return nil unless event["type"] == event_type
+
+          {
+            "event_type" => event_type, "total_cost_usd" => event["total_cost_usd"],
+            "usage" => event["usage"], "model_usage" => event["modelUsage"] || event["model_usage"],
+            "model" => event["model"], "duration_ms" => event["duration_ms"]
+          }.compact
+        end
+
+        def infer_status(events)
+          result = events.reverse.find { |event| event["type"] == event_type }
+          result ? result["is_error"] ? "failed" : "succeeded" : "unknown"
+        end
+
+        def reported_cost(entries)
+          entries.filter_map { |entry| yield(entry) }.last
+        end
+      end
+
+      class OpenCode < Base
+        def initialize
+          super(adapter: "opencode", event_type: "step_finish")
+        end
+
+        def usage_metadata(event)
+          return nil unless event["type"] == event_type
+
+          {
+            "event_type" => event_type, "total_cost_usd" => event["total_cost_usd"] || event.dig("part", "cost"),
+            "usage" => event["usage"] || event.dig("part", "tokens"),
+            "model" => event["model"] || event.dig("part", "model")
+          }.compact
+        end
+
+        def session_id(event)
+          value = event["session_id"] || event["sessionID"] || event["sessionId"] || event.dig("session", "id")
+          value.to_s unless value.to_s.empty?
+        end
+
+        def infer_status(events)
+          events.any? { |event| event["type"] == event_type } ? "succeeded" : "unknown"
+        end
+
+        def reported_cost(entries)
+          values = entries.filter_map { |entry| yield(entry) }
+          values.sum unless values.empty?
+        end
+      end
+
+      PROVIDERS = {
+        "codex" => Codex,
+        "claude" => Claude,
+        "opencode" => OpenCode
+      }.freeze
+
+      def self.for(harness)
+        adapter = HQ.harness_adapter(harness)
+        provider = PROVIDERS[adapter]
+        provider ? provider.new : Base.new(adapter:)
+      end
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics/query.rb
+++ b/lib/hq/domain/usage_metrics/query.rb
@@ -3,9 +3,14 @@
 require "date"
 require "time"
 
+require_relative "session_aggregate"
+require_relative "values"
+
 module HQ
   module UsageMetrics
     class Query
+      include Values
+
       TIMEZONE_MUTEX = Mutex.new
       FILTERS = %w[group project agent harness model status].freeze
 
@@ -25,8 +30,9 @@ module HQ
         runs.sort_by! { |run| [run["started_at"].to_s, run["run_id"].to_s] }
         session_rows = sessions_for(runs)
         priced_runs = runs.select { |run| !numeric(run.dig("estimated_cost", "amount_usd")).nil? }
-        complete_session_costs = session_rows.filter_map { |session| numeric(session["estimated_cost_usd"]) }.sort
+        priced_session_costs = session_rows.filter_map { |session| numeric(session["estimated_cost_usd"]) }.sort
         native_sessions = runs.filter_map { |run| present(run["session_key"]) }.uniq
+        session_run_count = runs.count { |run| present(run["session_key"]) }
 
         {
           "schema_version" => document.fetch("schema_version"),
@@ -42,15 +48,15 @@ module HQ
             "managed_agents" => runs.map { |run| run["agent_key"] }.uniq.length,
             "distinct_native_sessions" => native_sessions.length,
             "runs_without_native_session" => runs.count { |run| run["native_session_id"].to_s.empty? },
-            "average_runs_per_session" => native_sessions.empty? ? nil : runs.length.to_f / native_sessions.length,
+            "average_runs_per_session" => native_sessions.empty? ? nil : session_run_count.to_f / native_sessions.length,
             "known_estimated_cost_usd" => priced_runs.empty? ? nil : priced_runs.sum { |run| numeric(run.dig("estimated_cost", "amount_usd")) },
-            "median_complete_session_cost_usd" => median(complete_session_costs),
-            "max_complete_session_cost_usd" => complete_session_costs.max,
+            "median_priced_session_cost_usd" => median(priced_session_costs),
+            "max_priced_session_cost_usd" => priced_session_costs.max,
             "priced_run_count" => priced_runs.length,
             "unpriced_run_count" => runs.length - priced_runs.length,
             "priced_run_coverage" => runs.empty? ? nil : priced_runs.length.to_f / runs.length,
-            "complete_priced_session_count" => complete_session_costs.length,
-            "incomplete_or_unpriced_session_count" => session_rows.length - complete_session_costs.length,
+            "priced_session_count" => priced_session_costs.length,
+            "unpriced_or_partially_priced_session_count" => session_rows.length - priced_session_costs.length,
             "cost_semantics" => "estimate_not_invoice"
           },
           "runs" => runs.map { |run| public_run(run) },
@@ -91,37 +97,7 @@ module HQ
 
       def sessions_for(runs)
         runs.reject { |run| run["native_session_id"].to_s.empty? }.group_by { |run| run.fetch("session_key") }
-            .values.map { |group| summarize_session(group) }.sort_by { |session| session["first_activity_at"] }
-      end
-
-      def summarize_session(runs)
-        sorted = runs.sort_by { |run| run["started_at"] }
-        costs = sorted.filter_map { |run| numeric(run.dig("estimated_cost", "amount_usd")) }
-        all_priced = costs.length == sorted.length
-        all_complete = sorted.all? { |run| run.dig("completeness", "overall") == "complete" }
-        {
-          "session_key" => sorted.first["session_key"],
-          "native_session_id" => sorted.first["native_session_id"],
-          "harness_adapter" => sorted.first["harness_adapter"],
-          "first_activity_at" => sorted.first["started_at"],
-          "last_activity_at" => sorted.map { |run| run["finished_at"] || run["started_at"] }.max,
-          "run_count" => sorted.length,
-          "agent_count" => sorted.map { |run| run["agent_key"] }.uniq.length,
-          "configured_models" => sorted.filter_map { |run| present(run["configured_model"]) }.uniq.sort,
-          "observed_models" => sorted.flat_map { |run| Array(run["observed_models"]) }.uniq.sort,
-          "known_estimated_cost_usd" => costs.empty? ? nil : costs.sum,
-          "estimated_cost_usd" => all_priced && all_complete ? costs.sum : nil,
-          "currency" => costs.empty? ? nil : "USD",
-          "pricing_coverage" => if all_priced && all_complete
-                                  "complete"
-                                elsif all_priced
-                                  "priced_incomplete"
-                                elsif costs.empty?
-                                  "unpriced"
-                                else
-                                  "partial"
-                                end
-        }
+            .values.map { |group| SessionAggregate.build(group) }.sort_by { |session| session["first_activity_at"] }
       end
 
       def public_run(run)
@@ -182,21 +158,6 @@ module HQ
         values.length.odd? ? values[middle] : (values[middle - 1] + values[middle]) / 2.0
       end
 
-      def numeric(value)
-        number = Float(value)
-        number if number.finite? && number >= 0
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-      def present(value)
-        text = value.to_s.strip
-        text unless text.empty?
-      end
-
-      def stringify(value)
-        value.each_with_object({}) { |(key, entry), result| result[key.to_s] = entry }
-      end
     end
   end
 end

--- a/lib/hq/domain/usage_metrics/query.rb
+++ b/lib/hq/domain/usage_metrics/query.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "date"
+require "time"
+
+module HQ
+  module UsageMetrics
+    class Query
+      TIMEZONE_MUTEX = Mutex.new
+      FILTERS = %w[group project agent harness model status].freeze
+
+      def initialize(metrics_store:)
+        @metrics_store = metrics_store
+      end
+
+      def call(filters = {})
+        options = stringify(filters || {})
+        timezone = options.fetch("timezone", "UTC")
+        from = parse_boundary(options["from"], timezone:, end_boundary: false)
+        to = parse_boundary(options["to"], timezone:, end_boundary: true)
+        raise ArgumentError, "--to must be after --from" if from && to && to <= from
+
+        document = @metrics_store.snapshot
+        runs = document.fetch("runs").values.select { |run| selected?(run, options, from:, to:) }
+        runs.sort_by! { |run| [run["started_at"].to_s, run["run_id"].to_s] }
+        session_rows = sessions_for(runs)
+        priced_runs = runs.select { |run| !numeric(run.dig("estimated_cost", "amount_usd")).nil? }
+        complete_session_costs = session_rows.filter_map { |session| numeric(session["estimated_cost_usd"]) }.sort
+        native_sessions = runs.filter_map { |run| present(run["session_key"]) }.uniq
+
+        {
+          "schema_version" => document.fetch("schema_version"),
+          "query" => {
+            "from" => from&.utc&.iso8601(6),
+            "to" => to&.utc&.iso8601(6),
+            "range_semantics" => "from_inclusive_to_exclusive",
+            "timezone" => timezone,
+            "filters" => FILTERS.to_h { |key| [key, split_filter(options[key])] }.reject { |_key, value| value.empty? }
+          },
+          "summary" => {
+            "run_starts" => runs.length,
+            "managed_agents" => runs.map { |run| run["agent_key"] }.uniq.length,
+            "distinct_native_sessions" => native_sessions.length,
+            "runs_without_native_session" => runs.count { |run| run["native_session_id"].to_s.empty? },
+            "average_runs_per_session" => native_sessions.empty? ? nil : runs.length.to_f / native_sessions.length,
+            "known_estimated_cost_usd" => priced_runs.empty? ? nil : priced_runs.sum { |run| numeric(run.dig("estimated_cost", "amount_usd")) },
+            "median_complete_session_cost_usd" => median(complete_session_costs),
+            "max_complete_session_cost_usd" => complete_session_costs.max,
+            "priced_run_count" => priced_runs.length,
+            "unpriced_run_count" => runs.length - priced_runs.length,
+            "priced_run_coverage" => runs.empty? ? nil : priced_runs.length.to_f / runs.length,
+            "complete_priced_session_count" => complete_session_costs.length,
+            "incomplete_or_unpriced_session_count" => session_rows.length - complete_session_costs.length,
+            "cost_semantics" => "estimate_not_invoice"
+          },
+          "runs" => runs.map { |run| public_run(run) },
+          "sessions" => session_rows,
+          "recovery" => document["recovery"]
+        }
+      end
+
+      def self.parse_boundary(value, timezone:, end_boundary: false)
+        new(metrics_store: nil).send(:parse_boundary, value, timezone:, end_boundary:)
+      end
+
+      private
+
+      def selected?(run, options, from:, to:)
+        started = Time.iso8601(run.fetch("started_at"))
+        return false if from && started < from
+        return false if to && started >= to
+
+        FILTERS.all? do |filter|
+          accepted = split_filter(options[filter])
+          accepted.empty? || values_for_filter(run, filter).any? { |value| accepted.include?(value) }
+        end
+      rescue ArgumentError
+        false
+      end
+
+      def values_for_filter(run, filter)
+        values = case filter
+                 when "project" then [run["project_key"]]
+                 when "agent" then [run["agent_key"]]
+                 when "harness" then [run["harness"], run["harness_adapter"]]
+                 when "model" then [run["configured_model"], *Array(run["observed_models"])]
+                 else [run[filter]]
+                 end
+        values.filter_map { |value| present(value)&.downcase }.uniq
+      end
+
+      def sessions_for(runs)
+        runs.reject { |run| run["native_session_id"].to_s.empty? }.group_by { |run| run.fetch("session_key") }
+            .values.map { |group| summarize_session(group) }.sort_by { |session| session["first_activity_at"] }
+      end
+
+      def summarize_session(runs)
+        sorted = runs.sort_by { |run| run["started_at"] }
+        costs = sorted.filter_map { |run| numeric(run.dig("estimated_cost", "amount_usd")) }
+        all_priced = costs.length == sorted.length
+        all_complete = sorted.all? { |run| run.dig("completeness", "overall") == "complete" }
+        {
+          "session_key" => sorted.first["session_key"],
+          "native_session_id" => sorted.first["native_session_id"],
+          "harness_adapter" => sorted.first["harness_adapter"],
+          "first_activity_at" => sorted.first["started_at"],
+          "last_activity_at" => sorted.map { |run| run["finished_at"] || run["started_at"] }.max,
+          "run_count" => sorted.length,
+          "agent_count" => sorted.map { |run| run["agent_key"] }.uniq.length,
+          "configured_models" => sorted.filter_map { |run| present(run["configured_model"]) }.uniq.sort,
+          "observed_models" => sorted.flat_map { |run| Array(run["observed_models"]) }.uniq.sort,
+          "known_estimated_cost_usd" => costs.empty? ? nil : costs.sum,
+          "estimated_cost_usd" => all_priced && all_complete ? costs.sum : nil,
+          "currency" => costs.empty? ? nil : "USD",
+          "pricing_coverage" => if all_priced && all_complete
+                                  "complete"
+                                elsif all_priced
+                                  "priced_incomplete"
+                                elsif costs.empty?
+                                  "unpriced"
+                                else
+                                  "partial"
+                                end
+        }
+      end
+
+      def public_run(run)
+        run.reject { |key, _value| key == "provenance" }.merge(
+          "provenance" => {
+            "source" => run.dig("provenance", "source"),
+            "event_count" => run.dig("provenance", "event_count"),
+            "events" => Array(run.dig("provenance", "events"))
+          }.compact
+        )
+      end
+
+      def parse_boundary(value, timezone:, end_boundary:)
+        text = value.to_s.strip
+        return nil if text.empty?
+        validate_timezone!(timezone)
+        return Time.iso8601(text) if text.match?(/[zZ]\z|[+-]\d{2}:?\d{2}\z/)
+
+        parts = Date._parse(text, false)
+        raise ArgumentError, "Invalid time boundary #{text.inspect}" unless parts[:year] && parts[:mon] && parts[:mday]
+
+        local_time(timezone) do
+          Time.local(parts[:year], parts[:mon], parts[:mday], parts[:hour] || 0, parts[:min] || 0,
+                     (parts[:sec] || 0) + Rational(parts[:sec_fraction] || 0))
+        end
+      rescue Date::Error, ArgumentError => error
+        raise ArgumentError, "Invalid #{end_boundary ? "to" : "from"} boundary #{text.inspect}: #{error.message}"
+      end
+
+      def validate_timezone!(timezone)
+        zone = timezone.to_s
+        raise ArgumentError, "Timezone is required" if zone.empty?
+        return if %w[UTC Etc/UTC GMT].include?(zone)
+
+        root = "/usr/share/zoneinfo/"
+        candidate = File.expand_path(zone, root)
+        raise ArgumentError, "Unknown timezone #{zone.inspect}" unless candidate.start_with?(root) && File.file?(candidate)
+      end
+
+      def local_time(timezone)
+        TIMEZONE_MUTEX.synchronize do
+          previous = ENV["TZ"]
+          ENV["TZ"] = timezone
+          yield
+        ensure
+          previous.nil? ? ENV.delete("TZ") : ENV["TZ"] = previous
+        end
+      end
+
+      def split_filter(value)
+        Array(value).flat_map { |entry| entry.to_s.split(",") }.map { |entry| entry.strip.downcase }.reject(&:empty?).uniq
+      end
+
+      def median(values)
+        return nil if values.empty?
+
+        middle = values.length / 2
+        values.length.odd? ? values[middle] : (values[middle - 1] + values[middle]) / 2.0
+      end
+
+      def numeric(value)
+        number = Float(value)
+        number if number.finite? && number >= 0
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def present(value)
+        text = value.to_s.strip
+        text unless text.empty?
+      end
+
+      def stringify(value)
+        value.each_with_object({}) { |(key, entry), result| result[key.to_s] = entry }
+      end
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics/session_aggregate.rb
+++ b/lib/hq/domain/usage_metrics/session_aggregate.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "values"
+
+module HQ
+  module UsageMetrics
+    module SessionAggregate
+      module_function
+
+      def build(runs)
+        sorted = runs.sort_by { |run| [run["started_at"].to_s, run["run_id"].to_s] }
+        costs = sorted.filter_map { |run| Values.numeric(run.dig("estimated_cost", "amount_usd")) }
+        all_priced = costs.length == sorted.length
+        tokens_complete = sorted.all? { |run| valid_tokens?(run["tokens"]) }
+        token_totals = sum_tokens(sorted.map { |run| run["tokens"] })
+        observed_models = sorted.flat_map { |run| Array(run["observed_models"]) }.uniq.sort
+        configured_models = sorted.filter_map { |run| Values.present(run["configured_model"]) }.uniq.sort
+        {
+          "session_key" => sorted.first.fetch("session_key"),
+          "native_session_id" => sorted.first.fetch("native_session_id"),
+          "harness_adapter" => sorted.first.fetch("harness_adapter"),
+          "first_activity_at" => sorted.first.fetch("started_at"),
+          "last_activity_at" => sorted.map { |run| run["finished_at"] || run["started_at"] }.max,
+          "run_count" => sorted.length,
+          "agent_count" => sorted.map { |run| run["agent_key"] }.uniq.length,
+          "configured_models" => configured_models,
+          "observed_models" => observed_models,
+          "mixed_model" => (configured_models + observed_models).uniq.length > 1,
+          "tokens" => tokens_complete ? token_totals : nil,
+          "known_tokens" => token_totals,
+          "known_estimated_cost_usd" => costs.empty? ? nil : costs.sum,
+          "estimated_cost_usd" => all_priced ? costs.sum : nil,
+          "currency" => costs.empty? ? nil : "USD",
+          "pricing_coverage" => all_priced ? "complete" : costs.empty? ? "unpriced" : "partial",
+          "completeness" => {
+            "tokens" => tokens_complete ? "complete" : "partial",
+            "pricing" => all_priced ? "priced" : costs.empty? ? "unpriced" : "partial",
+            "overall" => all_priced && tokens_complete &&
+              sorted.all? { |run| run.dig("completeness", "overall") == "complete" } ? "complete" : "partial",
+            "unknown_reasons" => sorted.flat_map { |run| Array(run.dig("completeness", "unknown_reasons")) }.uniq
+          }
+        }
+      end
+
+      def valid_tokens?(value)
+        value.is_a?(Hash) && %w[input_tokens cached_input_tokens output_tokens].all? do |key|
+          number = value[key]
+          number.is_a?(Numeric) && number.finite? && number >= 0
+        end
+      end
+
+      def sum_tokens(tokens)
+        keys = Array(tokens).filter_map { |value| value.is_a?(Hash) ? value.keys : nil }.flatten.uniq
+        keys.to_h do |key|
+          values = Array(tokens).filter_map { |value| Values.numeric(value[key]) if value.is_a?(Hash) }
+          [key, values.empty? ? nil : values.sum]
+        end.compact
+      end
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics/store.rb
+++ b/lib/hq/domain/usage_metrics/store.rb
@@ -1,0 +1,367 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "time"
+
+require_relative "../constants"
+require_relative "../file_store"
+require_relative "../openai_model_pricing"
+
+module HQ
+  module UsageMetrics
+    class Store
+      SCHEMA_VERSION = 1
+
+      attr_reader :path, :lock_path
+
+      def initialize(path: USAGE_METRICS_FILE, lock_path: nil)
+        @path = File.expand_path(path)
+        @lock_path = File.expand_path(lock_path || "#{@path}.lock")
+      end
+
+      def upsert(record)
+        normalized = stringify(record)
+        identity = normalized.fetch("run_id")
+        with_lock(File::LOCK_EX) do
+          document = read_document
+          existing = document.fetch("runs")[identity]
+          document.fetch("runs")[identity] = normalized
+          rebuild!(document)
+          return :unchanged if existing == document.fetch("runs")[identity]
+
+          write_document(document)
+          existing ? :updated : :created
+        end
+      end
+
+      def replace(records)
+        with_lock(File::LOCK_EX) do
+          document = blank_document
+          Array(records).each do |record|
+            normalized = stringify(record)
+            document.fetch("runs")[normalized.fetch("run_id")] = normalized
+          end
+          rebuild!(document)
+          write_document(document)
+          document
+        end
+      end
+
+      def upsert_many(records)
+        normalized_records = Array(records).map { |record| stringify(record) }
+        with_lock(File::LOCK_EX) do
+          document = read_document
+          existing = normalized_records.to_h do |record|
+            identity = record.fetch("run_id")
+            [identity, document.fetch("runs")[identity]]
+          end
+          normalized_records.each do |record|
+            document.fetch("runs")[record.fetch("run_id")] = record
+          end
+          rebuild!(document)
+          outcomes = normalized_records.map { |record| record.fetch("run_id") }.uniq.to_h do |identity|
+            prior = existing[identity]
+            outcome = if prior.nil?
+                        :created
+                      elsif prior == document.fetch("runs")[identity]
+                        :unchanged
+                      else
+                        :updated
+                      end
+            [identity, outcome]
+          end
+          write_document(document) if outcomes.value?(:created) || outcomes.value?(:updated)
+          outcomes.values.tally
+        end
+      end
+
+      def snapshot
+        with_lock(File::LOCK_SH) { deep_copy(read_document) }
+      end
+
+      def runs
+        snapshot.fetch("runs").values
+      end
+
+      def sessions
+        snapshot.fetch("sessions").values
+      end
+
+      def mark_agent_archived(agent_key)
+        changed = false
+        with_lock(File::LOCK_EX) do
+          document = read_document
+          document.fetch("runs").each_value do |run|
+            next unless run["agent_key"] == agent_key.to_s
+            next if run["archived"] == true
+
+            run["archived"] = true
+            changed = true
+          end
+          if changed
+            rebuild!(document)
+            write_document(document)
+          end
+        end
+        changed
+      end
+
+      private
+
+      def blank_document
+        {
+          "schema_version" => SCHEMA_VERSION,
+          "generated_at" => Time.now.utc.iso8601(6),
+          "runs" => {},
+          "sessions" => {},
+          "recovery" => { "discarded_run_count" => 0, "warnings" => [] }
+        }
+      end
+
+      def read_document
+        return blank_document unless File.exist?(@path)
+
+        raw = JSON.parse(FileStore.read_text(@path))
+        migrate(raw)
+      rescue StandardError => error
+        backup = read_backup
+        raise error unless backup
+
+        migrated = migrate(backup)
+        migrated["recovery"] = {
+          "discarded_run_count" => 0,
+          "warnings" => ["Recovered metrics from the atomic-write backup after #{error.class}"]
+        }
+        migrated
+      end
+
+      def read_backup
+        backup_path = FileStore.backup_path(@path)
+        return nil unless File.exist?(backup_path)
+
+        JSON.parse(FileStore.read_text(backup_path))
+      rescue StandardError
+        nil
+      end
+
+      def migrate(raw)
+        raise ArgumentError, "Usage metrics root must be an object" unless raw.is_a?(Hash)
+
+        version = Integer(raw["schema_version"] || 0)
+        case version
+        when SCHEMA_VERSION
+          normalize_document(raw)
+        when 0
+          migrate_v0(raw)
+        else
+          raise ArgumentError, "Unsupported usage metrics schema version #{version}"
+        end
+      end
+
+      def migrate_v0(raw)
+        records = Array(raw["records"] || raw["runs"])
+        document = blank_document
+        records.each do |record|
+          next unless record.is_a?(Hash) && !record["run_id"].to_s.empty?
+
+          document.fetch("runs")[record.fetch("run_id").to_s] = stringify(record)
+        end
+        rebuild!(document)
+        document.fetch("recovery").fetch("warnings") << "Migrated usage metrics schema 0 to 1"
+        document
+      end
+
+      def normalize_document(raw)
+        document = blank_document.merge(stringify(raw))
+        source_runs = document["runs"]
+        source_runs = Array(source_runs).to_h { |record| [record["run_id"].to_s, record] } if source_runs.is_a?(Array)
+        source_runs = {} unless source_runs.is_a?(Hash)
+        discarded = 0
+        document["runs"] = source_runs.each_with_object({}) do |(identity, record), result|
+          unless valid_record?(record)
+            discarded += 1
+            next
+          end
+          result[identity.to_s] = stringify(record)
+        end
+        document["recovery"] = stringify(document["recovery"] || {})
+        document["recovery"]["discarded_run_count"] = discarded
+        document["recovery"]["warnings"] = Array(document["recovery"]["warnings"])
+        document["recovery"]["warnings"] << "Discarded #{discarded} invalid run records" if discarded.positive?
+        rebuild!(document)
+        document
+      end
+
+      def valid_record?(record)
+        record.is_a?(Hash) && !record["run_id"].to_s.empty? && !record["started_at"].to_s.empty?
+      end
+
+      def rebuild!(document)
+        recalculate_codex_runs!(document.fetch("runs").values)
+        document["sessions"] = build_sessions(document.fetch("runs").values)
+        document["schema_version"] = SCHEMA_VERSION
+        document["generated_at"] = Time.now.utc.iso8601(6)
+      end
+
+      def recalculate_codex_runs!(runs)
+        grouped = runs.select { |run| run["harness_adapter"] == "codex" && !run["native_session_id"].to_s.empty? }
+                      .group_by { |run| run.fetch("session_key") }
+        grouped.each_value do |session_runs|
+          previous = nil
+          session_runs.sort_by { |run| [run["started_at"].to_s, run["run_id"].to_s] }.each do |run|
+            snapshot = run["cumulative_tokens"]
+            delta, reason = codex_delta(snapshot, previous, baseline_known: run["codex_baseline_known"] == true)
+            run["tokens"] = delta
+            update_codex_cost!(run, delta, reason)
+            previous = snapshot if valid_tokens?(snapshot)
+          end
+        end
+      end
+
+      def codex_delta(current, previous, baseline_known:)
+        return [nil, "Codex did not report a complete cumulative token snapshot"] unless valid_tokens?(current)
+        return [nil, "The preceding Codex cumulative snapshot is unavailable"] if previous.nil? && !baseline_known
+        return [current.dup, nil] unless previous
+        return [nil, "The preceding Codex cumulative snapshot is incomplete"] unless valid_tokens?(previous)
+
+        delta = current.each_with_object({}) do |(key, value), result|
+          prior = previous[key]
+          return [nil, "Codex cumulative token counters decreased"] if prior.is_a?(Numeric) && value < prior
+          result[key] = prior.is_a?(Numeric) ? value - prior : value
+        end
+        [delta, nil]
+      end
+
+      def update_codex_cost!(run, delta, delta_reason)
+        if delta
+          estimate = OpenAIModelPricing.estimate(model: run["configured_model"], tokens: delta)
+          pricing = estimate["pricing"]&.merge("version" => estimate.dig("pricing", "as_of"))
+          run["estimated_cost"] = cost_payload(estimate["amount_usd"], estimate["amount_usd"] ? "api_list_price_estimate" : "unpriced",
+                                                pricing, estimate["reason_unavailable"])
+        else
+          run["estimated_cost"] = cost_payload(nil, "unpriced", nil, delta_reason)
+        end
+        refresh_completeness!(run, delta_reason)
+      end
+
+      def refresh_completeness!(run, token_reason)
+        completeness = stringify(run["completeness"] || {})
+        reasons = Array(completeness["unknown_reasons"]).reject { |reason| reason.to_s.start_with?("Codex ") || reason == "The preceding Codex cumulative snapshot is unavailable" }
+        reasons << token_reason if token_reason
+        cost_reason = run.dig("estimated_cost", "reason_unavailable")
+        reasons << cost_reason if cost_reason
+        completeness["tokens"] = run["tokens"] ? "complete" : "unknown"
+        completeness["pricing"] = run.dig("estimated_cost", "amount_usd").nil? ? "unpriced" : "priced"
+        completeness["unknown_reasons"] = reasons.compact.uniq
+        completeness["overall"] = completeness["unknown_reasons"].empty? ? "complete" : "partial"
+        run["completeness"] = completeness
+      end
+
+      def build_sessions(runs)
+        runs.reject { |run| run["native_session_id"].to_s.empty? }.group_by { |run| run.fetch("session_key") }
+            .transform_values { |session_runs| session_record(session_runs) }
+      end
+
+      def session_record(runs)
+        sorted = runs.sort_by { |run| [run["started_at"].to_s, run["run_id"].to_s] }
+        costs = sorted.filter_map { |run| numeric(run.dig("estimated_cost", "amount_usd")) }
+        all_priced = costs.length == sorted.length
+        all_complete = sorted.all? { |run| run.dig("completeness", "overall") == "complete" }
+        tokens_complete = sorted.all? { |run| valid_tokens?(run["tokens"]) }
+        token_totals = sum_tokens(sorted.map { |run| run["tokens"] })
+        observed_models = sorted.flat_map { |run| Array(run["observed_models"]) }.uniq.sort
+        configured_models = sorted.filter_map { |run| present(run["configured_model"]) }.uniq.sort
+        {
+          "session_key" => sorted.first.fetch("session_key"),
+          "native_session_id" => sorted.first.fetch("native_session_id"),
+          "harness_adapter" => sorted.first.fetch("harness_adapter"),
+          "first_activity_at" => sorted.first.fetch("started_at"),
+          "last_activity_at" => sorted.map { |run| run["finished_at"] || run["started_at"] }.max,
+          "run_count" => sorted.length,
+          "agent_count" => sorted.map { |run| run["agent_key"] }.uniq.length,
+          "configured_models" => configured_models,
+          "observed_models" => observed_models,
+          "mixed_model" => (configured_models + observed_models).uniq.length > 1,
+          "tokens" => tokens_complete ? token_totals : nil,
+          "known_tokens" => token_totals,
+          "known_estimated_cost_usd" => costs.empty? ? nil : costs.sum,
+          "estimated_cost_usd" => all_priced && all_complete ? costs.sum : nil,
+          "currency" => costs.empty? ? nil : "USD",
+          "completeness" => {
+            "tokens" => tokens_complete ? "complete" : "partial",
+            "pricing" => all_priced ? "priced" : costs.empty? ? "unpriced" : "partial",
+            "overall" => all_priced && tokens_complete && all_complete ? "complete" : "partial",
+            "unknown_reasons" => sorted.flat_map { |run| Array(run.dig("completeness", "unknown_reasons")) }.uniq
+          }
+        }
+      end
+
+      def sum_tokens(tokens)
+        keys = Array(tokens).filter_map { |value| value.is_a?(Hash) ? value.keys : nil }.flatten.uniq
+        keys.to_h do |key|
+          values = Array(tokens).filter_map { |value| numeric(value[key]) if value.is_a?(Hash) }
+          [key, values.empty? ? nil : values.sum]
+        end.compact
+      end
+
+      def valid_tokens?(value)
+        value.is_a?(Hash) && %w[input_tokens cached_input_tokens output_tokens].all? do |key|
+          number = value[key]
+          number.is_a?(Numeric) && number.finite? && number >= 0
+        end
+      end
+
+      def cost_payload(amount, source, pricing, reason)
+        {
+          "amount_usd" => amount,
+          "currency" => amount.nil? ? nil : "USD",
+          "semantics" => "estimate_not_invoice",
+          "source" => source,
+          "pricing" => pricing,
+          "reason_unavailable" => reason
+        }
+      end
+
+      def write_document(document)
+        recovered = Array(document.dig("recovery", "warnings")).any? { |warning| warning.include?("atomic-write backup") }
+        FileStore.write_json(@path, document, backup: !recovered)
+      end
+
+      def with_lock(mode)
+        FileUtils.mkdir_p(File.dirname(@lock_path))
+        File.open(@lock_path, File::RDWR | File::CREAT, 0o600) do |lock|
+          lock.flock(mode)
+          yield
+        ensure
+          lock.flock(File::LOCK_UN) rescue nil
+        end
+      end
+
+      def stringify(value)
+        case value
+        when Hash then value.each_with_object({}) { |(key, entry), result| result[key.to_s] = stringify(entry) }
+        when Array then value.map { |entry| stringify(entry) }
+        else value
+        end
+      end
+
+      def deep_copy(value)
+        JSON.parse(JSON.generate(value))
+      end
+
+      def numeric(value)
+        number = Float(value)
+        number if number.finite? && number >= 0
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def present(value)
+        text = value.to_s.strip
+        text unless text.empty?
+      end
+    end
+  end
+end

--- a/lib/hq/domain/usage_metrics/store.rb
+++ b/lib/hq/domain/usage_metrics/store.rb
@@ -8,10 +8,14 @@ require "time"
 require_relative "../constants"
 require_relative "../file_store"
 require_relative "../openai_model_pricing"
+require_relative "session_aggregate"
+require_relative "values"
 
 module HQ
   module UsageMetrics
     class Store
+      include Values
+
       SCHEMA_VERSION = 1
 
       attr_reader :path, :lock_path
@@ -195,7 +199,14 @@ module HQ
       end
 
       def valid_record?(record)
-        record.is_a?(Hash) && !record["run_id"].to_s.empty? && !record["started_at"].to_s.empty?
+        return false unless record.is_a?(Hash)
+        return false if %w[run_id started_at agent_key harness_adapter].any? { |key| record[key].to_s.empty? }
+        return false if !record["native_session_id"].to_s.empty? && record["session_key"].to_s.empty?
+
+        Time.iso8601(record.fetch("started_at"))
+        true
+      rescue ArgumentError
+        false
       end
 
       def rebuild!(document)
@@ -261,49 +272,7 @@ module HQ
 
       def build_sessions(runs)
         runs.reject { |run| run["native_session_id"].to_s.empty? }.group_by { |run| run.fetch("session_key") }
-            .transform_values { |session_runs| session_record(session_runs) }
-      end
-
-      def session_record(runs)
-        sorted = runs.sort_by { |run| [run["started_at"].to_s, run["run_id"].to_s] }
-        costs = sorted.filter_map { |run| numeric(run.dig("estimated_cost", "amount_usd")) }
-        all_priced = costs.length == sorted.length
-        all_complete = sorted.all? { |run| run.dig("completeness", "overall") == "complete" }
-        tokens_complete = sorted.all? { |run| valid_tokens?(run["tokens"]) }
-        token_totals = sum_tokens(sorted.map { |run| run["tokens"] })
-        observed_models = sorted.flat_map { |run| Array(run["observed_models"]) }.uniq.sort
-        configured_models = sorted.filter_map { |run| present(run["configured_model"]) }.uniq.sort
-        {
-          "session_key" => sorted.first.fetch("session_key"),
-          "native_session_id" => sorted.first.fetch("native_session_id"),
-          "harness_adapter" => sorted.first.fetch("harness_adapter"),
-          "first_activity_at" => sorted.first.fetch("started_at"),
-          "last_activity_at" => sorted.map { |run| run["finished_at"] || run["started_at"] }.max,
-          "run_count" => sorted.length,
-          "agent_count" => sorted.map { |run| run["agent_key"] }.uniq.length,
-          "configured_models" => configured_models,
-          "observed_models" => observed_models,
-          "mixed_model" => (configured_models + observed_models).uniq.length > 1,
-          "tokens" => tokens_complete ? token_totals : nil,
-          "known_tokens" => token_totals,
-          "known_estimated_cost_usd" => costs.empty? ? nil : costs.sum,
-          "estimated_cost_usd" => all_priced && all_complete ? costs.sum : nil,
-          "currency" => costs.empty? ? nil : "USD",
-          "completeness" => {
-            "tokens" => tokens_complete ? "complete" : "partial",
-            "pricing" => all_priced ? "priced" : costs.empty? ? "unpriced" : "partial",
-            "overall" => all_priced && tokens_complete && all_complete ? "complete" : "partial",
-            "unknown_reasons" => sorted.flat_map { |run| Array(run.dig("completeness", "unknown_reasons")) }.uniq
-          }
-        }
-      end
-
-      def sum_tokens(tokens)
-        keys = Array(tokens).filter_map { |value| value.is_a?(Hash) ? value.keys : nil }.flatten.uniq
-        keys.to_h do |key|
-          values = Array(tokens).filter_map { |value| numeric(value[key]) if value.is_a?(Hash) }
-          [key, values.empty? ? nil : values.sum]
-        end.compact
+            .transform_values { |session_runs| SessionAggregate.build(session_runs) }
       end
 
       def valid_tokens?(value)
@@ -339,29 +308,10 @@ module HQ
         end
       end
 
-      def stringify(value)
-        case value
-        when Hash then value.each_with_object({}) { |(key, entry), result| result[key.to_s] = stringify(entry) }
-        when Array then value.map { |entry| stringify(entry) }
-        else value
-        end
-      end
-
       def deep_copy(value)
         JSON.parse(JSON.generate(value))
       end
 
-      def numeric(value)
-        number = Float(value)
-        number if number.finite? && number >= 0
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-      def present(value)
-        text = value.to_s.strip
-        text unless text.empty?
-      end
     end
   end
 end

--- a/lib/hq/domain/usage_metrics/values.rb
+++ b/lib/hq/domain/usage_metrics/values.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module HQ
+  module UsageMetrics
+    module Values
+      module_function
+
+      def numeric(value)
+        number = Float(value)
+        number if number.finite? && number >= 0
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def present(value)
+        text = value.to_s.strip
+        text unless text.empty?
+      end
+
+      def stringify(value)
+        case value
+        when Hash then value.each_with_object({}) { |(key, entry), result| result[key.to_s] = stringify(entry) }
+        when Array then value.map { |entry| stringify(entry) }
+        else value
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/parser/claude.rb
+++ b/lib/hq/parser/claude.rb
@@ -120,6 +120,9 @@ module HQ
         meta["terminal_reason"] = event["terminal_reason"] if event["terminal_reason"]
         meta["stop_reason"] = event["stop_reason"] if event["stop_reason"]
         meta["session_id"] = event["session_id"] if event["session_id"]
+        model_usage = event["modelUsage"] || event["model_usage"]
+        meta["model_usage"] = model_usage if model_usage.is_a?(Hash)
+        meta["model"] = event["model"] if event["model"]
 
         summary_parts = []
         summary_parts << "$#{format("%.4f", cost)}" if cost

--- a/lib/hq/parser/codex.rb
+++ b/lib/hq/parser/codex.rb
@@ -144,6 +144,7 @@ module HQ
             "reasoning_output_tokens" => reasoning_tokens
           }
         )
+        system.last.metadata["model"] = event["model"] if event["model"]
       end
 
       def parse_error(event, system)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -38,6 +38,7 @@ require_relative "domain/skill_installer"
 require_relative "domain/onboarding"
 require_relative "domain/visibility"
 require_relative "domain/web_push_notifier"
+require_relative "domain/usage_metrics"
 
 module HQ
   class RemoteServer
@@ -301,6 +302,8 @@ module HQ
         end
       end
       return ok(service.resource_snapshot) if method == "GET" && parts == ["resources"]
+      return ok(service.metrics_query(request&.query_params || {})) if method == "GET" && parts == ["metrics"]
+      return ok(service.metrics_backfill(body)) if method == "POST" && parts == ["metrics", "backfill"]
       return ok(agents: service.agents) if method == "GET" && parts == ["agents"]
       return created(agent: service.create_agent(body)) if method == "POST" && parts == ["agents"]
       return ok(schedules: service.schedules, daemon: service.schedule_daemon) if method == "GET" && parts == ["schedules"]
@@ -2492,6 +2495,21 @@ module HQ
       visible = visible_agents(agents)
       visible_keys = visible.map(&:key)
       dispatch_agent_push_events(events.select { |event| visible_keys.include?(event.agent_key) }, agents: visible)
+    end
+
+    def metrics_query(filters = {})
+      UsageMetrics.query(filters)
+    rescue ArgumentError => e
+      raise Error.new(e.message, status: 400)
+    end
+
+    def metrics_backfill(attrs = {})
+      UsageMetrics.backfill({
+        "timezone" => attrs["timezone"],
+        "include_raw" => attrs["durable_only"] != true
+      })
+    rescue ArgumentError, ConfigError => e
+      raise Error.new(e.message, status: 400)
     end
 
     def skills(project_key, agent_kind)

--- a/test/cli_command_test.rb
+++ b/test/cli_command_test.rb
@@ -25,6 +25,7 @@ module CLICommandTest
     assert_remote_client_reports_timeout_and_unsupported_operation
     assert_github_commands_cover_device_login_status_and_logout
     assert_debug_claude_is_listed_in_usage
+    assert_metrics_commands_are_listed_in_usage
     assert_debug_claude_run_agent_uses_claude_defaults
     puts "cli_command_test: ok"
   end
@@ -187,6 +188,16 @@ module CLICommandTest
       assert(!unreachable.fetch(:status).success? && unreachable.fetch(:stderr).include?("is unreachable"),
              "expected a clear unreachable-server error")
     end
+  end
+
+  def assert_metrics_commands_are_listed_in_usage
+    output = StringIO.new
+    status = HQ::CLICommand.usage(nil, err: output)
+    text = output.string
+
+    assert(status.zero?, "expected metrics help rendering to succeed")
+    assert(text.include?("metrics query") && text.include?("metrics backfill"),
+           "expected metrics query and backfill in CLI usage")
   end
 
   def assert_remote_client_reports_timeout_and_unsupported_operation

--- a/test/fixtures/metrics/claude_model_usage.jsonl
+++ b/test/fixtures/metrics/claude_model_usage.jsonl
@@ -1,0 +1,1 @@
+{"type":"result","session_id":"claude-session-1","total_cost_usd":1.5,"usage":{"input_tokens":300,"cache_creation_input_tokens":20,"cache_read_input_tokens":100,"output_tokens":60},"modelUsage":{"claude-sonnet-4-5":{"inputTokens":200,"outputTokens":40,"costUSD":1.0},"claude-haiku-4-5":{"inputTokens":100,"outputTokens":20,"costUSD":0.5}}}

--- a/test/fixtures/metrics/codex_cumulative.jsonl
+++ b/test/fixtures/metrics/codex_cumulative.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"codex-session-1"}
+{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"reasoning_output_tokens":5}}
+---RUN---
+{"type":"thread.started","thread_id":"codex-session-1"}
+{"type":"turn.completed","usage":{"input_tokens":175,"cached_input_tokens":90,"output_tokens":32,"reasoning_output_tokens":8}}

--- a/test/fixtures/metrics/historical_claude.raw.txt
+++ b/test/fixtures/metrics/historical_claude.raw.txt
@@ -1,0 +1,5 @@
+=== [2026-07-06 10:00:00] start ===
+workspace=/redacted
+
+=== process output ===
+{"type":"result","session_id":"isolated-session-1","total_cost_usd":1.5,"usage":{"input_tokens":300,"cache_creation_input_tokens":20,"cache_read_input_tokens":100,"output_tokens":60},"modelUsage":{"claude-sonnet-4-5":{"inputTokens":200,"outputTokens":40,"costUSD":1.0},"claude-haiku-4-5":{"inputTokens":100,"outputTokens":20,"costUSD":0.5}}}

--- a/test/fixtures/metrics/missing_telemetry.jsonl
+++ b/test/fixtures/metrics/missing_telemetry.jsonl
@@ -1,0 +1,1 @@
+{"type":"result","usage":{"input_tokens":10,"output_tokens":2}}

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -22,6 +22,7 @@ module RemoteServerTest
     assert_remote_agent_clone_archives_source_with_editable_name
     assert_remote_agent_payload_has_revision
     assert_remote_agent_payload_has_cost_snapshot
+    assert_remote_metrics_query_and_backfill_routes
     assert_remote_inquiry_payload_has_stable_id_and_guarded_answer
     assert_remote_agent_payload_includes_attachments
     assert_remote_agent_pull_request_diff_payload
@@ -97,6 +98,47 @@ module RemoteServerTest
       payload = service.send(:agent_payload, agent)
       assert(payload.dig(:cost_snapshot, "amount_usd") == 2.5,
              "expected remote agent payloads to expose the persisted cost snapshot")
+    end
+  end
+
+  def assert_remote_metrics_query_and_backfill_routes
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace)
+      store = HQ::UsageMetrics::Store.new(path: HQ::USAGE_METRICS_FILE)
+      store.upsert(
+        "run_id" => "remote-metric-run",
+        "agent_key" => "demo-agent-1",
+        "project_key" => "demo",
+        "group" => "work",
+        "harness" => "claude",
+        "harness_adapter" => "claude",
+        "configured_model" => "configured-model",
+        "observed_models" => ["observed-model"],
+        "native_session_id" => "remote-session",
+        "session_key" => "claude:remote-session",
+        "started_at" => Time.utc(2026, 7, 6, 10).iso8601,
+        "status" => "succeeded",
+        "tokens" => { "input_tokens" => 10, "cached_input_tokens" => 0, "output_tokens" => 2 },
+        "estimated_cost" => {
+          "amount_usd" => 1.25,
+          "currency" => "USD",
+          "semantics" => "estimate_not_invoice",
+          "source" => "claude_reported_estimate"
+        },
+        "completeness" => { "overall" => "complete", "unknown_reasons" => [] },
+        "provenance" => { "source" => "fixture", "event_count" => 0 }
+      )
+      service = HQ::RemoteService.new(registry: registry)
+      server = HQ::RemoteServer.new
+
+      query = server.send(:route, service, "GET", "/metrics", {}, nil)
+      assert(query.dig(:body, "summary", "run_starts") == 1, "expected Remote API metrics query")
+      assert(query.dig(:body, "summary", "known_estimated_cost_usd") == 1.25,
+             "expected Remote API cost summary")
+      backfill = server.send(:route, service, "POST", "/metrics/backfill", { "durable_only" => true }, nil)
+      assert(backfill.dig(:body, "status") == "success", "expected Remote API backfill route")
     end
   end
 
@@ -200,6 +242,7 @@ module RemoteServerTest
   def assert_remote_agent_lifecycle
     Dir.mktmpdir("hq-remote-test") do |dir|
       old_agents_file = replace_constant(HQ, :AGENTS_FILE, File.join(dir, "managed_agents.json"))
+      old_usage_metrics_file = replace_constant(HQ, :USAGE_METRICS_FILE, File.join(dir, "usage_metrics.json"))
       old_logs_dir = replace_constant(HQ, :AGENT_LOGS_DIR, File.join(dir, "agents"))
       old_archive_dir = replace_constant(HQ, :AGENT_ARCHIVE_DIR, File.join(dir, "agents", "archive"))
 
@@ -235,6 +278,7 @@ module RemoteServerTest
       assert(service.agents.empty?, "expected archived agent to be removed from active list")
     ensure
       replace_constant(HQ, :AGENTS_FILE, old_agents_file) if old_agents_file
+      replace_constant(HQ, :USAGE_METRICS_FILE, old_usage_metrics_file) if old_usage_metrics_file
       replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
       replace_constant(HQ, :AGENT_ARCHIVE_DIR, old_archive_dir) if old_archive_dir
     end
@@ -5448,6 +5492,7 @@ module RemoteServerTest
   def with_remote_temp_store
     Dir.mktmpdir("hq-remote-test") do |dir|
       old_agents_file = replace_constant(HQ, :AGENTS_FILE, File.join(dir, "managed_agents.json"))
+      old_usage_metrics_file = replace_constant(HQ, :USAGE_METRICS_FILE, File.join(dir, "usage_metrics.json"))
       old_schedules_file = replace_constant(HQ, :SCHEDULES_FILE, File.join(dir, "config", "schedules.yml"))
       old_schedules_state_file = replace_constant(HQ, :SCHEDULES_STATE_FILE, File.join(dir, "schedules.json"))
       old_scheduler_daemon_file = replace_constant(HQ, :SCHEDULER_DAEMON_FILE, File.join(dir, "scheduler_daemon.json"))
@@ -5472,6 +5517,7 @@ module RemoteServerTest
       yield dir
     ensure
       replace_constant(HQ, :AGENTS_FILE, old_agents_file) if old_agents_file
+      replace_constant(HQ, :USAGE_METRICS_FILE, old_usage_metrics_file) if old_usage_metrics_file
       replace_constant(HQ, :SCHEDULES_FILE, old_schedules_file) if old_schedules_file
       replace_constant(HQ, :SCHEDULES_STATE_FILE, old_schedules_state_file) if old_schedules_state_file
       replace_constant(HQ, :SCHEDULER_DAEMON_FILE, old_scheduler_daemon_file) if old_scheduler_daemon_file

--- a/test/usage_metrics_test.rb
+++ b/test/usage_metrics_test.rb
@@ -1,0 +1,348 @@
+# frozen_string_literal: true
+
+require "json"
+require "tmpdir"
+
+require_relative "../lib/hq/domain/usage_metrics"
+require_relative "../lib/hq/domain/managed_agent"
+require_relative "../lib/hq/parser"
+
+module UsageMetricsTest
+  module_function
+
+  FixtureAgent = Struct.new(
+    :key, :project_key, :project_group, :agent, :model, :session_id, :runs,
+    keyword_init: true
+  )
+
+  def run!
+    assert_codex_cumulative_usage_is_normalized_and_idempotent
+    assert_managed_run_finalization_persists_once
+    assert_claude_model_usage_preserves_mixed_model_attribution
+    assert_unknown_ids_models_and_prices_stay_unknown
+    assert_retries_resumes_filters_and_report_statistics
+    assert_archive_transition_preserves_metrics_and_manifest
+    assert_timezone_boundaries_are_inclusive_exclusive
+    assert_backfill_prefers_manifests_and_is_idempotent
+    assert_schema_migration_and_corruption_recovery
+    puts "usage_metrics_test: ok"
+  end
+
+  def assert_codex_cumulative_usage_is_normalized_and_idempotent
+    with_store do |store|
+      segments = fixture_segments("codex_cumulative.jsonl")
+      first = run("run-1", 10, session_id: "codex-session-1")
+      second = run("run-2", 11, session_id: "codex-session-1")
+      agent = agent("codex", "gpt-5.5", [first], session_id: "codex-session-1")
+
+      first_record = normalize(agent, first, usage_entries(segments[0], "codex"))
+      agent.runs << second
+      second_record = normalize(agent, second, usage_entries(segments[1], "codex"))
+      assert(store.upsert(first_record) == :created, "expected first ingestion to create a run")
+      assert(store.upsert(second_record) == :created, "expected resumed run ingestion to create a run")
+      assert(store.upsert(second_record) == :unchanged, "expected repeated ingestion to be idempotent")
+
+      runs = store.runs.sort_by { |record| record["started_at"] }
+      assert(runs[0].dig("tokens", "input_tokens") == 100, "expected first Codex cumulative snapshot as its delta")
+      assert(runs[1].dig("tokens", "input_tokens") == 75, "expected resumed Codex input delta")
+      assert(runs[1].dig("tokens", "cached_input_tokens") == 50, "expected resumed Codex cached delta")
+      assert_close(runs[0].dig("estimated_cost", "amount_usd"), 0.00092)
+      assert_close(runs[1].dig("estimated_cost", "amount_usd"), 0.00051)
+      assert(runs[1].dig("estimated_cost", "pricing", "version") == HQ::OpenAIModelPricing::PRICE_DATE,
+             "expected versioned Codex pricing provenance")
+      session = store.sessions.fetch(0)
+      assert(session["run_count"] == 2, "expected distinct runs inside one native session")
+      assert_close(session["known_estimated_cost_usd"], 0.00143)
+      assert(session["estimated_cost_usd"].nil?,
+             "expected missing observed-model telemetry to keep the session incomplete")
+    end
+  end
+
+  def assert_claude_model_usage_preserves_mixed_model_attribution
+    with_store do |store|
+      current = run("claude-run", 12, session_id: "claude-session-1", model: "configured-alias")
+      fixture_agent = agent("claude", "configured-alias", [current], session_id: "claude-session-1")
+      record = normalize(fixture_agent, current, usage_entries(fixture("claude_model_usage.jsonl"), "claude"))
+      store.upsert(record)
+
+      stored = store.runs.fetch(0)
+      assert(stored["configured_model"] == "configured-alias", "expected configured model to remain distinct")
+      assert(stored["observed_models"] == %w[claude-haiku-4-5 claude-sonnet-4-5],
+             "expected both observed models")
+      assert(stored["model_attribution"].map { |item| item["estimated_cost_usd"] }.sum == 1.5,
+             "expected modelUsage cost attribution")
+      assert(stored.dig("estimated_cost", "pricing", "version").nil? &&
+             stored.dig("estimated_cost", "pricing", "version_unknown_reason").include?("did not report"),
+             "expected an explicit unknown Claude pricing version")
+      assert(store.sessions.fetch(0)["mixed_model"] == true, "expected mixed-model session marker")
+    end
+  end
+
+  def assert_managed_run_finalization_persists_once
+    Dir.mktmpdir("usage-metrics-finalization") do |dir|
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "metrics.json"))
+      started = Time.utc(2026, 7, 6, 9)
+      marker = "=== [#{started.strftime("%Y-%m-%d %H:%M:%S")}] start ===\n"
+      raw = File.join(dir, "managed.raw.log")
+      File.write(raw, marker + fixture("claude_model_usage.jsonl").join("\n") + "\n")
+      current = HQ::ManagedAgent::AgentRun.new(
+        run_id: "finalized-run", started_at: started, finished_at: started + 60,
+        status: "succeeded", session_id: "claude-session-1", agent: "claude",
+        model: "configured-model", log_path: raw, log_start_offset: marker.bytesize
+      )
+      managed = HQ::ManagedAgent.new(
+        key: "demo-agent-finalized", name: "Finalized", project_key: "demo", project_group: "work",
+        template_key: "custom", workspace: dir, prompt: "prompt", log_path: raw,
+        started_at: started, finished_at: started + 60, agent: "claude", model: "configured-model",
+        runs: [current]
+      )
+      managed.usage_metrics_store = store
+
+      managed.send(:capture_run_memory!, current)
+      managed.send(:capture_run_memory!, current)
+      assert(store.runs.length == 1, "expected repeated finalization capture not to double-count")
+      assert(store.runs.fetch(0)["run_id"] == "finalized-run", "expected persisted lifecycle run identity")
+    end
+  end
+
+  def assert_unknown_ids_models_and_prices_stay_unknown
+    with_store do |store|
+      current = run("unknown-run", 13, session_id: nil, model: nil)
+      fixture_agent = agent("claude", nil, [current])
+      record = normalize(fixture_agent, current, usage_entries(fixture("missing_telemetry.jsonl"), "claude"))
+      store.upsert(record)
+      result = HQ::UsageMetrics::Query.new(metrics_store: store).call
+      stored = result.fetch("runs").fetch(0)
+
+      assert(stored["native_session_id"].nil?, "expected absent native ID to remain nil")
+      assert(stored["configured_model"].nil?, "expected absent model to remain nil")
+      assert(stored.dig("estimated_cost", "amount_usd").nil?, "expected absent price to remain nil")
+      assert(result.dig("summary", "known_estimated_cost_usd").nil?, "expected no fabricated zero total")
+      assert(result.dig("summary", "unpriced_run_count") == 1, "expected explicit unpriced coverage")
+      assert(stored.dig("completeness", "unknown_reasons").any? { |reason| reason.include?("session ID") },
+             "expected session unknown reason")
+    end
+  end
+
+  def assert_retries_resumes_filters_and_report_statistics
+    with_store do |store|
+      records = [
+        priced_record("failed-retry", "session-a", 1.0, status: "failed", harness: "claude", hour: 10),
+        priced_record("successful-resume", "session-a", 2.0, status: "succeeded", harness: "claude", hour: 11),
+        priced_record("other-session", "session-b", 5.0, status: "succeeded", harness: "claude", hour: 12),
+        priced_record("unpriced-session", "session-c", nil, status: "succeeded", harness: "codex", hour: 13)
+      ]
+      records.each { |record| store.upsert(record) }
+      result = HQ::UsageMetrics::Query.new(metrics_store: store).call(
+        "project" => "demo", "group" => "work", "harness" => "claude,codex"
+      )
+
+      assert(result.dig("summary", "run_starts") == 4, "expected retry and resume as distinct run starts")
+      assert(result.dig("summary", "distinct_native_sessions") == 3, "expected three native sessions")
+      assert_close(result.dig("summary", "average_runs_per_session"), 4.0 / 3)
+      assert_close(result.dig("summary", "known_estimated_cost_usd"), 8.0)
+      assert_close(result.dig("summary", "median_complete_session_cost_usd"), 4.0)
+      assert_close(result.dig("summary", "max_complete_session_cost_usd"), 5.0)
+      assert(result.dig("summary", "priced_run_count") == 3, "expected priced run coverage")
+      assert(result.dig("summary", "unpriced_run_count") == 1, "expected unpriced run coverage")
+
+      failed = HQ::UsageMetrics::Query.new(metrics_store: store).call("status" => "failed")
+      assert(failed.dig("summary", "run_starts") == 1, "expected status filter")
+      model = HQ::UsageMetrics::Query.new(metrics_store: store).call("model" => "observed-model")
+      assert(model.dig("summary", "run_starts") == 4, "expected observed-model filter")
+    end
+  end
+
+  def assert_archive_transition_preserves_metrics_and_manifest
+    Dir.mktmpdir("usage-metrics-archive") do |dir|
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "usage_metrics.json"))
+      raw = File.join(dir, "agent.raw.log")
+      File.write(raw, "telemetry")
+      current = run("archive-run", 14, session_id: "archive-session")
+      fixture_agent = HQ::ManagedAgent.new(
+        key: "demo-agent-archive", name: "Archive", project_key: "demo", project_group: "work",
+        template_key: "custom", workspace: dir, prompt: "sensitive prompt", log_path: raw,
+        agent: "claude", model: "configured-model", runs: [current]
+      )
+      fixture_agent.usage_metrics_store = store
+      metric = priced_record("archive-run", "archive-session", 2.5, hour: 14)
+      metric["agent_key"] = "demo-agent-archive"
+      store.upsert(metric)
+      before = HQ::UsageMetrics::Query.new(metrics_store: store).call.fetch("summary")
+      destination = fixture_agent.archive_logs!(File.join(dir, "archive"))
+      after = HQ::UsageMetrics::Query.new(metrics_store: store).call.fetch("summary")
+
+      assert(before == after, "expected archive transition not to change totals")
+      assert(store.runs.fetch(0)["archived"] == true, "expected global query path to mark archive state")
+      manifest = JSON.parse(File.read(File.join(destination, "agent_manifest.json")))
+      snapshot = JSON.parse(File.read(File.join(destination, "usage_metrics.json")))
+      assert(manifest["agent"] == "claude", "expected exact harness in archived manifest")
+      assert(manifest["model"] == "configured-model", "expected exact model in archived manifest")
+      assert(snapshot.fetch("runs").fetch(0).dig("estimated_cost", "amount_usd") == 2.5,
+             "expected archived metric snapshot")
+    end
+  end
+
+  def assert_timezone_boundaries_are_inclusive_exclusive
+    with_store do |store|
+      store.upsert(priced_record("at-start", "tz-a", 1.0, hour: 17, day: 5)) # midnight Jakarta on July 6
+      store.upsert(priced_record("at-end", "tz-b", 2.0, hour: 17, day: 6))   # midnight Jakarta on July 7
+      result = HQ::UsageMetrics::Query.new(metrics_store: store).call(
+        "from" => "2026-07-06", "to" => "2026-07-07", "timezone" => "Asia/Jakarta"
+      )
+
+      assert(result.dig("summary", "run_starts") == 1, "expected inclusive start and exclusive end")
+      assert(result.fetch("runs").fetch(0)["run_id"] == "at-start", "expected Jakarta boundary conversion")
+      assert(result.dig("query", "range_semantics") == "from_inclusive_to_exclusive", "expected explicit semantics")
+    end
+  end
+
+  def assert_schema_migration_and_corruption_recovery
+    Dir.mktmpdir("usage-metrics-recovery") do |dir|
+      path = File.join(dir, "usage_metrics.json")
+      legacy = priced_record("legacy", "legacy-session", 1.0)
+      File.write(path, JSON.generate("records" => [legacy]))
+      store = HQ::UsageMetrics::Store.new(path: path)
+      assert(store.snapshot.fetch("schema_version") == 1, "expected schema migration")
+      assert(store.runs.length == 1, "expected migrated record")
+
+      HQ::FileStore.write_json(path, store.snapshot)
+      updated = store.snapshot
+      updated["generated_at"] = "newer"
+      HQ::FileStore.write_json(path, updated)
+      File.write(path, "{partial")
+      recovered = store.snapshot
+      assert(recovered.fetch("runs").length == 1, "expected backup recovery after partial write corruption")
+      assert(recovered.dig("recovery", "warnings").any? { |warning| warning.include?("backup") },
+             "expected explicit recovery warning")
+
+      partial = recovered.merge("runs" => recovered.fetch("runs").merge("bad" => { "run_id" => "bad" }))
+      File.write(path, JSON.generate(partial))
+      assert(store.snapshot.dig("recovery", "discarded_run_count") == 1, "expected invalid partial record handling")
+    end
+  end
+
+  def assert_backfill_prefers_manifests_and_is_idempotent
+    Dir.mktmpdir("usage-metrics-backfill") do |dir|
+      path = File.join(dir, "legacy.raw.log")
+      marker = "=== [2026-07-06 10:00:00] start ===\n"
+      File.write(path, marker + fixture("claude_model_usage.jsonl").join("\n") + "\n")
+      current = HQ::ManagedAgent::AgentRun.new(
+        run_id: "manifest-run", started_at: Time.new(2026, 7, 6, 10, 0, 0, "+07:00"),
+        finished_at: Time.new(2026, 7, 6, 10, 1, 0, "+07:00"), status: "succeeded",
+        session_id: "claude-session-1", agent: "claude", model: "configured-exact",
+        log_path: path, log_start_offset: marker.bytesize
+      )
+      fixture_agent = HQ::ManagedAgent.new(
+        key: "demo-agent-backfill", name: "Backfill", project_key: "demo", project_group: "work",
+        template_key: "custom", workspace: dir, prompt: "prompt", log_path: path,
+        agent: "claude", model: "configured-exact", runs: [current]
+      )
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "metrics.json"))
+      registry = Struct.new(:projects).new([Struct.new(:key, :group).new("demo", "work")])
+      options = {
+        "registry" => registry,
+        "manifests" => [{ "agent" => fixture_agent, "archived" => false, "directory" => nil }],
+        "raw_paths" => [path],
+        "timezone" => "Asia/Jakarta"
+      }
+
+      first = HQ::UsageMetrics.backfill(options, metrics_store: store)
+      second = HQ::UsageMetrics.backfill(options, metrics_store: store)
+      assert(first["created"] == 1 && first["raw_fallback_run_count"] == 0,
+             "expected the durable manifest to claim its raw segment")
+      assert(second["unchanged"] == 1 && store.runs.length == 1, "expected idempotent repeated backfill")
+      assert(store.runs.fetch(0)["configured_model"] == "configured-exact",
+             "expected durable model provenance to win")
+    end
+  end
+
+  def priced_record(id, session_id, cost, status: "succeeded", harness: "claude", hour: 10, day: 6)
+    {
+      "schema_version" => 1,
+      "run_id" => id,
+      "agent_key" => id.start_with?("other") ? "demo-agent-2" : "demo-agent-1",
+      "project_key" => "demo",
+      "group" => "work",
+      "harness" => harness,
+      "harness_adapter" => harness,
+      "configured_model" => "configured-model",
+      "observed_models" => ["observed-model"],
+      "model_attribution" => [],
+      "native_session_id" => session_id,
+      "session_key" => "#{harness}:#{session_id}",
+      "started_at" => Time.utc(2026, 7, day, hour).iso8601(6),
+      "finished_at" => Time.utc(2026, 7, day, hour, 1).iso8601(6),
+      "duration_ms" => 60_000,
+      "status" => status,
+      "tokens" => { "input_tokens" => 10, "cached_input_tokens" => 0, "output_tokens" => 2 },
+      "estimated_cost" => {
+        "amount_usd" => cost,
+        "currency" => cost.nil? ? nil : "USD",
+        "semantics" => "estimate_not_invoice",
+        "source" => cost.nil? ? "unpriced" : "claude_reported_estimate",
+        "reason_unavailable" => cost.nil? ? "Price unavailable" : nil
+      }.compact,
+      "completeness" => {
+        "overall" => cost.nil? ? "partial" : "complete",
+        "unknown_reasons" => cost.nil? ? ["Price unavailable"] : []
+      },
+      "provenance" => { "source" => "fixture", "event_count" => 0 },
+      "archived" => false
+    }
+  end
+
+  def normalize(fixture_agent, current_run, entries)
+    HQ::UsageMetrics::Normalizer.new(
+      agent: fixture_agent, run: current_run, usage_entries: entries, source: "fixture"
+    ).record
+  end
+
+  def agent(harness, model, runs, session_id: nil)
+    FixtureAgent.new(
+      key: "demo-agent-1", project_key: "demo", project_group: "work", agent: harness,
+      model: model, session_id: session_id, runs: runs
+    )
+  end
+
+  def run(id, hour, session_id:, model: nil)
+    HQ::ManagedAgent::AgentRun.new(
+      run_id: id,
+      started_at: Time.utc(2026, 7, 6, hour),
+      finished_at: Time.utc(2026, 7, 6, hour, 1),
+      status: "succeeded",
+      exit_code: 0,
+      session_id: session_id,
+      model: model
+    )
+  end
+
+  def usage_entries(lines, harness)
+    _conversation, system = HQ::Parser.parse_stream(lines, agent_type: harness)
+    system.select { |entry| entry.type == :usage }
+  end
+
+  def fixture_segments(name)
+    fixture(name).slice_before { |line| line == "---RUN---" }.map { |lines| lines.reject { |line| line == "---RUN---" } }
+  end
+
+  def fixture(name)
+    File.readlines(File.join(__dir__, "fixtures", "metrics", name), chomp: true)
+  end
+
+  def with_store
+    Dir.mktmpdir("usage-metrics") do |dir|
+      yield HQ::UsageMetrics::Store.new(path: File.join(dir, "usage_metrics.json"))
+    end
+  end
+
+  def assert_close(actual, expected)
+    assert(!actual.nil? && (actual - expected).abs < 0.000_000_001, "expected #{actual.inspect} to equal #{expected}")
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+end
+
+UsageMetricsTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/usage_metrics_test.rb
+++ b/test/usage_metrics_test.rb
@@ -21,9 +21,13 @@ module UsageMetricsTest
     assert_claude_model_usage_preserves_mixed_model_attribution
     assert_unknown_ids_models_and_prices_stay_unknown
     assert_retries_resumes_filters_and_report_statistics
+    assert_start_failure_is_ingested_immediately
     assert_archive_transition_preserves_metrics_and_manifest
     assert_timezone_boundaries_are_inclusive_exclusive
     assert_backfill_prefers_manifests_and_is_idempotent
+    assert_backfill_identity_survives_archive_move
+    assert_missing_manifest_telemetry_is_preserved
+    assert_trimmed_codex_history_has_unknown_baseline
     assert_schema_migration_and_corruption_recovery
     puts "usage_metrics_test: ok"
   end
@@ -53,8 +57,9 @@ module UsageMetricsTest
       session = store.sessions.fetch(0)
       assert(session["run_count"] == 2, "expected distinct runs inside one native session")
       assert_close(session["known_estimated_cost_usd"], 0.00143)
-      assert(session["estimated_cost_usd"].nil?,
-             "expected missing observed-model telemetry to keep the session incomplete")
+      assert_close(session["estimated_cost_usd"], 0.00143)
+      assert(session.dig("completeness", "overall") == "partial",
+             "expected pricing completeness to remain distinct from missing model metadata")
     end
   end
 
@@ -130,26 +135,48 @@ module UsageMetricsTest
         priced_record("failed-retry", "session-a", 1.0, status: "failed", harness: "claude", hour: 10),
         priced_record("successful-resume", "session-a", 2.0, status: "succeeded", harness: "claude", hour: 11),
         priced_record("other-session", "session-b", 5.0, status: "succeeded", harness: "claude", hour: 12),
-        priced_record("unpriced-session", "session-c", nil, status: "succeeded", harness: "codex", hour: 13)
+        priced_record("unpriced-session", "session-c", nil, status: "succeeded", harness: "codex", hour: 13),
+        priced_record("orphan-run", nil, nil, status: "failed", harness: "claude", hour: 14)
       ]
+      records[2]["completeness"] = {
+        "overall" => "partial", "unknown_reasons" => ["Observed model was not reported"]
+      }
       records.each { |record| store.upsert(record) }
       result = HQ::UsageMetrics::Query.new(metrics_store: store).call(
         "project" => "demo", "group" => "work", "harness" => "claude,codex"
       )
 
-      assert(result.dig("summary", "run_starts") == 4, "expected retry and resume as distinct run starts")
+      assert(result.dig("summary", "run_starts") == 5, "expected retry, resume, and orphan as distinct run starts")
       assert(result.dig("summary", "distinct_native_sessions") == 3, "expected three native sessions")
       assert_close(result.dig("summary", "average_runs_per_session"), 4.0 / 3)
       assert_close(result.dig("summary", "known_estimated_cost_usd"), 8.0)
-      assert_close(result.dig("summary", "median_complete_session_cost_usd"), 4.0)
-      assert_close(result.dig("summary", "max_complete_session_cost_usd"), 5.0)
+      assert_close(result.dig("summary", "median_priced_session_cost_usd"), 4.0)
+      assert_close(result.dig("summary", "max_priced_session_cost_usd"), 5.0)
       assert(result.dig("summary", "priced_run_count") == 3, "expected priced run coverage")
-      assert(result.dig("summary", "unpriced_run_count") == 1, "expected unpriced run coverage")
+      assert(result.dig("summary", "unpriced_run_count") == 2, "expected unpriced run coverage")
 
       failed = HQ::UsageMetrics::Query.new(metrics_store: store).call("status" => "failed")
-      assert(failed.dig("summary", "run_starts") == 1, "expected status filter")
+      assert(failed.dig("summary", "run_starts") == 2, "expected status filter")
       model = HQ::UsageMetrics::Query.new(metrics_store: store).call("model" => "observed-model")
-      assert(model.dig("summary", "run_starts") == 4, "expected observed-model filter")
+      assert(model.dig("summary", "run_starts") == 5, "expected observed-model filter")
+    end
+  end
+
+  def assert_start_failure_is_ingested_immediately
+    Dir.mktmpdir("usage-metrics-start-failure") do |dir|
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "metrics.json"))
+      managed = HQ::ManagedAgent.new(
+        key: "demo-agent-launch-failure", name: "Launch failure", project_key: "demo", project_group: "work",
+        template_key: "custom", workspace: dir, prompt: "prompt", log_path: File.join(dir, "agent.raw.log"),
+        agent: "claude", model: "configured-model"
+      )
+      managed.usage_metrics_store = store
+      managed.send(:record_start_failure!, "executable unavailable", ["missing-command"])
+
+      metric = store.runs.fetch(0)
+      assert(metric["status"] == "failed" && !metric["run_id"].to_s.empty?,
+             "expected launch failure lifecycle ingestion with a persisted identity")
+      assert(metric.dig("estimated_cost", "amount_usd").nil?, "expected launch failure cost to remain unknown")
     end
   end
 
@@ -180,6 +207,9 @@ module UsageMetricsTest
       assert(manifest["model"] == "configured-model", "expected exact model in archived manifest")
       assert(snapshot.fetch("runs").fetch(0).dig("estimated_cost", "amount_usd") == 2.5,
              "expected archived metric snapshot")
+      public_metrics = JSON.generate(HQ::UsageMetrics::Query.new(metrics_store: store).call)
+      assert(!public_metrics.include?("sensitive prompt") && !public_metrics.include?(dir),
+             "expected metric output to exclude prompts and internal paths")
     end
   end
 
@@ -219,6 +249,13 @@ module UsageMetricsTest
       partial = recovered.merge("runs" => recovered.fetch("runs").merge("bad" => { "run_id" => "bad" }))
       File.write(path, JSON.generate(partial))
       assert(store.snapshot.dig("recovery", "discarded_run_count") == 1, "expected invalid partial record handling")
+
+      broken_session = priced_record("broken-session", "native-id", 1.0).tap { |record| record.delete("session_key") }
+      File.write(path, JSON.generate(recovered.merge("runs" => { "broken-session" => broken_session })))
+      structurally_recovered = store.snapshot
+      assert(structurally_recovered.fetch("runs").empty? &&
+             structurally_recovered.dig("recovery", "discarded_run_count") == 1,
+             "expected structurally incomplete session records to be discarded without crashing")
     end
   end
 
@@ -257,6 +294,85 @@ module UsageMetricsTest
     end
   end
 
+  def assert_backfill_identity_survives_archive_move
+    Dir.mktmpdir("usage-metrics-backfill-archive") do |dir|
+      active_dir = File.join(dir, "active")
+      archive_dir = File.join(dir, "archive", "20260706-100000-demo-agent-backfill")
+      FileUtils.mkdir_p(active_dir)
+      path = File.join(active_dir, "legacy.raw.log")
+      marker = "=== [2026-07-06 10:00:00] start ===\n"
+      File.write(path, marker + fixture("claude_model_usage.jsonl").join("\n") + "\n")
+      current = HQ::ManagedAgent::AgentRun.new(
+        started_at: Time.new(2026, 7, 6, 10, 0, 0, "+07:00"), status: "succeeded",
+        session_id: "claude-session-1", agent: "claude", log_path: path, log_start_offset: marker.bytesize
+      )
+      fixture_agent = HQ::ManagedAgent.new(
+        key: "demo-agent-backfill", name: "Backfill", project_key: "demo", project_group: "work",
+        template_key: "custom", workspace: dir, prompt: "prompt", log_path: path,
+        agent: "claude", model: "configured-exact", runs: [current]
+      )
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "metrics.json"))
+      registry = Struct.new(:projects).new([])
+      active = { "registry" => registry, "manifests" => [{ "agent" => fixture_agent, "archived" => false }],
+                 "raw_paths" => [], "timezone" => "Asia/Jakarta" }
+      HQ::UsageMetrics.backfill(active, metrics_store: store)
+      FileUtils.mkdir_p(archive_dir)
+      FileUtils.mv(path, File.join(archive_dir, File.basename(path)))
+      archived = active.merge("manifests" => [{ "agent" => fixture_agent, "archived" => true,
+                                                 "directory" => archive_dir }])
+      outcome = HQ::UsageMetrics.backfill(archived, metrics_store: store)
+
+      assert(store.runs.length == 1 && outcome["created"].zero?,
+             "expected location-independent backfill identity across archive move")
+      assert(store.runs.fetch(0)["archived"] == true, "expected the existing metric to transition to archived")
+    end
+  end
+
+  def assert_missing_manifest_telemetry_is_preserved
+    Dir.mktmpdir("usage-metrics-missing-telemetry") do |dir|
+      missing = File.join(dir, "missing.raw.log")
+      current = HQ::ManagedAgent::AgentRun.new(
+        run_id: "missing-log-run", started_at: Time.utc(2026, 7, 6, 10), status: "failed",
+        agent: "claude", log_path: missing
+      )
+      fixture_agent = agent("claude", nil, [current])
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "metrics.json"))
+      options = { "registry" => Struct.new(:projects).new([]),
+                  "manifests" => [{ "agent" => fixture_agent, "archived" => false }], "raw_paths" => [] }
+      HQ::UsageMetrics.backfill(options, metrics_store: store)
+
+      metric = store.runs.fetch(0)
+      assert(metric.dig("completeness", "unknown_reasons").include?("Raw telemetry for the durable run was unavailable"),
+             "expected durable run with missing telemetry and an explicit unknown reason")
+    end
+  end
+
+  def assert_trimmed_codex_history_has_unknown_baseline
+    Dir.mktmpdir("usage-metrics-trimmed-codex") do |dir|
+      path = File.join(dir, "codex.raw.log")
+      marker = "=== [2026-07-06 10:00:00] start ===\n"
+      File.write(path, marker + fixture_segments("codex_cumulative.jsonl").first.join("\n") + "\n")
+      current = HQ::ManagedAgent::AgentRun.new(
+        started_at: Time.new(2026, 7, 6, 10, 0, 0, "+07:00"), status: "succeeded",
+        session_id: "codex-session-1", agent: "codex", model: "gpt-5.5",
+        log_path: path, log_start_offset: marker.bytesize
+      )
+      fixture_agent = HQ::ManagedAgent.new(
+        key: "demo-agent-codex", name: "Codex", project_key: "demo", project_group: "work",
+        template_key: "custom", workspace: dir, prompt: "prompt", log_path: path,
+        agent: "codex", model: "gpt-5.5", runs: [current], total_run_count: 2
+      )
+      store = HQ::UsageMetrics::Store.new(path: File.join(dir, "metrics.json"))
+      options = { "registry" => Struct.new(:projects).new([]),
+                  "manifests" => [{ "agent" => fixture_agent, "archived" => false }], "raw_paths" => [] }
+      HQ::UsageMetrics.backfill(options, metrics_store: store)
+
+      metric = store.runs.fetch(0)
+      assert(metric["tokens"].nil? && metric["codex_baseline_known"] == false,
+             "expected retained cumulative telemetry not to become a false zero-baseline delta")
+    end
+  end
+
   def priced_record(id, session_id, cost, status: "succeeded", harness: "claude", hour: 10, day: 6)
     {
       "schema_version" => 1,
@@ -270,7 +386,7 @@ module UsageMetricsTest
       "observed_models" => ["observed-model"],
       "model_attribution" => [],
       "native_session_id" => session_id,
-      "session_key" => "#{harness}:#{session_id}",
+      "session_key" => session_id ? "#{harness}:#{session_id}" : nil,
       "started_at" => Time.utc(2026, 7, day, hour).iso8601(6),
       "finished_at" => Time.utc(2026, 7, day, hour, 1).iso8601(6),
       "duration_ms" => 60_000,


### PR DESCRIPTION
Implements Fizzy #125 end to end.

Summary:
- adds a versioned, atomic, concurrency-safe run/session metrics store with provider-specific normalization, provenance, completeness, and idempotent identities
- integrates managed-run finalization and archive preservation, plus CLI and Remote API query/backfill surfaces
- adds historical backfill, report artifacts for 2026-07-06 through 2026-08-06, operational documentation, and fixture-driven regression coverage

Validation:
- bin/test
- focused usage metrics, CLI, and Remote API tests
- isolated CLI/API backfill and query checks
- idempotent production-history backfill: 0 created, 0 updated, 5792 unchanged
- report artifact exact-match check
- git diff and secret/path exposure checks
- independent standards and specification reviews, with all actionable findings fixed

Costs are estimates, not invoices. This PR does not merge or close the Fizzy card.