### PR TITLE
Speed up pull request detail and diff fetching

### DIFF
--- a/lib/hq/domain/github_auth.rb
+++ b/lib/hq/domain/github_auth.rb
@@ -473,6 +473,7 @@ module HQ
         @runner = runner
         @timeout = timeout
         @now = now
+        @token_lock = Mutex.new
       end
 
       def available?
@@ -484,18 +485,20 @@ module HQ
       end
 
       def token
-        now = @now.call
-        return @token if defined?(@token_checked_at) && now - @token_checked_at < CACHE_TTL
+        @token_lock.synchronize do
+          now = @now.call
+          return @token if defined?(@token_checked_at) && now - @token_checked_at < CACHE_TTL
 
-        @token_checked_at = now
-        return @token = nil unless available?
+          @token_checked_at = now
+          return @token = nil unless available?
 
-        stdout, _stderr, status = Timeout.timeout(@timeout) do
-          @runner.capture3(@resolution.command, "auth", "token")
+          stdout, _stderr, status = Timeout.timeout(@timeout) do
+            @runner.capture3(@resolution.command, "auth", "token")
+          end
+          @token = status.success? ? stdout.to_s.strip : nil
+          @token = nil if @token.to_s.empty? || @token.to_s.bytesize > 4_096
+          @token
         end
-        @token = status.success? ? stdout.to_s.strip : nil
-        @token = nil if @token.to_s.empty? || @token.to_s.bytesize > 4_096
-        @token
       rescue Timeout::Error, SystemCallError
         @token = nil
       end

--- a/lib/hq/domain/pull_request_diff.rb
+++ b/lib/hq/domain/pull_request_diff.rb
@@ -111,8 +111,31 @@ module HQ
       end
 
       def metadata(reference)
+        metadata_with_pull(reference).first
+      end
+
+      def metadata_with_pull(reference)
         response = @client.get_json("/repos/#{reference.repository}/pulls/#{reference.number}")
         data = response.body
+        [metadata_from(reference, data, response), data]
+      rescue GitHubAPIClient::Error => e
+        raise Error.new(e.message, status: e.status)
+      end
+
+      def patch(reference)
+        response = @client.get_text(
+          "/repos/#{reference.repository}/pulls/#{reference.number}",
+          accept: "application/vnd.github.diff"
+        )
+        output, truncated = structurally_truncate(response.body)
+        [output, truncated]
+      rescue GitHubAPIClient::Error => e
+        raise Error.new(e.message, status: e.status)
+      end
+
+      private
+
+      def metadata_from(reference, data, response)
         {
           "title" => data["title"],
           "body" => data["body"],
@@ -134,22 +157,7 @@ module HQ
           "etag" => response.etag,
           "rate_limit" => response.rate_limit
         }.compact
-      rescue GitHubAPIClient::Error => e
-        raise Error.new(e.message, status: e.status)
       end
-
-      def patch(reference)
-        response = @client.get_text(
-          "/repos/#{reference.repository}/pulls/#{reference.number}",
-          accept: "application/vnd.github.diff"
-        )
-        output, truncated = structurally_truncate(response.body)
-        [output, truncated]
-      rescue GitHubAPIClient::Error => e
-        raise Error.new(e.message, status: e.status)
-      end
-
-      private
 
       def structurally_truncate(output)
         return [output, false] if output.bytesize <= MAX_PATCH_BYTES
@@ -216,8 +224,8 @@ module HQ
         "https://github.com/#{repository}/pull/#{number}"
       end
 
