### PR TITLE
Persist CLI-launched agent exit status

### DIFF
--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -458,8 +458,8 @@ module HQ
       log_file = File.open(@log_path, "a")
       launch = structured_output_runner_launch(command, environment)
       @pid = spawn(
-        external_process_environment(launch.fetch(:env)),
-        *launch.fetch(:command),
+        external_process_environment(launch.fetch(:env)).merge("TYCHO_STATUS_PATH" => status_path),
+        RbConfig.ruby, "-e", agent_runner_script, *launch.fetch(:command),
         chdir: @workspace, out: log_file, err: %i[child out], pgroup: true
       )
       log_file.close
@@ -492,7 +492,8 @@ module HQ
       return unless running?
 
       @stop_requested_at = Time.now
-      Process.kill("TERM", -@pid)
+      terminate_process_group!(term_timeout: 1.0)
+      poll! unless process_group_alive?
       HQ.logger.info("Agent") { "Stopped #{@key}" }
     rescue Errno::ESRCH, Errno::EPERM
       HQ.logger.warn("Agent") { "Failed to stop #{@key}: process not found or permission denied" }
@@ -574,7 +575,7 @@ module HQ
     end
 
     def completed_status_available?
-      status_file_paths.any? { |path| File.file?(path) }
+      status_file_paths.any? { |path| valid_status_file?(path) }
     end
 
     def own_process_group?(pid)
@@ -1078,9 +1079,14 @@ module HQ
           1
         end
         begin
-          File.write(ENV.fetch("TYCHO_STATUS_PATH"), status.to_s)
+          path = ENV.fetch("TYCHO_STATUS_PATH")
+          temporary_path = "\#{path}.tmp-\#{Process.pid}"
+          File.write(temporary_path, status.to_s)
+          File.rename(temporary_path, path)
         rescue StandardError
           nil
+        ensure
+          File.delete(temporary_path) if temporary_path && File.exist?(temporary_path)
         end
         exit(status)
       RUBY
@@ -1090,7 +1096,7 @@ module HQ
       thread = Thread.new do
         _waited_pid, status = Process.wait2(pid)
         begin
-          File.write(status_path, process_exit_code(status).to_s)
+          write_status_file(status_path, process_exit_code(status))
         rescue StandardError
           nil
         end
@@ -1106,6 +1112,14 @@ module HQ
       return 128 + status.termsig.to_i if status.signaled?
 
       status.exitstatus.to_i
+    end
+
+    def write_status_file(path, exit_code)
+      temporary_path = "#{path}.tmp-#{Process.pid}-#{Thread.current.object_id}"
+      File.write(temporary_path, Integer(exit_code).to_s)
+      File.rename(temporary_path, path)
+    ensure
+      FileUtils.rm_f(temporary_path) if temporary_path
     end
 
     def external_process_environment(environment)
@@ -1136,14 +1150,23 @@ module HQ
       if @pid && (monitor = @process_monitors&.delete(@pid))
         monitor.join(0.5)
       end
-      path = status_file_paths.find { |candidate| File.exist?(candidate) }
+      path = status_file_paths.find { |candidate| valid_status_file?(candidate) }
       return nil unless path
 
-      File.read(path).strip.to_i
+      Integer(File.read(path).strip, 10)
     rescue StandardError
       nil
     ensure
       FileUtils.rm_f(path) if path
+    end
+
+    def valid_status_file?(path)
+      return false unless File.file?(path)
+
+      Integer(File.read(path).strip, 10)
+      true
+    rescue ArgumentError, TypeError, SystemCallError
+      false
     end
 
     def finalize_latest_run!
@@ -1284,13 +1307,31 @@ module HQ
 
     def signal_process_group(signal)
       Process.kill(signal, -@pid)
-    rescue Errno::ESRCH, Errno::EPERM
+    rescue Errno::ESRCH
+      nil
+    rescue Errno::EPERM
       clear_foreign_pid!
     end
 
     def wait_until_not_running(timeout)
       deadline = Time.now + timeout.to_f
       while running? && Time.now < deadline
+        sleep 0.05
+      end
+    end
+
+    def process_group_alive?(pid = @pid)
+      return false unless pid
+
+      Process.kill(0, -pid)
+      true
+    rescue Errno::ESRCH, Errno::EPERM
+      false
+    end
+
+    def wait_until_process_group_stops(timeout)
+      deadline = Time.now + timeout.to_f
+      while process_group_alive? && Time.now < deadline
         sleep 0.05
       end
     end
@@ -1307,11 +1348,11 @@ module HQ
 
     def terminate_process_group!(term_timeout:, kill_timeout: 0.5)
       signal_process_group("TERM")
-      wait_until_not_running(term_timeout)
-      return unless running?
+      wait_until_process_group_stops(term_timeout)
+      return unless process_group_alive?
 
       signal_process_group("KILL")
