### PR TITLE
Allow selected PR diff lines in agent context

### DIFF
--- a/lib/hq/domain/pull_request_selection.rb
+++ b/lib/hq/domain/pull_request_selection.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "json"
+
+module HQ
+  # Validates path/index based diff selections against one immutable snapshot and
+  # renders the only prompt representation sent to an agent.
+  class PullRequestSelection
+    MAX_ITEMS = 100
+    MAX_LINES = 250
+    MAX_BYTES = 12 * 1024
+    OPEN = "[TYCHO_PR_DIFF_CONTEXT]"
+    CLOSE = "[/TYCHO_PR_DIFF_CONTEXT]"
+
+    class Error < StandardError; end
+
+    class << self
+      def normalize(snapshot, selection)
+        selection = stringify(selection)
+        snapshot_id = selection["snapshot_id"].to_s
+        raise Error, "A pull request snapshot is required." if snapshot_id.empty?
+        raise Error, "The pull request changed. Refresh and select lines again." unless snapshot_id == snapshot["snapshot_id"].to_s
+
+        requested = Array(selection["lines"])
+        raise Error, "Select at most #{MAX_ITEMS} diff lines." if requested.length > MAX_ITEMS
+
+        lookup = snapshot_lines(snapshot)
+        seen = {}
+        requested.each_with_object([]) do |raw, result|
+          item = stringify(raw)
+          key = key_for(item)
+          raise Error, "Each selected line needs a path, hunk index, and line index." if key.nil?
+          next if seen[key]
+
+          line = lookup[key]
+          raise Error, "A selected diff line is no longer available in this snapshot." unless line
+          seen[key] = true
+          result << line
+        end.sort_by { |line| [line.fetch("file_index"), line.fetch("hunk_index"), line.fetch("line_index")] }
+      end
+
+      def render(snapshot, selection)
+        lines = normalize(snapshot, selection)
+        raise Error, "Select at least one diff line to attach." if lines.empty?
+
+        selected = []
+        omitted = 0
+        bytes = 0
+        lines.first(MAX_LINES).each do |line|
+          payload = line.slice("path", "old_path", "side", "kind", "old_number", "new_number", "content")
+          payload["content"] = safe_text(payload["content"])
+          encoded = JSON.generate(payload)
+          if bytes + encoded.bytesize > MAX_BYTES
+            omitted += 1
+          else
+            selected << payload
+            bytes += encoded.bytesize
+          end
+        end
+        omitted += lines.length - MAX_LINES if lines.length > MAX_LINES
+
+        identity = {
+          "url" => PullRequestDiff.canonical_url(snapshot.fetch("repository"), snapshot.fetch("number")),
+          "repository" => snapshot["repository"], "number" => snapshot["number"],
+          "snapshot_id" => snapshot["snapshot_id"], "base_sha" => snapshot["base_sha"], "head_sha" => snapshot["head_sha"]
+        }.compact
+        body = { "identity" => identity, "lines" => selected }
+        body["omitted_lines"] = omitted if omitted.positive?
+        body["snapshot_truncated"] = true if snapshot["truncated"]
+        [OPEN, JSON.generate(body), CLOSE].join("\n")
+      end
+
+      private
+
+      def snapshot_lines(snapshot)
+        Array(snapshot["files"]).each_with_index.each_with_object({}) do |(file, file_index), lookup|
+          next if file["binary"] || file[:binary]
+          path = (file["path"] || file[:path] || file["old_path"] || file[:old_path]).to_s
+          Array(file["hunks"] || file[:hunks]).each_with_index do |hunk, hunk_index|
+            Array(hunk["lines"] || hunk[:lines]).each_with_index do |line, line_index|
+              kind = line["kind"] || line[:kind]
+              next unless %w[added removed context].include?(kind)
+              entry = {
+                "path" => path, "old_path" => file["old_path"] || file[:old_path], "kind" => kind,
+                "old_number" => line["old_number"] || line[:old_number], "new_number" => line["new_number"] || line[:new_number],
+                "content" => line["content"] || line[:content], "side" => side_for(kind), "file_index" => file_index, "hunk_index" => hunk_index, "line_index" => line_index
+              }.compact
+              lookup[key_for(entry)] = entry
+            end
+          end
+        end
+      end
+
+      def key_for(item)
+        path = item["path"].to_s
+        hunk = Integer(item["hunk_index"], exception: false)
+        line = Integer(item["line_index"], exception: false)
+        return nil if path.empty? || hunk.nil? || line.nil?
+        [path, hunk, line].join("\0")
+      end
+
+      def safe_text(value)
+        value.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "�")
+          .gsub(/[\u0000-\u001f\u007f]/, " ").gsub(OPEN, escaped_delimiter(OPEN))
+          .gsub(CLOSE, escaped_delimiter(CLOSE))
+      end
+
+      def escaped_delimiter(value)
+        value.tr("[]", "［］")
+      end
+
+      def side_for(kind)
+        return "left" if kind == "removed"
+        return "right" if kind == "added"
+
+        "both"
+      end
+
+      def stringify(value)
+        case value
+        when Hash then value.to_h { |key, item| [key.to_s, stringify(item)] }
+        when Array then value.map { |item| stringify(item) }
+        else value
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/domain/pull_request_selection.rb
+++ b/lib/hq/domain/pull_request_selection.rb
@@ -8,7 +8,7 @@ module HQ
   class PullRequestSelection
     MAX_ITEMS = 100
     MAX_LINES = 250
