### PR TITLE
Fix flexible attachment popup layout

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -370,11 +370,13 @@ def write_smoke_script(path)
       const unscheduledAgentKey = process.env.TYCHO_REMOTE_UI_UNSCHEDULED_AGENT_KEY;
       const chromePath = process.env.CHROME_PATH;
       const captureDir = process.env.TYCHO_REMOTE_UI_CAPTURE_DIR || "";
+      const beforeCapture = process.env.TYCHO_REMOTE_UI_BEFORE_CAPTURE || "";
       const skillsOnly = process.env.TYCHO_REMOTE_UI_SKILLS_ONLY === "1";
       const draft = "Remote UI smoke draft " + Date.now();
       const errors = [];
 
       if (captureDir) fs.mkdirSync(captureDir, { recursive: true });
+      if (captureDir && beforeCapture) fs.copyFileSync(beforeCapture, path.join(captureDir, "attachment-flyout-before.png"));
 
       const browser = await chromium.launch({ executablePath: chromePath, headless: true });
       const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
@@ -2415,6 +2417,124 @@ def write_smoke_script(path)
         }
 
         await page.setViewportSize({ width: 1280, height: 800 });
+        const attachmentFlyoutLayouts = await page.evaluate((key) => {
+          const agent = findAgent(key);
+          const longName = `very-long-attachment-name-${"x".repeat(180)}.md`;
+          const measurements = [0, 1, 2, 3, 16].map((count) => {
+            agent.attachments = Array.from({ length: count }, (_, index) => ({
+              id: `attachment-flyout-${count}-${index}`,
+              agent_key: key,
+              type: "file",
+              title: index === 0 ? longName : `attachment-${index + 1}.md`,
+              path: `/tmp/${index === 0 ? longName : `attachment-${index + 1}.md`}`,
+              blob_path: `/attachments/attachment-flyout-${count}-${index}/blob`,
+              format: "text",
+            }));
+            state.renderedViewHtml = "";
+            render();
+
+            const button = document.querySelector("[data-toggle-attachments]");
+            const flyout = document.querySelector("[data-attachment-flyout]");
+            if (!count) return { count, button: Boolean(button), flyout: Boolean(flyout) };
+
+            setAttachmentFlyoutOpen(true);
+            const list = flyout.querySelector(".attachment-list");
+            const header = flyout.querySelector(".attachment-panel-header");
+            const copy = flyout.querySelector(".attachment-copy");
+            const rect = flyout.getBoundingClientRect();
+            const headerRect = header.getBoundingClientRect();
+            const listRect = list.getBoundingClientRect();
+            const result = {
+              count,
+              controls: button.getAttribute("aria-controls"),
+              label: flyout.getAttribute("aria-label"),
+              panel: rect.toJSON(),
+              list: listRect.toJSON(),
+              panelScrollHeight: flyout.scrollHeight,
+              listScrollHeight: list.scrollHeight,
+              listClientHeight: list.clientHeight,
+              listOverflowY: getComputedStyle(list).overflowY,
+              copyOverflows: copy.scrollWidth > copy.clientWidth,
+              intrinsicDelta: Math.abs(rect.height - (headerRect.height + listRect.height + 30)),
+            };
+            document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+            result.closedWithEscape = flyout.classList.contains("hidden");
+            result.focusReturned = document.activeElement === button;
+            return result;
+          });
+          return measurements;
+        }, agentKey);
+        const zeroAttachmentFlyout = attachmentFlyoutLayouts.find((layout) => layout.count === 0);
+        const compactAttachmentFlyouts = attachmentFlyoutLayouts.filter((layout) => [1, 2, 3].includes(layout.count));
+        const overflowingAttachmentFlyout = attachmentFlyoutLayouts.find((layout) => layout.count === 16);
+        if (zeroAttachmentFlyout.button || zeroAttachmentFlyout.flyout ||
+            compactAttachmentFlyouts.some((layout) => layout.controls !== "agent-attachment-flyout" ||
+              layout.label !== "Attachments" || layout.intrinsicDelta > 2 || layout.panel.width > 360 ||
+              layout.copyOverflows || !layout.closedWithEscape || !layout.focusReturned) ||
+            overflowingAttachmentFlyout.panel.height > 341 ||
+            overflowingAttachmentFlyout.listScrollHeight <= overflowingAttachmentFlyout.listClientHeight ||
+            !["auto", "scroll"].includes(overflowingAttachmentFlyout.listOverflowY) ||
+            !overflowingAttachmentFlyout.closedWithEscape || !overflowingAttachmentFlyout.focusReturned) {
+          throw new Error(`Attachment flyout does not shrink, scroll, or retain accessible controls: ${JSON.stringify(attachmentFlyoutLayouts)}`);
+        }
+        await page.evaluate((key) => {
+          const agent = findAgent(key);
+          agent.attachments = [{
+            id: "attachment-flyout-capture",
+            agent_key: key,
+            type: "file",
+            title: "very-long-attachment-name-for-the-flexible-popup-capture.md",
+            path: "/tmp/very-long-attachment-name-for-the-flexible-popup-capture.md",
+            blob_path: "/attachments/attachment-flyout-capture/blob",
+            format: "text",
+          }];
+          state.renderedViewHtml = "";
+          render();
+          setAttachmentFlyoutOpen(true);
+        }, agentKey);
+        if (captureDir) await page.screenshot({ path: path.join(captureDir, "attachment-flyout-desktop.png") });
+        await page.evaluate((key) => {
+          const agent = findAgent(key);
+          agent.attachments = Array.from({ length: 16 }, (_, index) => ({
+            id: `attachment-flyout-resize-${index}`,
+            agent_key: key,
+            type: "file",
+            title: `attachment-${index + 1}.md`,
+            path: `/tmp/attachment-${index + 1}.md`,
+            blob_path: `/attachments/attachment-flyout-resize-${index}/blob`,
+            format: "text",
+          }));
+          state.renderedViewHtml = "";
+          render();
+          setAttachmentFlyoutOpen(true);
+          document.querySelector(".attachment-list").scrollTop = 80;
+        }, agentKey);
+        await page.setViewportSize({ width: 390, height: 844 });
+        const attachmentFlyoutResizeContract = await page.evaluate(() => {
+          const flyout = document.querySelector("[data-attachment-flyout]:not(.hidden)");
+          const toggle = document.querySelector("[data-toggle-attachments]");
+          const list = flyout?.querySelector(".attachment-list");
+          const flyoutRect = flyout?.getBoundingClientRect();
+          const toggleRect = toggle?.getBoundingClientRect();
+          return {
+            viewport: { width: window.innerWidth, height: window.innerHeight },
+            flyout: flyoutRect?.toJSON(),
+            toggle: toggleRect?.toJSON(),
+            scrollTop: list?.scrollTop,
+            scrollHeight: list?.scrollHeight,
+            clientHeight: list?.clientHeight,
+          };
+        });
+        if (!attachmentFlyoutResizeContract.flyout || !attachmentFlyoutResizeContract.toggle ||
+            attachmentFlyoutResizeContract.flyout.left < 0 ||
+            attachmentFlyoutResizeContract.flyout.right > attachmentFlyoutResizeContract.viewport.width ||
+            attachmentFlyoutResizeContract.flyout.bottom > attachmentFlyoutResizeContract.toggle.top ||
+            attachmentFlyoutResizeContract.flyout.bottom > attachmentFlyoutResizeContract.viewport.height ||
+            attachmentFlyoutResizeContract.scrollTop <= 0 ||
+            attachmentFlyoutResizeContract.scrollHeight <= attachmentFlyoutResizeContract.clientHeight) {
+          throw new Error(`Attachment flyout lost its anchor or scroll position after resize: ${JSON.stringify(attachmentFlyoutResizeContract)}`);
+        }
+        await page.setViewportSize({ width: 1280, height: 800 });
         await page.evaluate((key) => {
           const attachment = {
             id: "smoke-attachment-menu",
@@ -3298,6 +3418,7 @@ def write_smoke_script(path)
             mobileAttachmentFlyout.flyout?.bottom > mobileAttachmentFlyout.viewport.height) {
           throw new Error(`Conversation attachments are cropped on mobile: ${JSON.stringify(mobileAttachmentFlyout)}`);
         }
+        if (captureDir) await mobileQuickAgentPage.screenshot({ path: path.join(captureDir, "attachment-flyout-mobile.png") });
         await mobileQuickAgentPage.close();
         const loopAgentKey = await page.evaluate(async () => {
           const data = await apiPost("/agents", {

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -2477,6 +2477,37 @@ def write_smoke_script(path)
             !overflowingAttachmentFlyout.closedWithEscape || !overflowingAttachmentFlyout.focusReturned) {
           throw new Error(`Attachment flyout does not shrink, scroll, or retain accessible controls: ${JSON.stringify(attachmentFlyoutLayouts)}`);
         }
+        const attachmentFlyoutRenderContract = await page.evaluate((key) => {
+          const agent = findAgent(key);
+          agent.attachments = Array.from({ length: 16 }, (_, index) => ({
+            id: `attachment-flyout-render-${index}`,
+            agent_key: key,
+            type: "file",
+            title: `attachment-${index + 1}.md`,
+            path: `/tmp/attachment-${index + 1}.md`,
+            blob_path: `/attachments/attachment-flyout-render-${index}/blob`,
+            format: "text",
+          }));
+          state.renderedViewHtml = "";
+          render();
+          setAttachmentFlyoutOpen(true);
+          const beforeRender = document.querySelector(".attachment-list");
+          beforeRender.scrollTop = 80;
+          const scrollTop = beforeRender.scrollTop;
+          state.renderedViewHtml = "";
+          render();
+          const flyout = document.querySelector("[data-attachment-flyout]");
+          const afterRender = flyout?.querySelector(".attachment-list");
+          return {
+            open: Boolean(flyout && !flyout.classList.contains("hidden")),
+            before: scrollTop,
+            after: afterRender?.scrollTop,
+          };
+        }, agentKey);
+        if (!attachmentFlyoutRenderContract.open || attachmentFlyoutRenderContract.before <= 0 ||
+            Math.abs(attachmentFlyoutRenderContract.after - attachmentFlyoutRenderContract.before) > 1) {
+          throw new Error(`Attachment flyout lost its scroll position during a normal render: ${JSON.stringify(attachmentFlyoutRenderContract)}`);
+        }
         await page.evaluate((key) => {
           const agent = findAgent(key);
           agent.attachments = [{

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -4120,16 +4120,17 @@ select {
   bottom: 52px;
   left: 0;
   z-index: 8;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
   width: min(360px, calc(100vw - 24px), calc(100% - 24px));
-  max-height: min(46dvh, 340px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  max-block-size: min(46dvh, 340px);
+  overflow: hidden;
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--info) 46%, var(--border));
   border-radius: 8px;
   background: color-mix(in srgb, var(--info) 8%, var(--panel));
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
 }
 
 .attachment-panel-header,
@@ -4161,6 +4162,9 @@ select {
 
 .attachment-list {
   display: grid;
+  min-block-size: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   gap: 7px;
 }
 
@@ -7023,9 +7027,7 @@ body:has(.inquiry-form-full-screen) {
   }
 
   .attachment-flyout {
-    max-height: min(64dvh, 520px);
-    overflow-y: auto;
-    overscroll-behavior: contain;
+    max-block-size: min(64dvh, 520px);
   }
 
   .attachment-viewer-actions {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -7535,7 +7535,7 @@ function renderAgentAttachments(agent) {
   if (!attachments.length) return "";
 
   return `
-    <section class="attachment-flyout hidden" data-attachment-flyout data-preserve-open data-preserve-scroll data-state-key="agent-attachment-flyout" aria-label="Attachments">
+    <section id="agent-attachment-flyout" class="attachment-flyout hidden" data-attachment-flyout data-preserve-open data-preserve-scroll data-state-key="agent-attachment-flyout" aria-label="Attachments">
       <div class="attachment-panel-header">
         <strong>Attachments</strong>
         <span>${escapeHtml(attachmentSummary(attachments))}</span>
@@ -7551,7 +7551,7 @@ function renderAttachmentToggle(agent) {
   const attachments = agentAttachments(agent);
   if (!attachments.length) return "";
 
-  return `<button class="attachment-toggle-button" type="button" data-toggle-attachments aria-label="Show attachments" title="Attachments" aria-expanded="false">${iconSvg("paperclip")}<span class="attachment-count">${escapeHtml(String(attachments.length))}</span></button>`;
+  return `<button class="attachment-toggle-button" type="button" data-toggle-attachments aria-controls="agent-attachment-flyout" aria-label="Show attachments" title="Attachments" aria-expanded="false">${iconSvg("paperclip")}<span class="attachment-count">${escapeHtml(String(attachments.length))}</span></button>`;
 }
 
 function renderAttachment(attachment) {
@@ -13933,6 +13933,20 @@ function setAttachmentFlyoutOpen(open) {
   button.setAttribute("aria-expanded", open ? "true" : "false");
 }
 
+function handleAttachmentFlyoutKeydown(event) {
+  if (event.key !== "Escape") return false;
+
+  const flyout = document.querySelector("[data-attachment-flyout]");
+  const button = document.querySelector("[data-toggle-attachments]");
+  if (!flyout || !button || flyout.classList.contains("hidden")) return false;
+
+  event.preventDefault();
+  event.stopPropagation();
+  setAttachmentFlyoutOpen(false);
+  button.focus({ preventScroll: true });
+  return true;
+}
+
 function scrollConversationToRecent() {
   if (!document.querySelector("[data-conversation-recent]")) return;
 
@@ -14559,6 +14573,7 @@ document.addEventListener("keydown", (event) => {
   if (shortcutModifierKey(event)) setShortcutModifierActive(true);
 
   if (handleSpeechModeShortcut(event)) return;
+  if (handleAttachmentFlyoutKeydown(event)) return;
 
   if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "k") {
     event.preventDefault();

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -7535,12 +7535,12 @@ function renderAgentAttachments(agent) {
   if (!attachments.length) return "";
 
   return `
-    <section id="agent-attachment-flyout" class="attachment-flyout hidden" data-attachment-flyout data-preserve-open data-preserve-scroll data-state-key="agent-attachment-flyout" aria-label="Attachments">
+    <section id="agent-attachment-flyout" class="attachment-flyout hidden" data-attachment-flyout data-preserve-open data-state-key="agent-attachment-flyout" aria-label="Attachments">
       <div class="attachment-panel-header">
         <strong>Attachments</strong>
         <span>${escapeHtml(attachmentSummary(attachments))}</span>
       </div>
-      <div class="attachment-list">
+      <div class="attachment-list" data-preserve-scroll data-state-key="agent-attachment-flyout-list">
         ${attachments.map(renderAttachment).join("")}
       </div>
     </section>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -3695,6 +3695,14 @@ module RemoteServerTest
     assert(css[:body].include?(".turn-completed-metric strong"),
            "expected Codex turn completion metrics to style compact values")
     assert(css[:body].include?(".attachment-flyout"), "expected Agent detail to style attachment flyouts")
+    assert(css[:body].include?("max-block-size: min(46dvh, 340px)") &&
+           css[:body].include?("overflow: hidden;"),
+           "expected attachment flyouts to shrink-wrap until their viewport-aware height cap")
+    assert(css[:body].include?(".attachment-list {\n  display: grid;\n  min-block-size: 0;\n  overflow-y: auto;") &&
+           css[:body].include?("overscroll-behavior: contain;"),
+           "expected attachment flyout lists to own bounded scrolling")
+    assert(css[:body].include?("max-block-size: min(64dvh, 520px)"),
+           "expected mobile attachment flyouts to use a viewport-aware height cap")
     assert(css[:body].include?(".attachment-item"), "expected Agent detail attachments to render as rows")
     assert(css[:body].include?(".attachment-main"), "expected Agent detail attachment rows to separate links from actions")
     assert(css[:body].include?(".attachment-actions"), "expected Agent detail attachment rows to expose row actions")
@@ -5227,6 +5235,10 @@ module RemoteServerTest
            "expected attachment rows not to render descriptions")
     assert(js[:body].include?("function toggleAttachmentFlyout"),
            "expected Agent detail attachments to be toggleable")
+    assert(js[:body].include?("aria-controls=\"agent-attachment-flyout\"") &&
+           js[:body].include?("function handleAttachmentFlyoutKeydown") &&
+           js[:body].include?("button.focus({ preventScroll: true })"),
+           "expected attachment flyouts to retain named trigger and Escape focus behavior")
     assert(js[:body].include?("!event.target.closest(\"[data-attachment-flyout]\")"),
            "expected Attachment flyout to close when clicking outside it")
     assert(js[:body].include?('aria-label="Upload file"') && js[:body].include?("iconSvg(\"upload\")"),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5239,6 +5239,9 @@ module RemoteServerTest
            js[:body].include?("function handleAttachmentFlyoutKeydown") &&
            js[:body].include?("button.focus({ preventScroll: true })"),
            "expected attachment flyouts to retain named trigger and Escape focus behavior")
+    assert(js[:body].include?("data-preserve-open data-state-key=\"agent-attachment-flyout\"") &&
+           js[:body].include?("attachment-list\" data-preserve-scroll data-state-key=\"agent-attachment-flyout-list\""),
+           "expected attachment flyout open state and list scroll state to persist independently")
     assert(js[:body].include?("!event.target.closest(\"[data-attachment-flyout]\")"),
            "expected Attachment flyout to close when clicking outside it")
     assert(js[:body].include?('aria-label="Upload file"') && js[:body].include?("iconSvg(\"upload\")"),


### PR DESCRIPTION
Fixes Fizzy #115.

- Make the attachment panel shrink-wrap short lists and put viewport-bounded scrolling on its list.
- Preserve trigger semantics while adding Escape close/focus return and explicit control linkage.
- Add desktop/mobile browser coverage for 0/1/2/3/many attachments, long names, scrolling, resize anchoring, and captures.

Evidence: the supplied `fizzy-115-attachment-popup.png` is retained as `attachment-flyout-before.png` when `TYCHO_REMOTE_UI_BEFORE_CAPTURE` is set; the smoke run generates desktop and mobile after screenshots.

Validated: `bundle exec ruby test/remote_server_test.rb`, `bin/remote-ui-smoke`, `bin/test`, `git diff --check`, and gitleaks.