-      wait_until_not_running(kill_timeout)
+      wait_until_process_group_stops(kill_timeout)
     end
 
     def stale_direct_output_wait(now:)

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -45,6 +45,10 @@ module ManagedAgentTest
     assert_poll_preserves_stale_structured_output
     assert_external_process_environment_removes_ruby_loader_state
     assert_start_spawns_harness_through_validation_runner
+    assert_started_agent_persists_status_after_launcher_exits
+    assert_incomplete_status_files_are_not_completion
+    assert_stop_kills_term_ignoring_harness_before_restart
+    assert_stop_finalizes_when_group_exits_before_signal
     assert_agent_runner_warns_when_command_cannot_execute
     puts "managed_agent_test: ok"
   end
@@ -1467,14 +1471,23 @@ module ManagedAgentTest
     return unless pid
 
     deadline = Time.now + timeout
-    loop do
-      Process.kill(0, pid)
-      break if Time.now >= deadline
-
+    while process_alive?(pid) && Time.now < deadline
       sleep 0.05
-    rescue Errno::ESRCH, Errno::EPERM
-      break
     end
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def process_group_alive?(pid)
+    Process.kill(0, -pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
   end
 
   def assert_external_process_environment_removes_ruby_loader_state
@@ -1557,6 +1570,208 @@ module ManagedAgentTest
     end
   ensure
     HQ.custom_harnesses = old_harnesses if defined?(old_harnesses)
+  end
+
+  def assert_started_agent_persists_status_after_launcher_exits
+    old_harnesses = HQ.custom_harnesses
+    [[0, "succeeded"], [23, "failed"]].each do |exit_code, expected_status|
+      Dir.mktmpdir("hq-detached-agent-status-test") do |dir|
+        harness = File.join(dir, "detached-harness")
+        manifest_path = File.join(dir, "agent.json")
+        result_status = exit_code.zero? ? "success" : "failed"
+        payload = JSON.generate(
+          "type" => "assistant",
+          "session_id" => "detached-session",
+          "message" => {
+            "role" => "assistant",
+            "content" => [{
+              "type" => "tool_use",
+              "name" => "StructuredOutput",
+              "input" => {
+                "status" => result_status,
+                "summary" => "Detached run completed.",
+                "inquiry_json" => "null",
+                "attachments_json" => "null"
+              }
+            }]
+          }
+        )
+        File.write(harness, <<~SH)
+          #!/bin/sh
+          sleep 0.5
+          printf '%s\n' '#{payload}'
+          exit #{exit_code}
+        SH
+        File.chmod(0o755, harness)
+        HQ.custom_harnesses = [
+          HQ::HarnessConfig.new(
+            key: "detached-wrapper",
+            adapter: "claude",
+            execution_command: [harness]
+          )
+        ]
+
+        launcher_pid = fork do
+          agent = HQ::ManagedAgent.new(
+            key: "detached-wrapper-agent",
+            name: "Detached Wrapper Agent",
+            project_key: "demo",
+            template_key: "custom",
+            workspace: dir,
+            prompt: "System prompt",
+            agent: "detached-wrapper",
+            log_path: File.join(dir, "detached.raw.log")
+          )
+          agent.start!
+          File.write(manifest_path, JSON.generate(agent.to_hash))
+          exit!(0)
+        end
+        Process.wait(launcher_pid)
+
+        agent = HQ::ManagedAgent.from_hash(JSON.parse(File.read(manifest_path)))
+        status_path = agent.send(:status_file_path)
+        50.times do
+          break if agent.send(:valid_status_file?, status_path)
+
+          sleep 0.1
+        end
+        persisted_exit_code = Integer(File.read(status_path), 10) if File.file?(status_path)
+        agent.poll!
+
+        log = File.read(agent.log_path)
+        assert(persisted_exit_code == exit_code,
+               "expected detached exit #{exit_code} to publish atomically, log: #{log}")
+        assert(agent.last_exit_code == exit_code,
+               "expected the detached managed child to preserve exit code #{exit_code}")
+        assert(agent.status == expected_status,
+               "expected detached managed child status #{expected_status}, got #{agent.status.inspect}")
+        assert(agent.last_summary == "Detached run completed.",
+               "expected the detached managed child to preserve its structured summary")
+      end
+    end
+  ensure
+    HQ.custom_harnesses = old_harnesses if defined?(old_harnesses)
+  end
+
+  def assert_incomplete_status_files_are_not_completion
+    Dir.mktmpdir("hq-incomplete-status-test") do |dir|
+      agent = HQ::ManagedAgent.new(
+        key: "incomplete-status-agent",
+        name: "Incomplete Status Agent",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "System prompt",
+        log_path: File.join(dir, "incomplete.raw.log")
+      )
+      status_path = agent.send(:status_file_path)
+
+      ["", "not-an-exit-code"].each do |contents|
+        File.write(status_path, contents)
+        assert(!agent.send(:completed_status_available?),
+               "expected #{contents.inspect} not to mark the agent complete")
+        assert(agent.send(:read_exit_code).nil?, "expected #{contents.inspect} not to parse as exit code 0")
+        assert(File.exist?(status_path), "expected an incomplete status file to remain available for replacement")
+      end
+    end
+  end
+
+  def assert_stop_kills_term_ignoring_harness_before_restart
+    old_harnesses = HQ.custom_harnesses
+    Dir.mktmpdir("hq-term-ignoring-harness-test") do |dir|
+      harness = File.join(dir, "term-ignoring-harness")
+      child_pid_path = File.join(dir, "child.pid")
+      File.write(harness, <<~SH)
+        #!/bin/sh
+        trap '' TERM
+        echo $$ > '#{child_pid_path}'
+        sleep 30
+      SH
+      File.chmod(0o755, harness)
+      HQ.custom_harnesses = [
+        HQ::HarnessConfig.new(
+          key: "term-ignoring-wrapper",
+          adapter: "claude",
+          execution_command: [harness]
+        )
+      ]
+      agent = HQ::ManagedAgent.new(
+        key: "term-ignoring-agent",
+        name: "Term Ignoring Agent",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "System prompt",
+        agent: "term-ignoring-wrapper",
+        log_path: File.join(dir, "term-ignoring.raw.log")
+      )
+      agent.start!
+      wrapper_pid = agent.pid
+      deadline = Time.now + 5
+      sleep 0.05 until File.file?(child_pid_path) || Time.now >= deadline
+      child_pid = Integer(File.read(child_pid_path), 10)
+
+      agent.stop!
+      wait_for_process_exit(child_pid)
+
+      assert(!agent.send(:process_group_alive?, wrapper_pid),
+             "expected TERM-to-KILL escalation to remove the complete managed process group")
+      assert(!process_alive?(child_pid), "expected the TERM-ignoring harness to be killed")
+      assert(agent.status == "stopped", "expected the stopped run to finalize before restart")
+      assert(agent.pid.nil?, "expected stop to clear the completed process id before returning")
+      assert(agent.last_run.status == "stopped", "expected stop to finalize the persisted run before returning")
+
+      agent.start!
+      assert(agent.pid != wrapper_pid, "expected restart to use a new process-group leader")
+      assert(!process_group_alive?(wrapper_pid), "expected no old harness group to overlap the restarted run")
+    ensure
+      agent&.retire_for_archive!(timeout: 0.1) if agent&.running?
+      Process.kill("KILL", -wrapper_pid) if wrapper_pid && process_group_alive?(wrapper_pid)
+    end
+  ensure
+    HQ.custom_harnesses = old_harnesses if defined?(old_harnesses)
+  end
+
+  def assert_stop_finalizes_when_group_exits_before_signal
+    Dir.mktmpdir("hq-stop-exit-race-test") do |dir|
+      dead_pid = spawn(RbConfig.ruby, "-e", "exit 0")
+      Process.wait(dead_pid)
+      started_at = Time.now - 1
+      log_path = File.join(dir, "stop-exit-race.raw.log")
+      File.write(log_path, "=== process output ===\n")
+      run = HQ::ManagedAgent::AgentRun.new(
+        started_at: started_at,
+        status: "running",
+        log_path: log_path,
+        command: "finished-before-stop"
+      )
+      agent = HQ::ManagedAgent.new(
+        key: "stop-exit-race-agent",
+        name: "Stop Exit Race Agent",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: dir,
+        prompt: "System prompt",
+        pid: dead_pid,
+        started_at: started_at,
+        log_path: log_path,
+        runs: [run]
+      )
+      File.write(agent.send(:status_file_path), "143")
+      original_running = agent.method(:running?)
+      running_checks = 0
+      agent.define_singleton_method(:running?) do
+        running_checks += 1
+        running_checks == 1 ? true : original_running.call
+      end
+
+      agent.stop!
+
+      assert(agent.pid.nil?, "expected an ESRCH stop race to clear pid through finalization")
+      assert(agent.last_exit_code == 143, "expected an ESRCH stop race to consume the published status")
+      assert(agent.status == "stopped", "expected an ESRCH stop race to finalize as stopped")
+      assert(agent.last_run.status == "stopped", "expected an ESRCH stop race to finalize its run")
+    end
   end
 
   def assert_start_records_missing_harness_without_spawning


### PR DESCRIPTION
## Summary

- wrap the managed child in the existing durable status writer so completion survives a short-lived `agent run` CLI process
- keep the in-process monitor for server-owned runs
- add a regression that exits the launcher immediately, then restores and finalizes the agent from its persisted status and structured output

## Root cause

`ManagedAgent#start!` relied only on an in-memory monitor thread to write the status file. `bin/tycho agent run` exits after spawning, which terminates that thread while the managed child keeps running. Later status reads therefore had no exit code and reported `idle` despite successful structured output.

## Validation

- `bundle exec ruby test/managed_agent_test.rb`
- `bin/test`
- `git diff --check`
- `gitleaks detect --no-banner --redact --source . --no-git`

`bin/remote-ui-smoke` reaches the browser checks on `main` but fails at the existing skill-autocomplete contract (`[data-skill-autocomplete]:not(.hidden)` timeout). This change does not touch Remote UI code.