-    MAX_BYTES = 12 * 1024
+    MAX_RENDERED_BYTES = 12 * 1024
     OPEN = "[TYCHO_PR_DIFF_CONTEXT]"
     CLOSE = "[/TYCHO_PR_DIFF_CONTEXT]"
 
@@ -43,31 +43,26 @@ module HQ
         lines = normalize(snapshot, selection)
         raise Error, "Select at least one diff line to attach." if lines.empty?
 
-        selected = []
-        omitted = 0
-        bytes = 0
-        lines.first(MAX_LINES).each do |line|
+        selected = lines.first(MAX_LINES).map do |line|
           payload = line.slice("path", "old_path", "side", "kind", "old_number", "new_number", "content")
           payload["content"] = safe_text(payload["content"])
-          encoded = JSON.generate(payload)
-          if bytes + encoded.bytesize > MAX_BYTES
-            omitted += 1
-          else
-            selected << payload
-            bytes += encoded.bytesize
-          end
+          payload
         end
-        omitted += lines.length - MAX_LINES if lines.length > MAX_LINES
 
         identity = {
           "url" => PullRequestDiff.canonical_url(snapshot.fetch("repository"), snapshot.fetch("number")),
           "repository" => snapshot["repository"], "number" => snapshot["number"],
           "snapshot_id" => snapshot["snapshot_id"], "base_sha" => snapshot["base_sha"], "head_sha" => snapshot["head_sha"]
         }.compact
-        body = { "identity" => identity, "lines" => selected }
-        body["omitted_lines"] = omitted if omitted.positive?
-        body["snapshot_truncated"] = true if snapshot["truncated"]
-        [OPEN, JSON.generate(body), CLOSE].join("\n")
+        loop do
+          omitted = lines.length - selected.length
+          rendered = render_block(identity, selected, omitted, snapshot["truncated"])
+          return rendered if rendered.bytesize <= MAX_RENDERED_BYTES
+
+          raise Error, "Pull request context metadata exceeds the #{MAX_RENDERED_BYTES / 1024} KB limit." if selected.empty?
+
+          selected.pop
+        end
       end
 
       private
@@ -107,6 +102,13 @@ module HQ
 
       def escaped_delimiter(value)
         value.tr("[]", "［］")
+      end
+
+      def render_block(identity, lines, omitted, snapshot_truncated)
+        body = { "identity" => identity, "lines" => lines }
+        body["omitted_lines"] = omitted if omitted.positive?
+        body["snapshot_truncated"] = true if snapshot_truncated
+        [OPEN, JSON.generate(body), CLOSE].join("\n")
       end
 
       def side_for(kind)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -1846,14 +1846,16 @@ module HQ
       snapshot = @pull_request_diff_store.fetch(reference.id)
       if attrs.key?("selections")
         raise Error.new("Fetch the pull request diff before selecting lines.", status: 409) unless snapshot
-        begin
-          PullRequestSelection.normalize(snapshot, attrs.fetch("selections")) if attrs.fetch("selections").is_a?(Hash) && attrs.fetch("selections").key?("lines")
-        rescue PullRequestSelection::Error => e
-          raise Error.new(e.message, status: 409)
-        end
+        selections = attrs.fetch("selections")
+        raise Error.new("Selected pull request context must be an object.", status: 400) unless selections.is_a?(Hash)
         supplied_snapshot_id = attrs["selection_snapshot_id"].to_s
         unless supplied_snapshot_id == snapshot["snapshot_id"].to_s
           raise Error.new("The pull request changed. Refresh and select lines again.", status: 409)
+        end
+        begin
+          PullRequestSelection.normalize(snapshot, selections.merge("snapshot_id" => supplied_snapshot_id)) if selections.key?("lines")
+        rescue PullRequestSelection::Error => e
+          raise Error.new(e.message, status: 409)
         end
         values["selection_snapshot_id"] = snapshot["snapshot_id"]
       end

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -30,6 +30,7 @@ require_relative "domain/push_notification_store"
 require_relative "domain/push_subscription_store"
 require_relative "domain/pull_request_diff"
 require_relative "domain/pull_request_review"
+require_relative "domain/pull_request_selection"
 require_relative "domain/response_style_policy"
 require_relative "domain/remote_credential_store"
 require_relative "domain/schedule_daemon_supervisor"