-      def snapshot_for(reference, provider: GitHubProvider.new)
-        metadata = provider.metadata(reference)
+      def snapshot_for(reference, provider: GitHubProvider.new, metadata: nil)
+        metadata ||= provider.metadata(reference)
         patch, truncated = provider.patch(reference)
         files = GitDiff.parse_patch_text(patch).map { |file| annotate_file(file) }
         snapshot_id = Digest::SHA256.hexdigest(

--- a/lib/hq/domain/pull_request_review.rb
+++ b/lib/hq/domain/pull_request_review.rb
@@ -157,21 +157,24 @@ module HQ
     end
 
     class GitHubContext
+      MAX_CONCURRENT_COLLECTION_FETCHES = 8
+      @collection_fetch_lock = Mutex.new
+      @collection_fetch_condition = ConditionVariable.new
+      @collection_fetches_in_flight = 0
+
       def initialize(client: GitHubAPIClient.new)
         @client = client
       end
 
-      def fetch(reference)
-        pull = @client.get_json(pr_path(reference)).body
-        commits, = @client.paginate("#{pr_path(reference)}/commits", max_pages: 3)
-        reviews, = @client.paginate("#{pr_path(reference)}/reviews", max_pages: 5)
-        comments, = @client.paginate("#{pr_path(reference)}/comments", max_pages: 5)
-        issue_comments, = @client.paginate(
-          "/repos/#{reference.repository}/issues/#{reference.number}/comments",
-          max_pages: 5
-        )
-        statuses = fetch_statuses(reference, pull.dig("head", "sha"))
-        threads = fetch_threads(reference)
+      def fetch(reference, pull: nil)
+        pull ||= @client.get_json(pr_path(reference)).body
+        collections = fetch_collections(reference, pull.dig("head", "sha"))
+        commits = collections.fetch(:commits)
+        reviews = collections.fetch(:reviews)
+        comments = collections.fetch(:comments)
+        issue_comments = collections.fetch(:issue_comments)
+        statuses = collections.fetch(:statuses)
+        threads = collections.fetch(:threads)
         {
           "title" => pull["title"],
           "url" => pull["html_url"],
@@ -267,6 +270,55 @@ module HQ
       end
 
       private
+
+      def fetch_collections(reference, head_sha)
+        tasks = {
+          commits: -> { @client.paginate("#{pr_path(reference)}/commits", max_pages: 3).first },
+          reviews: -> { @client.paginate("#{pr_path(reference)}/reviews", max_pages: 5).first },
+          comments: -> { @client.paginate("#{pr_path(reference)}/comments", max_pages: 5).first },
+          issue_comments: lambda {
+            @client.paginate("/repos/#{reference.repository}/issues/#{reference.number}/comments", max_pages: 5).first
+          },
+          statuses: -> { fetch_statuses(reference, head_sha) },
+          threads: -> { fetch_threads(reference) }
+        }
+        threads = tasks.transform_values { |task| start_collection_fetch(&task) }
+        threads.to_h { |name, thread| [name, thread.value] }
+      ensure
+        threads&.each_value(&:join)
+      end
+
+      def start_collection_fetch(&task)
+        self.class.acquire_collection_fetch_slot
+        Thread.new do
+          task.call
+        ensure
+          self.class.release_collection_fetch_slot
+        end
+      rescue StandardError
+        self.class.release_collection_fetch_slot
+        raise
+      end
+
+      class << self
+        def acquire_collection_fetch_slot
+          collection_fetch_lock.synchronize do
+            collection_fetch_condition.wait(collection_fetch_lock) until
+              collection_fetches_in_flight < MAX_CONCURRENT_COLLECTION_FETCHES
+            self.collection_fetches_in_flight += 1
+          end
+        end
+
+        def release_collection_fetch_slot
+          collection_fetch_lock.synchronize do
+            self.collection_fetches_in_flight -= 1
+            collection_fetch_condition.broadcast
+          end
+        end
+
+        attr_reader :collection_fetch_lock, :collection_fetch_condition
+        attr_accessor :collection_fetches_in_flight
+      end
 
       def pr_path(reference)
         "/repos/#{reference.repository}/pulls/#{reference.number}"

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -6,6 +6,7 @@ require "fileutils"
 require "json"
 require "net/http"
 require "open3"
+require "thread"
 require "socket"
 require "uri"
 
@@ -1480,6 +1481,8 @@ module HQ
       @github_client = github_client
       @pull_request_diff_store = pull_request_diff_store
       @pull_request_review_store = pull_request_review_store
+      @pull_request_fetch_lock = Mutex.new
+      @pull_request_fetches = {}
     end
 
     def add_remote_server(body)
@@ -1699,7 +1702,7 @@ module HQ
       raise Error.new("Pull request diff has not been fetched yet", status: 404) unless snapshot
       return snapshot if PullRequestDiff.current_snapshot?(snapshot)
 
-      @pull_request_diff_store.save(PullRequestDiff.snapshot_for(reference, provider: github_provider))
+      refresh_pull_request_snapshot(reference)
     rescue PullRequestDiff::Error => e
       raise Error.new(e.message, status: e.status)
     end
@@ -1708,7 +1711,7 @@ module HQ
       ensure_github_enabled!
       agent = find_agent!(key)
       reference = pull_request_reference!(agent, id)
-      @pull_request_diff_store.save(PullRequestDiff.snapshot_for(reference, provider: github_provider))
+      refresh_pull_request_snapshot(reference)
     rescue PullRequestDiff::Error => e
       raise Error.new(e.message, status: e.status)
     end
@@ -1719,7 +1722,7 @@ module HQ
       refreshed = []
       failed = []
       PullRequestDiff.references_for_agent(agent).each do |reference|
-        refreshed << @pull_request_diff_store.save(PullRequestDiff.snapshot_for(reference, provider: github_provider))
+        refreshed << refresh_pull_request_snapshot(reference)
       rescue PullRequestDiff::Error => e
         failed << {
           id: reference.id,
@@ -1829,9 +1832,7 @@ module HQ
     def refresh_pull_request_review(id)
       ensure_github_enabled!
       reference = pull_request_reference_by_id!(id)
-      snapshot = @pull_request_diff_store.save(PullRequestDiff.snapshot_for(reference, provider: github_provider))
-      @pull_request_review_store.reconcile_snapshot(reference.id, snapshot)
-      { snapshot: snapshot, context: PullRequestReview::GitHubContext.new(client: @github_client).fetch(reference) }
+      refresh_pull_request_fetch(reference)
     rescue PullRequestDiff::Error => e
       raise Error.new(e.message, status: e.status)
     end
@@ -3159,6 +3160,77 @@ module HQ
 
     def github_provider
       PullRequestDiff::GitHubProvider.new(client: @github_client)
+    end
+
+    def refresh_pull_request_snapshot(reference)
+      refresh_pull_request_snapshot_fetch(reference).fetch(:snapshot)
+    end
+
+    def refresh_pull_request_snapshot_fetch(reference)
+      coalesce_pull_request_fetch(reference, "snapshot") do
+        metadata, pull = github_provider.metadata_with_pull(reference)
+        { snapshot: save_pull_request_snapshot(reference, metadata), pull: }
+      end
+    end
+
+    def refresh_pull_request_fetch(reference)
+      refreshed = refresh_pull_request_snapshot_fetch(reference)
+      context = coalesce_pull_request_fetch(reference, "context") do
+        PullRequestReview::GitHubContext.new(client: @github_client).fetch(reference, pull: refreshed.fetch(:pull))
+      end
+      { snapshot: refreshed.fetch(:snapshot), context: }
+    end
+
+    def save_pull_request_snapshot(reference, metadata)
+      snapshot = @pull_request_diff_store.save(
+        PullRequestDiff.snapshot_for(reference, provider: github_provider, metadata:)
+      )
+      @pull_request_review_store.reconcile_snapshot(reference.id, snapshot)
+      snapshot
+    end
+
+    def coalesce_pull_request_fetch(reference, operation)
+      key = [github_cache_scope, reference.id, operation].join("\0")
+      leader = false
+      @pull_request_fetch_lock.synchronize do
+        fetch = @pull_request_fetches[key]
+        unless fetch
+          fetch = { condition: ConditionVariable.new, complete: false }
+          @pull_request_fetches[key] = fetch
+          leader = true
+        end
+        unless leader
+          fetch[:condition].wait(@pull_request_fetch_lock) until fetch[:complete]
+          raise fetch[:error] if fetch[:error]
+
+          return fetch[:value]
+        end
+      end
+
+      value = yield
+      complete_pull_request_fetch(key, value:)
+      value
+    rescue StandardError => e
+      complete_pull_request_fetch(key, error: e) if leader
+      raise
+    end
+
+    def complete_pull_request_fetch(key, value: nil, error: nil)
+      @pull_request_fetch_lock.synchronize do
+        fetch = @pull_request_fetches.delete(key)
+        return unless fetch
+
+        fetch[:value] = value
+        fetch[:error] = error
+        fetch[:complete] = true
+        fetch[:condition].broadcast
+      end
+    end
+
+    def github_cache_scope
+      return @github_client.base_url.to_s if @github_client.respond_to?(:base_url)
+
+      @github_client.object_id.to_s
     end
 
     def ensure_github_enabled!

--- a/test/github_auth_test.rb
+++ b/test/github_auth_test.rb
@@ -14,6 +14,7 @@ module GitHubAuthTest
   def run!
     assert_device_flow_persists_and_refreshes_session
     assert_cli_fallback_and_app_precedence
+    assert_cli_token_fetch_is_coalesced
     puts "github_auth_test: ok"
   end
 
@@ -132,6 +133,49 @@ module GitHubAuthTest
     app.authenticated = true
     assert(auth.source == "github_app" && auth.access_token == "ghu_app",
            "expected the Tycho GitHub App session to take precedence")
+  end
+
+  def assert_cli_token_fetch_is_coalesced
+    runner = BlockingCLIRunner.new
+    cli = HQ::GitHubAuth::CLI.new(
+      resolution: HQ::ExecutableResolver::Resolution.new(
+        name: "gh", command: "/fake/gh", path: "/fake/gh", source: "test"
+      ),
+      runner:
+    )
+    first = Thread.new { cli.token }
+    runner.started.pop
+    second = Thread.new { cli.token }
+
+    runner.release!
+    assert([first.value, second.value] == ["gho_cli", "gho_cli"], "expected callers to receive the cached CLI token")
+    assert(runner.calls == 1, "expected concurrent token lookups to invoke gh once")
+  end
+
+  class BlockingCLIRunner
+    attr_reader :started, :calls
+
+    def initialize
+      @started = Queue.new
+      @calls = 0
+      @lock = Mutex.new
+      @condition = ConditionVariable.new
+      @released = false
+    end
+
+    def capture3(*)
+      @calls += 1
+      @started << true
+      @lock.synchronize { @condition.wait(@lock) until @released }
+      ["gho_cli", "", GitHubAuthTest::FakeStatus.new(true)]
+    end
+
+    def release!
+      @lock.synchronize do
+        @released = true
+        @condition.broadcast
+      end
+    end
   end
 
   def assert(condition, message)

--- a/test/pull_request_review_test.rb
+++ b/test/pull_request_review_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tmpdir"
+require "timeout"
 
 require_relative "../lib/hq/domain/pull_request_review"
 
@@ -12,6 +13,8 @@ module PullRequestReviewTest
     assert_revision_change_invalidates_review_state
     assert_handoff_is_bound_to_snapshot
     assert_thousand_file_state_remains_bounded
+    assert_context_fetches_independent_collections_concurrently
+    assert_context_reuses_a_known_pull_response
     puts "pull_request_review_test: ok"
   end
 
@@ -78,6 +81,30 @@ module PullRequestReviewTest
     assert(encoded.bytesize < 100_000, "expected path-only review state to remain bounded")
   end
 
+  def assert_context_fetches_independent_collections_concurrently
+    client = BlockingContextClient.new
+    worker = Thread.new { HQ::PullRequestReview::GitHubContext.new(client:).fetch(reference_for) }
+
+    begin
+      Timeout.timeout(1) { 6.times { client.started.pop } }
+    rescue Timeout::Error
+      raise "expected independent PR context requests to start before any one completes"
+    ensure
+      client.release!
+      worker.join
+    end
+    assert(worker.value["title"] == "Example", "expected the concurrent PR context to remain complete")
+  end
+
+  def assert_context_reuses_a_known_pull_response
+    client = BlockingContextClient.new(block: false)
+    pull = client.pull
+    context = HQ::PullRequestReview::GitHubContext.new(client:).fetch(reference_for, pull:)
+
+    assert(client.pull_requests.zero?, "expected a supplied PR payload to avoid a duplicate detail request")
+    assert(context["head_sha"] == "head", "expected the supplied PR payload to preserve detail fields")
+  end
+
   def reference_for
     HQ::PullRequestDiff::Reference.new(
       id: HQ::PullRequestDiff.reference_id("github", "example/web", 123),
@@ -87,6 +114,69 @@ module PullRequestReviewTest
       url: "https://github.com/example/web/pull/123",
       title: "Example"
     )
+  end
+
+  class BlockingContextClient
+    attr_reader :started, :pull_requests
+
+    def initialize(block: true)
+      @block = block
+      @started = Queue.new
+      @lock = Mutex.new
+      @condition = ConditionVariable.new
+      @released = false
+      @pull_requests = 0
+    end
+
+    def pull
+      {
+        "title" => "Example",
+        "html_url" => "https://github.com/example/web/pull/123",
+        "state" => "open",
+        "head" => { "sha" => "head", "ref" => "feature" },
+        "base" => { "sha" => "base", "ref" => "main" }
+      }
+    end
+
+    def get_json(path, **)
+      if path.end_with?("/pulls/123")
+        @pull_requests += 1
+        return response(pull)
+      end
+
+      wait_for_other_requests(:checks)
+      response("check_runs" => [])
+    end
+
+    def paginate(path, **)
+      wait_for_other_requests(path)
+      [[], nil]
+    end
+
+    def post_json(_path, _payload, **)
+      wait_for_other_requests(:threads)
+      response("data" => { "repository" => { "pullRequest" => { "reviewThreads" => { "nodes" => [] } } } })
+    end
+
+    def release!
+      @lock.synchronize do
+        @released = true
+        @condition.broadcast
+      end
+    end
+
+    private
+
+    def response(body)
+      HQ::GitHubAPIClient::Response.new(status: 200, body:, headers: {}, not_modified: false)
+    end
+
+    def wait_for_other_requests(name)
+      @started << name
+      return unless @block
+
+      @lock.synchronize { @condition.wait(@lock) until @released }
+    end
   end
 
   def assert(condition, message)

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -26,6 +26,8 @@ module RemoteServerTest
     assert_remote_inquiry_payload_has_stable_id_and_guarded_answer
     assert_remote_agent_payload_includes_attachments
     assert_remote_agent_pull_request_diff_payload
+    assert_concurrent_pull_request_diff_refreshes_are_coalesced
+    assert_pull_request_review_refresh_reuses_metadata
     assert_pull_request_feature_gate_and_global_inbox
     assert_github_app_auth_routes
     assert_pull_request_posting_is_confirmed_stale_safe_and_idempotent
@@ -966,6 +968,48 @@ module RemoteServerTest
       routed = server.send(:route, service, "GET",
                            "/agents/#{created[:key]}/pull-requests/#{reference["id"]}/diff", {}, nil)
       assert(routed.dig(:body, :diff, "file_count") == 1, "expected PR diff route to return saved snapshots")
+    end
+  end
+
+  def assert_concurrent_pull_request_diff_refreshes_are_coalesced
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      client = BlockingGitHubDiffClient.new
+      service = HQ::RemoteService.new(
+        registry: registry_for_project(dir, workspace),
+        github_client: client,
+        pull_request_diff_store: HQ::PullRequestDiff::Store.new(File.join(dir, "diffs.json"))
+      )
+      reference = HQ::PullRequestDiff.reference_from_url("https://github.com/example/web/pull/123")
+      first = Thread.new { service.send(:refresh_pull_request_snapshot, reference) }
+      client.metadata_started.pop
+      second = Thread.new { service.send(:refresh_pull_request_snapshot, reference) }
+
+      client.release!
+      [first, second].each(&:value)
+
+      assert(client.metadata_requests == 1 && client.diff_requests == 1,
+             "expected concurrent identical diff refreshes to share one metadata and diff fetch")
+    end
+  end
+
+  def assert_pull_request_review_refresh_reuses_metadata
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      client = FakeGitHubReviewClient.new
+      service = HQ::RemoteService.new(
+        registry: registry_for_project(dir, workspace),
+        github_client: client,
+        pull_request_diff_store: HQ::PullRequestDiff::Store.new(File.join(dir, "diffs.json"))
+      )
+      reference = HQ::PullRequestDiff.reference_from_url("https://github.com/example/web/pull/123")
+      refreshed = service.send(:refresh_pull_request_fetch, reference)
+
+      detail_requests = client.requests.count { |kind, path| kind == :get_json && path.end_with?("/pulls/123") }
+      assert(detail_requests == 1, "expected review refresh to reuse the PR metadata fetched for its diff")
+      assert(refreshed.dig(:context, "head_sha") == "head", "expected reused PR metadata to preserve review context")
     end
   end
 
@@ -5842,6 +5886,21 @@ module RemoteServerTest
       )
     end
 
+    def get_text(path, **)
+      @requests << [:get_text, path]
+      HQ::GitHubAPIClient::Response.new(
+        status: 200,
+        body: "diff --git a/app.rb b/app.rb\n--- a/app.rb\n+++ b/app.rb\n@@ -1 +1 @@\n-old\n+new\n",
+        headers: {},
+        not_modified: false
+      )
+    end
+
+    def paginate(path, **)
+      @requests << [:paginate, path]
+      [[], nil]
+    end
+
     def post_json(path, _payload, **)
       @requests << [:post_json, path]
       if path.end_with?("/pulls/123/reviews")
@@ -5870,6 +5929,64 @@ module RemoteServerTest
         headers: {},
         not_modified: false
       )
+    end
+  end
+
+  class BlockingGitHubDiffClient
+    attr_reader :metadata_started, :metadata_requests, :diff_requests
+
+    def initialize
+      @metadata_started = Queue.new
+      @lock = Mutex.new
+      @condition = ConditionVariable.new
+      @released = false
+      @metadata_requests = 0
+      @diff_requests = 0
+    end
+
+    def enabled?
+      true
+    end
+
+    def get_json(_path, **)
+      @metadata_requests += 1
+      @metadata_started << true
+      @lock.synchronize { @condition.wait(@lock) until @released }
+      HQ::GitHubAPIClient::Response.new(
+        status: 200,
+        body: {
+          "title" => "Shared PR",
+          "html_url" => "https://github.com/example/web/pull/123",
+          "head" => { "sha" => "head", "ref" => "feature" },
+          "base" => { "sha" => "base", "ref" => "main" }
+        },
+        headers: {},
+        not_modified: false
+      )
+    end
+
+    def get_text(_path, accept:, **)
+      @diff_requests += 1
+      HQ::GitHubAPIClient::Response.new(
+        status: 200,
+        body: <<~DIFF,
+          diff --git a/app.rb b/app.rb
+          --- a/app.rb
+          +++ b/app.rb
+          @@ -1 +1 @@
+          -old
+          +new
+        DIFF
+        headers: {},
+        not_modified: false
+      )
+    end
+
+    def release!
+      @lock.synchronize do
+        @released = true
+        @condition.broadcast
+      end
     end
   end
 


### PR DESCRIPTION
Implements Fizzy #118.

- Reuses the PR metadata response during review refreshes and starts independent review collections concurrently with a process-wide cap of 8.
- Coalesces concurrent server/repository/PR-qualified snapshot and context refreshes; GitHub CLI token lookup is also coalesced.
- Keeps existing snapshot retention, diff truncation, auth, stale/error, and multiserver behavior.

Evidence: review refresh drops from 9 upstream calls to 8 by removing the duplicate PR detail request; concurrent identical diff refreshes drop from 2 metadata + 2 diff calls to 1 + 1. Tests use call-count and blocking concurrency assertions.

Validation: `bin/test`, focused GitHub auth/PR review/diff/remote-server tests, syntax checks, `git diff --check`, and diff secret-pattern checks.