@@ -1843,7 +1844,20 @@ module HQ
       allowed = %w[read_at reviewed_head_sha reviewed_base_sha viewed_files selections priority outcome]
       values = attrs.select { |key, _value| allowed.include?(key.to_s) }
       snapshot = @pull_request_diff_store.fetch(reference.id)
-      values["selection_snapshot_id"] = snapshot["snapshot_id"] if snapshot && (attrs.key?("selections") || attrs.key?("viewed_files"))
+      if attrs.key?("selections")
+        raise Error.new("Fetch the pull request diff before selecting lines.", status: 409) unless snapshot
+        begin
+          PullRequestSelection.normalize(snapshot, attrs.fetch("selections")) if attrs.fetch("selections").is_a?(Hash) && attrs.fetch("selections").key?("lines")
+        rescue PullRequestSelection::Error => e
+          raise Error.new(e.message, status: 409)
+        end
+        supplied_snapshot_id = attrs["selection_snapshot_id"].to_s
+        unless supplied_snapshot_id == snapshot["snapshot_id"].to_s
+          raise Error.new("The pull request changed. Refresh and select lines again.", status: 409)
+        end
+        values["selection_snapshot_id"] = snapshot["snapshot_id"]
+      end
+      values["selection_snapshot_id"] = snapshot["snapshot_id"] if snapshot && attrs.key?("viewed_files")
       values["read_at"] = Time.now.iso8601 if truthy?(attrs["read"]) && !values.key?("read_at")
       @pull_request_review_store.update_state(reference.id, values)
     end
@@ -1874,13 +1888,27 @@ module HQ
 
       agent_key = attrs["agent_key"].to_s
       find_agent!(agent_key)
-      prompt = PullRequestReview.handoff_prompt(reference, snapshot, attrs["selection"] || {}, attrs["note"])
+      idempotency_key = attrs["idempotency_key"].to_s
+      raise Error.new("An idempotency key is required.", status: 400) if idempotency_key.empty?
+      state = @pull_request_review_store.state(reference.id)
+      previous = Array(state["handoffs"]).find { |handoff| handoff["idempotency_key"] == idempotency_key }
+      return { handoff: previous, review: state, idempotent: true } if previous
+      selection = attrs["selection"] || {}
+      line_context = if Array(selection["lines"]).any?
+                       begin
+                         PullRequestSelection.render(snapshot, selection)
+                       rescue PullRequestSelection::Error => e
+                         raise Error.new(e.message, status: 409)
+                       end
+                     end
+      prompt = [PullRequestReview.handoff_prompt(reference, snapshot, selection, attrs["note"]), line_context].compact.join("\n")
       result = submit_prompt(agent_key, "prompt" => prompt, "start" => truthy?(attrs.fetch("start", true)))
       state = @pull_request_review_store.record_handoff(
         reference.id,
         "agent_key" => agent_key,
         "snapshot_id" => snapshot["snapshot_id"],
-        "selection" => attrs["selection"] || {},
+        "idempotency_key" => idempotency_key,
+        "selection" => selection,
         "note" => attrs["note"].to_s
       )
       result.merge(review: state)

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1591,6 +1591,9 @@ select {
   white-space: pre-wrap;
 }
 
+.pr-line-selection { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.pr-line-selection span { color: var(--muted); }
+
 @media (max-width: 700px) {
   .pr-review-workspace .card-title,
   .pr-review-workspace .button-row,
@@ -3225,10 +3228,12 @@ select {
 
 .diff-line {
   display: grid;
-  grid-template-columns: 5ch 5ch 2ch minmax(40ch, 1fr);
+  grid-template-columns: 22px 5ch 5ch 2ch minmax(40ch, 1fr);
   min-height: 20px;
   padding: 0 12px;
 }
+
+.diff-line.selected { outline: 1px solid var(--accent); outline-offset: -1px; }
 
 .diff-line.added {
   background: color-mix(in srgb, var(--ok) 14%, transparent);
@@ -3300,7 +3305,7 @@ select {
   }
 
   .diff-line {
-    grid-template-columns: 4.5ch 4.5ch 2ch minmax(36ch, 1fr);
+    grid-template-columns: 22px 4.5ch 4.5ch 2ch minmax(36ch, 1fr);
     min-height: 18px;
     padding-inline: 10px;
   }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3277,6 +3277,7 @@ function renderPullRequestReview(id) {
   const files = arrayValue(snapshot.files);
   const viewed = new Set(arrayValue(reviewState.viewed_files));
   const selectedFiles = new Set(arrayValue(reviewState.selections?.files));
+  const selectedLines = arrayValue(reviewState.selections?.lines);
   const draft = reviewState.draft || {};
   setHeader(context.title || reference.title || "Pull request review", `${reference.repository || ""}#${reference.number || ""}`, "R");
   if (data.loading) {
@@ -3327,7 +3328,8 @@ function renderPullRequestReview(id) {
         <label class="field"><span>Find a file</span><input type="search" data-review-file-filter placeholder="Path or content"></label>
       </section>
       <section class="diff-viewer pr-review-files" aria-label="Pull request changed files">
-        ${files.length ? files.map((file, index) => renderReviewDiffFile(file, index, { viewed, selectedFiles })).join("") : emptyState("No textual files", snapshot.truncated ? "The first file exceeded the safe snapshot limit. Open the PR on GitHub." : "This pull request has no textual changes.")}
+        <div class="summary-card pr-line-selection" aria-live="polite"><strong>${selectedLines.length} line${selectedLines.length === 1 ? "" : "s"} selected</strong><span>Selected lines are attached from this immutable snapshot only.</span>${selectedLines.length ? `<button type="button" data-clear-review-lines>Clear selected lines</button>` : ""}</div>
+        ${files.length ? files.map((file, index) => renderReviewDiffFile(file, index, { viewed, selectedFiles, selectedLines })).join("") : emptyState("No textual files", snapshot.truncated ? "The first file exceeded the safe snapshot limit. Open the PR on GitHub." : "This pull request has no textual changes.")}
       </section>
       ${renderReviewHandoff(id, reviewState)}
       ${renderReviewDraft(id, draft)}
@@ -3371,7 +3373,7 @@ function renderReviewDiffFile(file, index, options) {
   const body = file.binary
     ? `<div class="diff-file-message">Binary file is not expanded.</div>`
     : hunks.length
-      ? hunks.map((hunk, hunkIndex) => renderReviewHunk(path, hunk, hunkIndex, selectedHunks)).join("")
+      ? hunks.map((hunk, hunkIndex) => renderReviewHunk(path, hunk, hunkIndex, selectedHunks, options.selectedLines)).join("")
       : `<div class="diff-file-message">${escapeHtml(file.message || "No textual hunks for this file.")}</div>`;
   return `
     <section class="pr-review-file" data-review-file="${escapeAttr(path)}" data-preserve-focus data-state-key="review-file:${escapeAttr(path)}" tabindex="-1">
@@ -3394,7 +3396,7 @@ function renderReviewDiffFile(file, index, options) {
   `;
 }
 
-function renderReviewHunk(path, hunk, index, selectedHunks) {
+function renderReviewHunk(path, hunk, index, selectedHunks, selectedLines = []) {
   const key = `${path}:${index}`;
   const lines = arrayValue(hunk.lines);
   return `
@@ -3403,9 +3405,24 @@ function renderReviewHunk(path, hunk, index, selectedHunks) {
         <label><input type="checkbox" data-select-review-hunk="${escapeAttr(key)}" ${selectedHunks.has(key) ? "checked" : ""}> Include hunk</label>
         <code>${escapeHtml(hunk.header || "@@")}</code>
       </div>
-      <div class="diff-lines">${lines.map(renderDiffLine).join("")}</div>
+      <div class="diff-lines">${lines.map((line, lineIndex) => renderReviewDiffLine(path, index, lineIndex, line, selectedLines)).join("")}</div>
     </section>
   `;
+}
+
+function reviewLineKey(path, hunkIndex, lineIndex) {
+  return `${path}\u0000${hunkIndex}\u0000${lineIndex}`;
+}
+
+function renderReviewDiffLine(path, hunkIndex, lineIndex, line, selectedLines) {
+  const kind = String(line.kind || "context");
+  const selectable = ["added", "removed", "context"].includes(kind);
+  const selected = selectedLines.some((item) => reviewLineKey(item.path, item.hunk_index, item.line_index) === reviewLineKey(path, hunkIndex, lineIndex));
+  const marker = kind === "added" ? "+" : kind === "removed" ? "-" : kind === "meta" ? "\\" : " ";
+  return `<label class="diff-line ${escapeAttr(kind)}${selected ? " selected" : ""}">
+    ${selectable ? `<input type="checkbox" data-select-review-line data-review-line-path="${escapeAttr(path)}" data-review-line-hunk="${hunkIndex}" data-review-line-index="${lineIndex}" aria-label="Select ${escapeAttr(kind)} line ${line.new_number || line.old_number || ""} in ${escapeAttr(path)}" ${selected ? "checked" : ""}>` : "<span></span>"}
+    <span class="diff-line-no">${diffLineNumber(line.old_number)}</span><span class="diff-line-no">${diffLineNumber(line.new_number)}</span><span class="diff-marker">${escapeHtml(marker)}</span><code>${escapeHtml(line.content || "")}</code>
+  </label>`;
 }
 
 function renderReviewHandoff(id, stateValue) {
@@ -3414,7 +3431,7 @@ function renderReviewHandoff(id, stateValue) {
       <div class="card-title"><div><strong>Agent handoff</strong><span>Preview selected context, then explicitly send it to an existing agent.</span></div></div>
       <label class="field"><span>Agent</span><select name="agent_key" required><option value="">Choose agent</option>${state.agents.map((agent) => `<option value="${escapeAttr(agent.key)}">${escapeHtml(agent.name || agent.key)}</option>`).join("")}</select></label>
       <label class="field"><span>Request</span><textarea name="note" required placeholder="Investigate this change or prepare a fix"></textarea></label>
-      <pre data-review-handoff-preview>Selected files are included with immutable snapshot SHAs.</pre>
+      <pre data-review-handoff-preview>${arrayValue(stateValue.selections?.lines).length ? `${arrayValue(stateValue.selections.lines).length} selected diff line(s) will be attached with repository, PR URL, and snapshot identity.` : "Select exact added, removed, or context lines above before sending."}</pre>
       <button type="submit" class="primary ui-button" data-variant="brand">Send to agent</button>
       ${arrayValue(stateValue.handoffs).length ? `<p>${escapeHtml(`${stateValue.handoffs.length} handoff(s) recorded`)}</p>` : ""}
     </form>
@@ -3463,6 +3480,7 @@ async function updateReviewFileState(path, mode, checked = null) {
     const response = await apiPatch(`/pull-requests/${encodeURIComponent(route.id)}/state`, {
       viewed_files: Array.from(viewed),
       selections,
+      selection_snapshot_id: data.snapshot?.snapshot_id,
     });
     data.review_state = response.review || review;
     render();
@@ -3481,12 +3499,40 @@ async function updateReviewSelection(value, kind, checked) {
   checked ? values.add(String(value)) : values.delete(String(value));
   selections[kind] = Array.from(values);
   try {
-    const response = await apiPatch(`/pull-requests/${encodeURIComponent(route.id)}/state`, { selections });
+    const response = await apiPatch(`/pull-requests/${encodeURIComponent(route.id)}/state`, { selections, selection_snapshot_id: data.snapshot?.snapshot_id });
     data.review_state = response.review || review;
     render();
   } catch (error) {
     showGrowl(error.message, "need");
   }
+}
+
+async function updateReviewLineSelection(target) {
+  const route = parseRoute();
+  const data = currentReviewData();
+  if (route.type !== "pullRequestReview" || !data) return;
+  const selections = { ...(data.review_state?.selections || {}) };
+  const lines = arrayValue(selections.lines).filter((item) => reviewLineKey(item.path, item.hunk_index, item.line_index) !== reviewLineKey(target.dataset.reviewLinePath, target.dataset.reviewLineHunk, target.dataset.reviewLineIndex));
+  if (target.checked) {
+    if (lines.length >= 100) { target.checked = false; showGrowl("Select at most 100 diff lines", "need"); return; }
+    lines.push({ path: target.dataset.reviewLinePath, hunk_index: Number(target.dataset.reviewLineHunk), line_index: Number(target.dataset.reviewLineIndex) });
+    if (reviewSelectionBytes(data.snapshot, lines) > 12 * 1024) { target.checked = false; showGrowl("Selected diff text exceeds 12 KB", "need"); return; }
+  }
+  selections.lines = lines;
+  try {
+    const response = await apiPatch(`/pull-requests/${encodeURIComponent(route.id)}/state`, { selections, selection_snapshot_id: data.snapshot?.snapshot_id });
+    data.review_state = response.review || data.review_state;
+    render();
+  } catch (error) { showGrowl(error.message, "need"); render(); }
+}
+
+function reviewSelectionBytes(snapshot, selection) {
+  const encoder = new TextEncoder();
+  return selection.reduce((total, item) => {
+    const file = arrayValue(snapshot?.files).find((candidate) => (candidate.path || candidate.old_path) === item.path);
+    const line = arrayValue(arrayValue(file?.hunks)[item.hunk_index]?.lines)[item.line_index];
+    return total + encoder.encode(String(line?.content || "")).length;
+  }, 0);
 }
 
 function navigateReviewFile(delta) {
@@ -3514,12 +3560,15 @@ async function sendReviewHandoff(form) {
   const fields = new FormData(form);
   const data = state.pullRequestReviews[id] || {};
   const selection = data.review_state?.selections || {};
+  const idempotencyKey = form.dataset.handoffIdempotencyKey || crypto.randomUUID();
+  form.dataset.handoffIdempotencyKey = idempotencyKey;
   try {
     setFormPending(form, true);
     const response = await apiPost(`/pull-requests/${encodeURIComponent(id)}/handoff`, {
       agent_key: fields.get("agent_key"),
       note: fields.get("note"),
-      selection,
+      selection: { ...selection, snapshot_id: data.snapshot?.snapshot_id },
+      idempotency_key: idempotencyKey,
       start: true,
     });
     data.review_state = response.review || data.review_state;
@@ -11271,6 +11320,16 @@ els.view.addEventListener("click", (event) => {
     ensurePullRequestInbox(true).then(render).catch((error) => showGrowl(error.message, "need"));
     return;
   }
+  if (event.target.closest("[data-clear-review-lines]")) {
+    const route = parseRoute(); const data = currentReviewData();
+    if (route.type === "pullRequestReview" && data) {
+      const selections = { ...(data.review_state?.selections || {}), lines: [] };
+      apiPatch(`/pull-requests/${encodeURIComponent(route.id)}/state`, { selections, selection_snapshot_id: data.snapshot?.snapshot_id })
+        .then((response) => { data.review_state = response.review || data.review_state; render(); })
+        .catch((error) => showGrowl(error.message, "need"));
+    }
+    return;
+  }
   const refreshReview = event.target.closest("[data-refresh-review]");
   if (refreshReview) {
     const id = refreshReview.dataset.refreshReview;
@@ -12140,6 +12199,10 @@ els.view.addEventListener("change", (event) => {
   }
   if (event.target.matches("[data-select-review-file]")) {
     updateReviewFileState(event.target.dataset.selectReviewFile, "selected", event.target.checked);
+    return;
+  }
+  if (event.target.matches("[data-select-review-line]")) {
+    updateReviewLineSelection(event.target);
     return;
   }
   if (event.target.matches("[data-select-review-hunk]")) {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3571,6 +3571,7 @@ async function sendReviewHandoff(form) {
       idempotency_key: idempotencyKey,
       start: true,
     });
+    delete form.dataset.handoffIdempotencyKey;
     data.review_state = response.review || data.review_state;
     showGrowl("Review context sent to agent", "done");
     render();

--- a/test/pull_request_selection_test.rb
+++ b/test/pull_request_selection_test.rb
@@ -11,6 +11,7 @@ module PullRequestSelectionTest
     assert_rejects_stale_and_invalid_lines
     assert_omits_binary_and_caps_selection
     assert_renders_safe_bounded_context
+    assert_caps_complete_rendered_block
     puts "pull_request_selection_test: ok"
   end
 
@@ -42,6 +43,16 @@ module PullRequestSelectionTest
     assert(rendered.include?("\"side\":\"right\"") && rendered.include?("\"side\":\"left\""), "expected source side for changed lines")
     assert(!rendered.include?("[TYCHO_PR_DIFF_CONTEXT] hostile"), "expected hostile delimiter text to be neutralized")
     assert(rendered.include?("snapshot_truncated"), "expected truncation marker")
+  end
+
+  def assert_caps_complete_rendered_block
+    oversized = snapshot
+    oversized["files"][0]["hunks"][0]["lines"][0]["content"] = "x" * (HQ::PullRequestSelection::MAX_RENDERED_BYTES * 2)
+    rendered = HQ::PullRequestSelection.render(oversized, "snapshot_id" => "snap", "lines" => [line("a.rb", 0, 0)])
+    assert(rendered.bytesize <= HQ::PullRequestSelection::MAX_RENDERED_BYTES, "expected framing and identity to fit the complete rendered limit")
+    assert(rendered.include?("omitted_lines"), "expected an explicit omission marker when the full block exceeds the limit")
+  rescue HQ::PullRequestSelection::Error => e
+    assert(e.message.include?("metadata"), "expected only irreducible metadata to fail the full rendered limit")
   end
 
   def snapshot

--- a/test/pull_request_selection_test.rb
+++ b/test/pull_request_selection_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../lib/hq/domain/pull_request_diff"
+require_relative "../lib/hq/domain/pull_request_selection"
+
+module PullRequestSelectionTest
+  module_function
+
+  def run!
+    assert_orders_and_deduplicates_lines
+    assert_rejects_stale_and_invalid_lines
+    assert_omits_binary_and_caps_selection
+    assert_renders_safe_bounded_context
+    puts "pull_request_selection_test: ok"
+  end
+
+  def assert_orders_and_deduplicates_lines
+    selected = HQ::PullRequestSelection.normalize(snapshot, {
+      "snapshot_id" => "snap", "lines" => [line("b.rb", 0, 0), line("a.rb", 0, 1), line("b.rb", 0, 0)]
+    })
+    assert(selected.map { |item| item["path"] } == ["a.rb", "b.rb"], "expected snapshot file ordering and duplicate removal")
+    assert(selected.first["kind"] == "removed", "expected removed lines to be selectable")
+  end
+
+  def assert_rejects_stale_and_invalid_lines
+    assert_raises("changed") { HQ::PullRequestSelection.normalize(snapshot, "snapshot_id" => "old", "lines" => [line("a.rb", 0, 0)]) }
+    assert_raises("longer available") { HQ::PullRequestSelection.normalize(snapshot, "snapshot_id" => "snap", "lines" => [line("a.rb", 9, 0)]) }
+    assert_raises("longer available") { HQ::PullRequestSelection.normalize(snapshot, "snapshot_id" => "snap", "lines" => [line("image.png", 0, 0)]) }
+  end
+
+  def assert_omits_binary_and_caps_selection
+    too_many = Array.new(HQ::PullRequestSelection::MAX_ITEMS + 1) { line("a.rb", 0, 0) }
+    assert_raises("at most") { HQ::PullRequestSelection.normalize(snapshot, "snapshot_id" => "snap", "lines" => too_many) }
+  end
+
+  def assert_renders_safe_bounded_context
+    rendered = HQ::PullRequestSelection.render(snapshot, "snapshot_id" => "snap", "lines" => [line("a.rb", 0, 0), line("a.rb", 0, 1), line("b.rb", 0, 0)])
+    assert(rendered.start_with?(HQ::PullRequestSelection::OPEN), "expected explicit context opening marker")
+    assert(rendered.end_with?(HQ::PullRequestSelection::CLOSE), "expected explicit context closing marker")
+    assert(rendered.include?("https://github.com/example/web/pull/123"), "expected canonical PR URL")
+    assert(rendered.include?("head-sha") && rendered.include?("base-sha"), "expected immutable SHA identity")
+    assert(rendered.include?("\"side\":\"right\"") && rendered.include?("\"side\":\"left\""), "expected source side for changed lines")
+    assert(!rendered.include?("[TYCHO_PR_DIFF_CONTEXT] hostile"), "expected hostile delimiter text to be neutralized")
+    assert(rendered.include?("snapshot_truncated"), "expected truncation marker")
+  end
+
+  def snapshot
+    {
+      "repository" => "example/web", "number" => 123, "snapshot_id" => "snap", "base_sha" => "base-sha", "head_sha" => "head-sha", "truncated" => true,
+      "files" => [
+        { "path" => "a.rb", "hunks" => [{ "lines" => [
+          { "kind" => "added", "new_number" => 10, "content" => "safe" },
+          { "kind" => "removed", "old_number" => 11, "content" => "[TYCHO_PR_DIFF_CONTEXT] hostile" },
+          { "kind" => "context", "old_number" => 12, "new_number" => 12, "content" => "context" }
+        ] }] },
+        { "path" => "b.rb", "old_path" => "old-b.rb", "status" => "renamed", "generated" => true, "hunks" => [{ "lines" => [{ "kind" => "context", "old_number" => 1, "new_number" => 1, "content" => "generated" }] }] },
+        { "path" => "image.png", "binary" => true, "hunks" => [{ "lines" => [{ "kind" => "added", "new_number" => 1, "content" => "no" }] }] }
+      ]
+    }
+  end
+
+  def line(path, hunk_index, line_index)
+    { "path" => path, "hunk_index" => hunk_index, "line_index" => line_index }
+  end
+
+  def assert_raises(fragment)
+    yield
+    raise "expected selection error"
+  rescue HQ::PullRequestSelection::Error => e
+    raise "expected #{fragment.inspect}, got #{e.message.inspect}" unless e.message.include?(fragment)
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+end
+
+PullRequestSelectionTest.run!

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -1087,6 +1087,25 @@ module RemoteServerTest
         "base_sha" => "base", "head_sha" => "head", "diff_format" => HQ::PullRequestDiff::DIFF_FORMAT,
         "files" => [{ "path" => "lib/example.rb", "hunks" => [{ "lines" => [{ "kind" => "added", "new_number" => 4, "content" => "puts :ok" }] }] }]
       )
+      persisted = service.update_pull_request_review_state(
+        reference.id,
+        "selection_snapshot_id" => "snapshot-1",
+        "selections" => { "lines" => [{ "path" => "lib/example.rb", "hunk_index" => 0, "line_index" => 0 }] }
+      )
+      assert(persisted.dig("selections", "lines", 0, "path") == "lib/example.rb",
+             "expected valid selected lines to persist with the sibling snapshot id contract")
+      begin
+        service.update_pull_request_review_state(reference.id, "selection_snapshot_id" => "old", "selections" => { "lines" => [] })
+        raise "expected stale selected line state to fail"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.status == 409, "expected stale selected line state to return conflict")
+      end
+      begin
+        service.update_pull_request_review_state(reference.id, "selection_snapshot_id" => "snapshot-1", "selections" => [])
+        raise "expected malformed selected line state to fail"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.status == 400, "expected malformed selected line state to return bad request")
+      end
       result = service.handoff_pull_request_review(reference.id, "agent_key" => created[:key], "note" => "Inspect this.", "start" => false, "idempotency_key" => "line-handoff-1",
                                                     "selection" => { "snapshot_id" => "snapshot-1", "lines" => [{ "path" => "lib/example.rb", "hunk_index" => 0, "line_index" => 0 }] })
       content = result[:conversation].last[:content]

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -29,6 +29,7 @@ module RemoteServerTest
     assert_concurrent_pull_request_diff_refreshes_are_coalesced
     assert_pull_request_review_refresh_reuses_metadata
     assert_pull_request_feature_gate_and_global_inbox
+    assert_pull_request_line_handoff_uses_snapshot_context
     assert_github_app_auth_routes
     assert_pull_request_posting_is_confirmed_stale_safe_and_idempotent
     assert_remote_prompt_accepts_uploaded_attachments
@@ -1065,6 +1066,42 @@ module RemoteServerTest
              "expected canonical PR to preserve every agent and project occurrence")
       assert(client.requests.none? { |request| request.first == :get_text },
              "expected inbox metadata work not to fetch patches")
+    end
+  end
+
+  def assert_pull_request_line_handoff_uses_snapshot_context
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace)
+      diff_store = HQ::PullRequestDiff::Store.new(File.join(dir, "handoff-diffs.json"))
+      service = HQ::RemoteService.new(registry:, github_client: FakeGitHubReviewClient.new, pull_request_diff_store: diff_store,
+                                      pull_request_review_store: HQ::PullRequestReview::Store.new(File.join(dir, "handoff-reviews.json")))
+      created = service.create_agent("project_key" => "web", "template_key" => "custom", "name" => "Recipient", "prompt" => "Work.", "agent" => "codex")
+      agent = HQ::AgentStore.new(registry.projects).load.find { |item| item.key == created[:key] }
+      HQ::AgentMemory.new(agent).append_attachment!({ "kind" => "link", "title" => "PR", "url" => "https://github.com/example/web/pull/123" })
+      HQ::AgentStore.new(registry.projects).save([agent])
+      reference = HQ::PullRequestDiff.reference_from_url("https://github.com/example/web/pull/123")
+      diff_store.save(
+        "id" => reference.id, "snapshot_id" => "snapshot-1", "provider" => "github", "repository" => "example/web", "number" => 123,
+        "base_sha" => "base", "head_sha" => "head", "diff_format" => HQ::PullRequestDiff::DIFF_FORMAT,
+        "files" => [{ "path" => "lib/example.rb", "hunks" => [{ "lines" => [{ "kind" => "added", "new_number" => 4, "content" => "puts :ok" }] }] }]
+      )
+      result = service.handoff_pull_request_review(reference.id, "agent_key" => created[:key], "note" => "Inspect this.", "start" => false, "idempotency_key" => "line-handoff-1",
+                                                    "selection" => { "snapshot_id" => "snapshot-1", "lines" => [{ "path" => "lib/example.rb", "hunk_index" => 0, "line_index" => 0 }] })
+      content = result[:conversation].last[:content]
+      assert(content.include?("Inspect this.") && content.include?(HQ::PullRequestSelection::OPEN) && content.include?("https://github.com/example/web/pull/123"),
+             "expected handoff to append bounded immutable line context through the normal user-message flow")
+      begin
+        service.handoff_pull_request_review(reference.id, "agent_key" => created[:key], "note" => "Retry", "start" => false, "idempotency_key" => "line-handoff-stale",
+                                            "selection" => { "snapshot_id" => "old", "lines" => [{ "path" => "lib/example.rb", "hunk_index" => 0, "line_index" => 0 }] })
+        raise "expected stale line selection to fail"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.status == 409, "expected stale selected lines to be rejected")
+      end
+      retry_result = service.handoff_pull_request_review(reference.id, "agent_key" => created[:key], "note" => "Ignored", "start" => false, "idempotency_key" => "line-handoff-1",
+                                                          "selection" => { "snapshot_id" => "snapshot-1", "lines" => [{ "path" => "lib/example.rb", "hunk_index" => 0, "line_index" => 0 }] })
+      assert(retry_result[:idempotent] == true, "expected an idempotent handoff retry")
     end
   end
 

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -12,7 +12,15 @@ module RemoteUIAssetSnapshotTest
 
   def run!
     assert_loaded_daemon_keeps_one_asset_build
+    assert_handoff_retry_key_is_cleared_after_success
     puts "remote_ui_asset_snapshot_test: ok"
+  end
+
+  def assert_handoff_retry_key_is_cleared_after_success
+    javascript = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.js"))
+    response_index = javascript.index("const response = await apiPost(`/pull-requests/${encodeURIComponent(id)}/handoff`")
+    clear_index = javascript.index("delete form.dataset.handoffIdempotencyKey", response_index)
+    raise "expected a successful handoff to clear its retry key" unless response_index && clear_index && clear_index > response_index
   end
 
   def assert_loaded_daemon_keeps_one_asset_build


### PR DESCRIPTION
Implements Fizzy #119.

Adds immutable PR snapshot line selection, bounded/sanitized prompt context, stale validation, and Remote UI selection controls.

Validation: `bin/test`, `bin/remote-ui-smoke`, focused Remote API and selection tests.