### PR TITLE
Prepare v0.10.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a reproducible HQ bug
+about: Report a reproducible Tycho bug
 title: ""
 labels: bug
 assignees: ""
@@ -18,7 +18,7 @@ assignees: ""
 
 - Ruby:
 - OS:
-- HQ commit or version:
+- Tycho commit or version:
 - Optional tools involved:
 
 ## Logs Or Screenshots

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an HQ improvement
+about: Suggest a Tycho improvement
 title: ""
 labels: enhancement
 assignees: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,55 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
-- Give Codex and Claude-compatible agents the same canonical result schema, and
-  inject that schema into cold OpenCode execution prompts without exposing it in
-  raw prompt headers, memory, the TUI, or Remote UI.
-- Add a read-only Remote UI project workspace browser with multiserver routing,
-  bounded directory listings, safe text previews, durable navigation, and
-  server-enforced traversal, symlink, binary, size, VCS, and secret controls.
-- Attach the structured-output runner's child stdin to the null device so
-  managed Codex agents start without waiting for input or failing with a
-  terminal I/O error.
-- Validate managed-agent structured output before success, request up to two
-  same-session corrections for Codex and Claude-compatible harnesses, and
-  preserve exhausted invalid responses in private diagnostic files while
-  surfacing each retry as a collapsed TYCHO system event block and actionable
-  exhausted failures in logs and Remote UI.
+## 0.10.0 - 2026-08-15
+
+### Highlights
+
+- Add durable parent-child agent delegation with CLI/API provenance, automatic
+  terminal reports to parent sessions, safe parent resume, and archive-stable
+  bidirectional navigation in Remote UI.
+- Add auditable run and native-session usage metrics with provider-correct token
+  and cost normalization, archive manifests, idempotent historical backfill,
+  CLI tables and JSON, and Remote API queries.
 - Add direct `--server` CLI targeting for remote project inspection and the
-  complete managed-agent lifecycle, with token/token_env authentication, JSON
-  output, and explicit transport, authentication, compatibility, and API errors.
+  complete managed-agent lifecycle. Store one bearer credential per stable
+  server key with login, logout, status, verify, and migration commands;
+  `token_env` remains supported and inline tokens remain a warned fallback
+  through v0.10.x.
+- Validate managed-agent structured output before success, request bounded
+  same-session corrections for Codex and Claude-compatible harnesses, preserve
+  exhausted invalid responses privately, and align the canonical result schema
+  across Codex, Claude-compatible harnesses, and cold OpenCode prompts.
+- Add a read-only Remote UI project workspace browser with multiserver routing,
+  bounded listings, safe text previews, durable navigation, and server-enforced
+  traversal, symlink, binary, size, VCS, and secret controls.
+
+### Other changes
+
+- Add Tycho skill status, install, and update flows for Codex, Claude Code, and
+  OpenCode, plus agent CLI installation guidance during onboarding.
+- Add selected pull-request diff lines to agent context, speed up PR detail
+  loading, and persist agent-owned PR catalogs and snapshots for fast switching.
+- Add a global speech-mode shortcut and refine speech following, inline comment
+  controls, Markdown code-block copy menus, and focused PR diff behavior.
+- Keep unread counts and agent switching live through compact activity endpoints
+  and independent Remote UI polling, including while focused views pause page
+  refreshes.
+- Keep the Settings section menu sticky in one horizontally scrollable row, add
+  previous/next run-summary navigation, and add quick file downloads beside
+  Summary attachment detail links.
+
+### Fixes
+
+- Retire expired Web Push subscriptions, renew stale browser subscriptions, keep
+  daemon API and browser asset builds coherent, and preserve Windows PWA display
+  and click routing.
+- Preserve structured inquiries, focused views, attachment menus, forms, and
+  polling state across desktop and mobile layouts.
+- Preserve CLI-launched agent exit status, clear leaked Bundler setup from agent
+  runners, and attach correction-runner stdin to the null device.
+- Fix mobile Quick Agent, attachment flyout, diff return, schedule menu, and
+  flexible popup layouts.
 
 ## 0.9.0 - 2026-07-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for working on HQ.
+Thanks for working on Tycho.
 
 ## Setup
 
@@ -25,7 +25,7 @@ Follow the existing Ruby style:
 - `SCREAMING_SNAKE_CASE` constants.
 - Small domain objects and focused rendering modules.
 
-behavior in domain objects. Keep rendering split between
+Keep behavior in domain objects. Keep rendering split between
 `lib/hq/ui/rendering.rb` and focused modules under `lib/hq/ui/rendering/`.
 
 ## Tests

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1018,6 +1018,8 @@ def write_smoke_script(path)
           const saved = {
             agents: state.agents,
             agentDetails: state.agentDetails,
+            activityAgents: state.activityAgents,
+            activityReadyServerKeys: state.activityReadyServerKeys,
             projects: state.projects,
             projectDetails: state.projectDetails,
             servers: state.servers,
@@ -1037,6 +1039,8 @@ def write_smoke_script(path)
           });
 
           try {
+            state.activityAgents = new Map();
+            state.activityReadyServerKeys = new Set();
             state.agentDetails = {
               "agent-detail-revision-fixture": {
                 key: "agent-detail-revision-fixture",
@@ -1054,6 +1058,8 @@ def write_smoke_script(path)
           } finally {
             state.agents = saved.agents;
             state.agentDetails = saved.agentDetails;
+            state.activityAgents = saved.activityAgents;
+            state.activityReadyServerKeys = saved.activityReadyServerKeys;
             state.projects = saved.projects;
             state.projectDetails = saved.projectDetails;
             state.servers = saved.servers;
@@ -4299,6 +4305,10 @@ def write_smoke_script(path)
           const originalHash = location.hash;
           const originalLoadResourceCatalog = loadResourceCatalog;
           const originalRender = render;
+          const originalActivityReadyServerKeys = state.activityReadyServerKeys;
+          clearTimeout(state.activityTimer);
+          state.activityTimer = null;
+          state.activityReadyServerKeys = new Set();
           const agent = findAgent(key);
           agent.running = true;
           agent.status = "running";
@@ -4364,6 +4374,7 @@ def write_smoke_script(path)
             window.fetch = originalFetch;
             loadResourceCatalog = originalLoadResourceCatalog;
             render = originalRender;
+            state.activityReadyServerKeys = originalActivityReadyServerKeys;
             clearTimeout(state.timer);
             state.timer = null;
             history.replaceState(null, "", originalHash);
@@ -4371,6 +4382,7 @@ def write_smoke_script(path)
             state.renderedViewHtml = "";
             originalRender();
             schedule();
+            scheduleAgentActivity();
           }
         }, agentKey);
         if (focusedStatusSyncContract.before.status !== "Running" ||
@@ -4628,8 +4640,39 @@ def write_smoke_script(path)
         }
 
         await page.evaluate((key) => {
-          findAgent(key).cost_snapshot = { amount_usd: 1.25, coverage: "partial" };
-          history.replaceState(null, "", routeHash({ type: "agentSummary", key }));
+          const agent = findAgent(key);
+          const attachment = {
+            id: "summary-download-fixture",
+            kind: "file",
+            type: "file",
+            title: "summary-notes.md",
+            path: "/tmp/tycho-smoke/summary-notes.md",
+            blob_path: "/attachments/summary-download-fixture/blob",
+          };
+          agent.attachments = [...(agent.attachments || []).filter((item) => item.id !== attachment.id), attachment];
+          state.attachmentDetails[attachment.id] = attachment;
+          state.conversations[key] ||= { blocks: [] };
+          state.conversations[key].blocks = [
+            {
+              kind: "run_summary",
+              content: "Older summary content.",
+              created_at: "2026-08-15T01:00:00Z",
+              metadata: { summary_id: "summary-older", run_number: 1, status: "success", attachments: [] },
+            },
+            {
+              kind: "run_summary",
+              content: "Newer summary content.",
+              created_at: "2026-08-15T02:00:00Z",
+              metadata: {
+                summary_id: "summary-newer",
+                run_number: 2,
+                status: "partial",
+                attachments: [attachment],
+                cost_snapshot: { amount_usd: 1.25, coverage: "partial" },
+              },
+            },
+          ];
+          history.replaceState(null, "", routeHash({ type: "agentSummary", key, summaryId: "summary-newer" }));
           state.renderedRouteKey = null;
           state.renderedViewHtml = "";
           render();
@@ -4642,13 +4685,32 @@ def write_smoke_script(path)
           summary: Boolean(document.querySelector("[data-agent-summary-page]")),
           cost: document.querySelector("[data-agent-summary-page]")?.innerText,
           recent: Boolean(document.querySelector("[data-go-recent]")),
+          previousDisabled: document.querySelector("[aria-label='Previous summary']")?.disabled,
+          nextDisabled: document.querySelector("[aria-label='Next summary']")?.disabled,
+          downloadButtons: document.querySelectorAll("[data-agent-summary-page] .summary-attachment-download[data-download-attachment='summary-download-fixture']").length,
+          attachmentDetailHref: document.querySelector("[data-agent-summary-page] .summary-attachment-item .summary-attachment-row")?.getAttribute("href"),
           deduplicated: runSummaryDetailContent({
             content: "partial: First paragraph.\\n\\nFirst paragraph.\\n\\nSecond paragraph.",
             metadata: { status: "partial" },
           }),
         }));
-        if (summaryFullView.mode !== "full" || !summaryFullView.full || !summaryFullView.summary || summaryFullView.recent || summaryFullView.deduplicated !== "First paragraph.\\n\\nSecond paragraph." || !summaryFullView.cost.includes("$1.25+")) {
+        if (summaryFullView.mode !== "full" || !summaryFullView.full || !summaryFullView.summary || summaryFullView.recent ||
+            summaryFullView.previousDisabled || !summaryFullView.nextDisabled || summaryFullView.downloadButtons !== 1 ||
+            !summaryFullView.attachmentDetailHref?.includes("attachment/summary-download-fixture") ||
+            summaryFullView.deduplicated !== "First paragraph.\\n\\nSecond paragraph." || !summaryFullView.cost.includes("$1.25+")) {
           throw new Error(`Summary did not retain the shared full-view layout: ${JSON.stringify(summaryFullView)}`);
+        }
+        if (captureDir) await page.screenshot({ path: path.join(captureDir, "summary-navigation-download.png") });
+        await page.click("[aria-label='Previous summary']");
+        const previousSummary = await page.evaluate(() => ({
+          summaryId: parseRoute().summaryId,
+          content: document.querySelector("[data-agent-summary-page]")?.innerText,
+          previousDisabled: document.querySelector("[aria-label='Previous summary']")?.disabled,
+          nextDisabled: document.querySelector("[aria-label='Next summary']")?.disabled,
+        }));
+        if (previousSummary.summaryId !== "summary-older" || !previousSummary.content?.includes("Older summary content.") ||
+            !previousSummary.previousDisabled || previousSummary.nextDisabled) {
+          throw new Error(`Summary navigation did not move to the older run: ${JSON.stringify(previousSummary)}`);
         }
 
         await page.evaluate((key) => {
@@ -5124,17 +5186,28 @@ def write_smoke_script(path)
           const nav = document.querySelector(".settings-section-nav");
           const button = document.querySelector("[data-scroll-settings-section='settings-automation']");
           const panel = document.querySelector("#settings-panel-automation");
+          const shell = document.querySelector(".settings-section-nav-shell");
+          const buttonTops = Array.from(nav?.querySelectorAll("button") || [], (item) => Math.round(item.getBoundingClientRect().top));
           return {
             sharedNav: nav?.classList.contains("ui-section-nav"),
             current: button?.getAttribute("aria-current"),
             controls: button?.getAttribute("aria-controls"),
             sharedPanel: panel?.classList.contains("ui-section-panel"),
+            singleRow: new Set(buttonTops).size === 1,
+            horizontalScroll: getComputedStyle(nav).overflowX === "auto",
+            scrollable: nav.scrollWidth > nav.clientWidth,
+            sticky: getComputedStyle(shell).position === "sticky",
+            shellTop: Math.round(shell?.getBoundingClientRect().top || 0),
+            headerBottom: Math.round(document.querySelector(".app-header")?.getBoundingClientRect().bottom || 0),
           };
         });
         if (!settingsComposite.sharedNav || settingsComposite.current !== "location" ||
-            settingsComposite.controls !== "settings-panel-automation" || !settingsComposite.sharedPanel) {
+            settingsComposite.controls !== "settings-panel-automation" || !settingsComposite.sharedPanel ||
+            !settingsComposite.singleRow || !settingsComposite.horizontalScroll || !settingsComposite.scrollable ||
+            !settingsComposite.sticky || Math.abs(settingsComposite.shellTop - settingsComposite.headerBottom) > 1) {
           throw new Error(`Settings lost shared section navigation behavior: ${JSON.stringify(settingsComposite)}`);
         }
+        if (captureDir) await page.screenshot({ path: path.join(captureDir, "settings-horizontal-nav.png") });
         const loopDefaults = {
           interval: await page.locator("#session-loop-default-interval").inputValue(),
           endTime: await page.locator("#session-loop-default-end-time").inputValue(),

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,12 +1,12 @@
 ---
 name: PROJECT_STATUS
-description: HQ project status, key decisions, and roadmap
+description: Tycho project status, key decisions, and roadmap
 type: project
 ---
 
-# Project Status - HQ
+# Project Status - Tycho
 
-> **Purpose:** Living status document for HQ. Stable conventions and architectural guidance live in [CLAUDE.md](../CLAUDE.md); operational pitfalls live in [GOTCHAS.md](./GOTCHAS.md).
+> **Purpose:** Living status document for Tycho. Stable conventions and architectural guidance live in [CLAUDE.md](../CLAUDE.md); operational pitfalls live in [GOTCHAS.md](./GOTCHAS.md).
 
 ## Last Updated
 
@@ -90,18 +90,12 @@ Key references:
 
 ## Current Focus
 
-**v0.9 release**: persistent multiserver Agent and Project catalogs and the
-second Remote UI design-system pass are complete. The Remote UI now aggregates
-peer agents and projects through a stale-while-revalidate broker catalog, keeps
-server-qualified detail and mutation routes explicit, persists last-good peer
-snapshots, and shows each connected server's Tycho version in Settings with
-host-version mismatch detection. GitHub App groundwork is present, including
-device login, guarded review posting, and immutable diff snapshots, but the
-canonical App workflow is not applicable for general use yet and the Review
-Inbox route remains paused until discovery is redesigned around bounded
-incremental loading. The remaining v0.9.0 work is to merge the release-prep
-commit, tag the release, publish GitHub notes, update the Homebrew tap, and
-verify the bottle.
+**v0.10 release**: remote CLI control, server-owned credentials, structured
+output correction, auditable usage metrics, project workspace browsing, Tycho
+skill installation, pull-request context, and durable agent delegation are
+complete. Remote UI now keeps compact agent activity live independently from
+page polling, preserves focused work, and adds direct navigation across run
+summaries and their attachments.
 
 ## Roadmap
 
@@ -203,13 +197,24 @@ verify the bottle.
       confirmations, detail headers, and empty states
 - [x] Pause the eager Review Inbox until bounded discovery and loading are redesigned
 
+### v0.10 — Agent Operations and Observability ✓
+
+- [x] Add remote project and managed-agent CLI operations with private,
+      server-bound credential management
+- [x] Validate structured output and request bounded same-session corrections
+- [x] Add normalized run/native-session usage metrics and historical backfill
+- [x] Add safe Remote UI workspace browsing and Tycho skill installation
+- [x] Add selected PR diff context and persistent agent PR catalogs
+- [x] Add durable managed-agent delegation and terminal parent callbacks
+- [x] Keep agent activity live during focused Remote UI workflows
+
 ## Features Candidates
 
 ### Release Hardening
 
 - [ ] Formalize specs
 - [x] Stabilize source packaging and pre-release browser/TUI checks
-- [ ] Publish and verify the 0.9.0 Homebrew bottles
+- [x] Publish and verify the 0.9.0 Homebrew bottles
 
 ### Canonical Tycho GitHub App
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-08-13
+2026-08-15
 
 ## Strategic Direction
 
@@ -73,6 +73,7 @@ Key references:
 | Remote UI control sizing | Shared 44 px control and touch-target tokens, 16 px mobile form text, visible focus states, and explicit validation/status text | Avoid mobile auto-zoom, undersized targets, color-only state, and inconsistent action geometry |
 | Remote UI design system | Keep a no-build internal system: semantic `--ds-*` tokens and reusable CSS components in `design_system.css`, product composition in `app.css`, and a static `/design-system` preview; migrate routes incrementally | Match the existing Ruby/vanilla-JS deployment, preserve behavior, make foundations governable, and avoid a framework or package rewrite |
 | Remote UI deployment coherence | Snapshot all browser assets and their shared hash when `tycho serve` starts; require a daemon restart to load source updates | Prevent an old Ruby API from serving a newer on-disk JavaScript client after a pull, which can break push subscription renewal and other cross-boundary flows |
+| Remote UI agent activity | Keep a server-owned in-memory activity snapshot updated by lifecycle mutations and the existing notification reconciliation pass; poll its compact read-only endpoint independently from page refreshes | Logo unread counts and agent switching stay current while forms pause page polling, without adding another server loop or letting slower catalog responses overwrite newer activity |
 | Remote multiserver resources | Keep one UI-serving broker, aggregate only compact Agent and Project resources through a disk-backed stale-while-revalidate catalog, and require explicit server identity for details and mutations | Combined lists stay responsive across peer failures and broker restarts; only a validated full snapshot may remove cached resources, while schedules, setup, GitHub, push, restart, and other server-level behavior remain local |
 | Project workspace browsing | Keep canonical path resolution, sensitive/generated-file policy, bounded listing, and text preview in `ProjectWorkspace`; expose only relative paths through project-scoped read-only endpoints | Remote and multiserver browsing must not leak host paths or let client routing bypass traversal, symlink, VCS, credential, binary, or size controls |
 | Remote credential ownership | Bind one bearer credential to each stable remote server key and verified scheme/host/effective-port origin; keep Tycho-managed values in atomic mode-`0600` `~/.tycho/config/remote_credentials.json`, with explicit per-server `token_env` overrides | CLI and broker share one resolver, multiple peers cannot select credentials by incidental names, origin changes require explicit recovery, and browser promotion removes its copy only after verified persistence |
@@ -358,6 +359,7 @@ verify the bottle.
 - [x] Full-screen inquiry editor with trailing unstructured Leave feedback field
 - [x] Poll-safe inline and full-screen Conversation/inquiry forms that remain attached and focused during shell refreshes
 - [x] Focused Summary, Attachment, PR Diff, and agent-backed project Diff routes show that conversation polling is paused, poll only the lightweight resource catalog, preserve their workspace DOM, and reconcile status/lifecycle controls in place; normal route polling resumes on Conversation and top-level live views
+- [x] Keep logo unread counts and agent switching live through a compact activity snapshot and independent client poll, including while full-screen forms pause page refreshes
 - [x] Attachment detail context menus with exclusive Balanced/Widen/Full layouts, content/path copy, and forced cache refresh
 - [x] Responsive desktop/mobile shell with persistent, header-aligned in-shell desktop navigation across top-level and detail routes, consistently named New agent action, shared control sizing, and fixed-region safe-area handling
 - [x] Sticky Settings section navigator over one continuous page and copyable native session ID in Conversation Settings

--- a/docs/REMOTE_SERVER.md
+++ b/docs/REMOTE_SERVER.md
@@ -381,6 +381,7 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/agents` | List active managed agents. |
+| `GET` | `/activity` | Read the local server's compact in-memory agent activity snapshot. |
 | `GET` | `/agents/archived` | List visible archived agents as read-only summaries. Supports `page`, `per_page` (maximum 100), `project_key`, and `q`. |
 | `POST` | `/agents` | Create a managed agent. |
 | `GET` | `/agents/{key}` | Read one managed agent. |
@@ -415,6 +416,7 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 | `POST` | `/push/test` | Send a test notification to an enabled subscription. |
 | `POST` | `/server/restart` | Restart the `tycho serve` Remote server process when restart is available. |
 | `GET` | `/servers` | List the local server and configured broker targets. |
+| `GET` | `/servers/activity` | Read compact local and cached peer activity for unread counts and agent switching. |
 | `GET` | `/servers/resources` | Read the cached combined agent/project catalog and per-server health. |
 | `DELETE` | `/servers/:server_key/resources` | Forget one peer's persisted agents and projects without changing the peer configuration or remote data. |
 | `POST` | `/servers/resources/refresh` | Queue bounded background refreshes for all configured servers. |
@@ -443,6 +445,19 @@ Conversation entries are projected from `AgentChatLog#chat_blocks` when availabl
 For peer resource routes, the browser may send `X-Tycho-Remote-Server-Token` when that peer's token lives in browser local storage. The broker converts it to the peer request's `Authorization: Bearer ...` header and does not persist it. The compatibility `/servers/{key}/proxy/{path}` route accepts only the same agent, project, and attachment roots; server-level paths are rejected.
 
 ## Endpoint Details
+
+### `GET /activity` and `GET /servers/activity`
+
+`GET /activity` returns the local server's compact in-memory agent activity
+snapshot. `GET /servers/activity` combines that live local snapshot with the
+cached peer catalog. Remote UI polls these endpoints independently from full
+page refreshes so unread counts, lifecycle state, and agent switching remain
+current while focused forms or detail views pause conversation polling.
+
+Both endpoints require the same bearer authentication as the rest of the JSON
+API and omit prompts, conversations, attachments, and other full agent detail.
+The local snapshot includes a monotonic revision; the combined response uses a
+content-derived revision so clients can skip unchanged updates.
 
 ### `POST /server/restart`
 

--- a/docs/WEB_PUSH_BEHAVIOR.md
+++ b/docs/WEB_PUSH_BEHAVIOR.md
@@ -9,7 +9,7 @@ This note explains how Tycho Remote UI uses browser push notifications, notifica
 3. `RemoteService#dispatch_agent_push_events` builds a compact JSON payload for the event.
 4. `WebPushNotifier#send_payload!` sends that payload to every enabled browser subscription with VAPID authentication.
 5. `/service-worker.js` receives the push event, updates the installed-app badge when a `badge_count` is present, and calls `registration.showNotification(title, options)`.
-6. When the Remote UI page is open, `syncUnreadAlert()` also mirrors the unread-agent count into the app badge so foreground state and background push state stay aligned.
+6. When the Remote UI page is open, a compact activity poll reads the server-owned snapshot and calls `syncUnreadAlert()` to mirror the unread-agent count into the logo and app badge. Lifecycle mutations update that snapshot immediately, while the existing notification reconciliation pass catches external process completion; no additional server loop is created.
 7. Notification clicks focus an existing Tycho Remote tab when possible, otherwise they open the payload URL, usually `/#agent/{key}`.
 
 ## Deployment Coherence

--- a/lib/hq/domain/agent_activity_snapshot.rb
+++ b/lib/hq/domain/agent_activity_snapshot.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "thread"
+require "time"
+
+module HQ
+  class AgentActivitySnapshot
+    SCHEMA_VERSION = 1
+
+    def initialize
+      @mutex = Mutex.new
+      @revision = 0
+      @generated_at = nil
+      @ready = false
+      @agents = {}
+    end
+
+    def replace!(agents)
+      replacement = Array(agents).to_h { |agent| [agent.key, activity_payload(agent)] }
+      @mutex.synchronize do
+        return false if @ready && @agents == replacement
+
+        @agents = replacement
+        changed!
+      end
+      true
+    end
+
+    def upsert!(agent)
+      payload = activity_payload(agent)
+      @mutex.synchronize do
+        return false if @ready && @agents[agent.key] == payload
+
+        @agents[agent.key] = payload
+        changed!
+      end
+      true
+    end
+
+    def remove!(key)
+      @mutex.synchronize do
+        removed = @agents.delete(key.to_s)
+        return false unless removed
+
+        changed!
+      end
+      true
+    end
+
+    def snapshot
+      @mutex.synchronize do
+        agents = @agents.values.sort_by { |agent| agent.fetch(:key) }.map(&:dup)
+        {
+          schema_version: SCHEMA_VERSION,
+          revision: @revision,
+          generated_at: @generated_at,
+          ready: @ready,
+          unread_count: agents.count { |agent| agent[:unread] },
+          agents: agents
+        }
+      end
+    end
+
+    private
+
+    def changed!
+      @revision += 1
+      @generated_at = Time.now.utc.iso8601
+      @ready = true
+    end
+
+    def activity_payload(agent)
+      status = agent.status
+      {
+        key: agent.key,
+        name: agent.display_name,
+        project_key: agent.project_key,
+        template_key: agent.template_key,
+        scheduled: agent.scheduled?,
+        schedule_key: agent.schedule_key,
+        agent: agent.agent,
+        model: agent.model,
+        reasoning_effort: agent.reasoning_effort,
+        status: status,
+        running: status == "running",
+        unread: agent.unread?,
+        awaiting_input: status == "awaiting-input",
+        blocked: status == "blocked",
+        run_count: agent.run_count,
+        created_at: agent.created_at&.iso8601,
+        started_at: agent.started_at&.iso8601,
+        finished_at: agent.finished_at&.iso8601,
+        updated_at: agent.last_activity_at&.iso8601,
+        last_exit_code: agent.last_exit_code,
+        last_result: agent.last_result_label,
+        summary: agent.last_summary,
+        archived: agent.archived?,
+        archived_at: agent.archived_at&.iso8601
+      }
+    end
+  end
+end

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -21,6 +21,7 @@ require_relative "domain/project_workspace"
 require_relative "domain/attachment_normalizer"
 require_relative "domain/constants"
 require_relative "domain/agent_attachment_store"
+require_relative "domain/agent_activity_snapshot"
 require_relative "domain/agent_chat_log"
 require_relative "domain/agent_store"
 require_relative "domain/agent_archive_store"
@@ -50,6 +51,11 @@ module HQ
     DEFAULT_HOST = "127.0.0.1"
     DEFAULT_PORT = 7373
     AGENT_PUSH_POLL_INTERVAL = 5
+    ACTIVITY_AGENT_FIELDS = %i[
+      key name project_key template_key scheduled schedule_key agent model reasoning_effort status running unread
+      awaiting_input blocked run_count created_at started_at finished_at updated_at last_exit_code last_result summary
+      archived archived_at
+    ].freeze
     REMOTE_DAEMON_LOG_FILE = File.join(LOGS_DIR, "remote_server_daemon.log")
     RESTART_CACHE_RESET_HEADERS = {
       "Cache-Control" => "no-store, max-age=0, must-revalidate",
@@ -71,7 +77,7 @@ module HQ
     def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, public_url: nil, startup_messages: nil,
                    restart_command: nil, token: HQ.env("REMOTE_TOKEN"), logger: HQ.logger, output: $stdout,
                    daemonize_after_startup: false, daemon_log_path: REMOTE_DAEMON_LOG_FILE, daemonizer: nil,
-                   resource_catalog: nil, resource_snapshot_path: nil)
+                   resource_catalog: nil, resource_snapshot_path: nil, agent_activity_snapshot: nil)
       @host = host.to_s.empty? ? DEFAULT_HOST : host.to_s
       @port = port.to_i.positive? ? port.to_i : DEFAULT_PORT
       @public_url = public_url.to_s
@@ -84,6 +90,7 @@ module HQ
       @daemon_log_path = daemon_log_path.to_s.empty? ? REMOTE_DAEMON_LOG_FILE : daemon_log_path.to_s
       @daemonizer = daemonizer
       @resource_catalog = resource_catalog || RemoteResourceCatalog.new(snapshot_path: resource_snapshot_path)
+      @agent_activity_snapshot = agent_activity_snapshot || AgentActivitySnapshot.new
     end
 
     def start
@@ -172,8 +179,15 @@ module HQ
         return
       end
 
-      if request.method == "GET" && request.path == "/servers/resources"
-        result = ok(@resource_catalog.snapshot)
+      cached_read = if request.method == "GET" && request.path == "/servers/resources"
+                      @resource_catalog.snapshot
+                    elsif request.method == "GET" && request.path == "/servers/activity"
+                      activity_catalog
+                    elsif request.method == "GET" && request.path == "/activity"
+                      @agent_activity_snapshot.snapshot
+                    end
+      if cached_read
+        result = ok(cached_read)
         status = result.fetch(:status)
         write_http(client, status, result.fetch(:body))
         return
@@ -183,7 +197,8 @@ module HQ
         server_url: "http://#{@host}:#{@port}",
         public_url: @public_url,
         auth_required: !@token.empty?,
-        restartable: restartable?
+        restartable: restartable?,
+        agent_activity_snapshot: @agent_activity_snapshot
       )
       result = route(service, request.method, request.path, json_body(request), request)
       status = result.fetch(:status, 200)
@@ -228,7 +243,8 @@ module HQ
       @last_agent_push_poll = now
       service = RemoteService.new(server_url: "http://#{@host}:#{@port}",
                                   public_url: @public_url,
-                                  auth_required: !@token.empty?)
+                                  auth_required: !@token.empty?,
+                                  agent_activity_snapshot: @agent_activity_snapshot)
       service.dispatch_agent_push_notifications!
     rescue StandardError => e
       HQ.logger.warn("Push") { "Agent push notification poll failed: #{e.class} - #{e.message}" }
@@ -241,6 +257,7 @@ module HQ
         broker = RemoteBroker.new(registry: service.registry, server_url: service.server_url)
         @resource_catalog.reconcile(registry: service.registry, server_url: service.server_url)
         return ok(servers: broker.servers) if method == "GET" && parts == ["servers"]
+        return ok(activity_catalog) if method == "GET" && parts == ["servers", "activity"]
         return ok(@resource_catalog.snapshot) if method == "GET" && parts == ["servers", "resources"]
         if method == "POST" && parts == ["servers", "resources", "refresh"]
           tokens = body["tokens"].is_a?(Hash) ? body["tokens"] : {}
@@ -306,6 +323,7 @@ module HQ
           return broker.proxy(parts[1], method, proxy_path, body, request)
         end
       end
+      return ok(service.agent_activity) if method == "GET" && parts == ["activity"]
       return ok(service.resource_snapshot) if method == "GET" && parts == ["resources"]
       return ok(service.metrics_query(request&.query_params || {})) if method == "GET" && parts == ["metrics"]
       return ok(service.metrics_backfill(body)) if method == "POST" && parts == ["metrics", "backfill"]
@@ -446,6 +464,37 @@ module HQ
       end
 
       raise Error.new("Not found", status: 404)
+    end
+
+    def activity_catalog
+      local = @agent_activity_snapshot.snapshot
+      catalog = @resource_catalog.snapshot
+      servers = Array(catalog[:servers]).map do |server|
+        source_agents = if server[:local] && local[:ready]
+                          local[:agents]
+                        else
+                          Array(server[:agents])
+                        end
+        agents = source_agents.map { |agent| agent.slice(*ACTIVITY_AGENT_FIELDS) }
+        {
+          key: server[:key],
+          name: server[:name],
+          icon: server[:icon],
+          local: server[:local],
+          status: server[:status],
+          stale: server[:stale],
+          ready: server[:local] ? local[:ready] : !server[:last_success_at].nil?,
+          agents: agents
+        }
+      end
+      activity = {
+        schema_version: AgentActivitySnapshot::SCHEMA_VERSION,
+        generated_at: Time.now.utc.iso8601,
+        unread_count: servers.sum { |server| server[:agents].count { |agent| agent[:unread] } },
+        servers: servers
+      }
+      activity[:revision] = Digest::SHA256.hexdigest(JSON.generate(activity.except(:generated_at)))
+      activity
     end
 
     def route_ui(path)
@@ -645,7 +694,8 @@ module HQ
         server_url: "http://#{@host}:#{@port}",
         public_url: @public_url,
         auth_required: !@token.empty?,
-        restartable: restartable?
+        restartable: restartable?,
+        agent_activity_snapshot: @agent_activity_snapshot
       )
       @resource_catalog.reconcile(registry: service.registry, server_url: service.server_url)
       @resource_catalog.refresh(
@@ -1339,7 +1389,7 @@ module HQ
 
   class RemoteBroker
     LOOPBACK_PEER_KEY = /\Aloopback-(\d{1,5})\z/
-    RESOURCE_ROOTS = %w[agents projects attachments].freeze
+    RESOURCE_ROOTS = %w[activity agents projects attachments].freeze
 
     LocalServerConfig = Struct.new(:key, :name, :url, keyword_init: true) do
       def resolved_token
@@ -1485,7 +1535,8 @@ module HQ
                    skill_installer: nil,
                    github_client: GitHubAPIClient.new,
                    pull_request_diff_store: PullRequestDiff::Store.new,
-                   pull_request_review_store: PullRequestReview::Store.new)
+                   pull_request_review_store: PullRequestReview::Store.new,
+                   agent_activity_snapshot: AgentActivitySnapshot.new)
       @registry = registry
       @projects = registry.projects.map { |config| Project.new(config) }
       @agent_store = AgentStore.new(@projects)
@@ -1503,6 +1554,7 @@ module HQ
       @github_client = github_client
       @pull_request_diff_store = pull_request_diff_store
       @pull_request_review_store = pull_request_review_store
+      @agent_activity_snapshot = agent_activity_snapshot
       @pull_request_fetch_lock = Mutex.new
       @pull_request_fetches = {}
       @archived_query_lock = Mutex.new
@@ -1608,6 +1660,10 @@ module HQ
       visible_agents(all_agents).map do |agent|
         agent_payload(agent, reference_context: context, relationship_context: relationships)
       end
+    end
+
+    def agent_activity
+      @agent_activity_snapshot.snapshot
     end
 
     def archived_agents(params = {})
@@ -2667,6 +2723,7 @@ module HQ
     def dispatch_agent_push_notifications!
       agents, events = load_agents_with_events
       visible = visible_agents(agents)
+      @agent_activity_snapshot.replace!(visible)
       visible_keys = visible.map(&:key)
       dispatch_agent_push_events(events.select { |event| visible_keys.include?(event.agent_key) }, agents: visible)
     end
@@ -2750,6 +2807,7 @@ module HQ
       )
       save_agent(target)
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"]) && !target.running?
+      @agent_activity_snapshot.upsert!(target)
       { agent: agent_payload(target), conversation: conversation(target.key) }
     end
 
@@ -2772,6 +2830,7 @@ module HQ
       target.add_user_message!(feedback, metadata: { "inquiry_feedback" => true }) unless feedback_embedded || feedback.empty?
       save_agent(target)
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"]) && !target.running?
+      @agent_activity_snapshot.upsert!(target)
       { agent: agent_payload(target), conversation: conversation(target.key) }
     end
 
@@ -2780,12 +2839,14 @@ module HQ
       target = associate_delegation_from_attrs!(target, attrs)
       save_agent(target)
       target = @agent_store.start_agent!(target.key) unless target.running?
+      @agent_activity_snapshot.upsert!(target)
       { agent: agent_payload(target) }
     end
 
     def stop_agent(key)
       target = find_agent!(key)
       target = @agent_store.stop_agent!(target.key)
+      @agent_activity_snapshot.upsert!(target)
       { agent: agent_payload(target) }
     end
 
@@ -2801,6 +2862,7 @@ module HQ
       target = associate_delegation_from_attrs!(target, attrs, agents: current, creating: true)
       save_agents(sort_agents(current))
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"])
+      @agent_activity_snapshot.upsert!(target)
       agent_payload(target)
     end
 
@@ -2834,11 +2896,13 @@ module HQ
       @agent_store.ensure_project_context_prompt!(target, project)
 
       archive_path = @agent_store.archive_agent!(source.key) if archive_source
+      @agent_activity_snapshot.remove!(source.key) if archive_source
       schedule_reconciled = reconcile_archived_schedule_agent(source) if archive_source
       next_agents = current.reject { |agent| agent.key == target.key || (archive_source && agent.key == source.key) }
       next_agents.unshift(target)
       save_agents(sort_agents(next_agents))
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"])
+      @agent_activity_snapshot.upsert!(target)
       HQ.hooks.publish("agent.cloned",
                        agent_key: target.key,
                        source_agent_key: source.key,
@@ -2862,6 +2926,7 @@ module HQ
       raise Error.new("Agent is running", status: 409) if target.running?
 
       archive_path = @agent_store.archive_agent!(target.key)
+      @agent_activity_snapshot.remove!(target.key)
       schedule_reconciled = reconcile_archived_schedule_agent(target)
       {
         archived: true,
@@ -2895,6 +2960,7 @@ module HQ
         end
 
         archive_path = @agent_store.archive_agent!(target.key)
+        @agent_activity_snapshot.remove!(target.key)
         archived << {
           agent_key: target.key,
           archive_path: archive_path,
@@ -3090,6 +3156,7 @@ module HQ
     def load_all_agents
       agents, events = load_agents_with_events
       visible = visible_agents(agents)
+      @agent_activity_snapshot.replace!(visible)
       visible_keys = visible.map(&:key)
       dispatch_agent_push_events(events.select { |event| visible_keys.include?(event.agent_key) }, agents: visible)
       agents
@@ -3233,6 +3300,7 @@ module HQ
 
     def save_agents(agents)
       @agent_store.save(agents)
+      @agent_activity_snapshot.replace!(visible_agents(agents))
     end
 
     def sort_agents(agents)

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -4498,6 +4498,14 @@ select {
   margin-top: 12px;
 }
 
+.summary-attachment-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .summary-attachment-row {
   display: flex;
   align-items: center;
@@ -4512,6 +4520,10 @@ select {
   font: inherit;
   text-align: left;
   text-decoration: none;
+}
+
+.summary-attachment-download {
+  flex: 0 0 auto;
 }
 
 .summary-attachment-row:hover,
@@ -4813,6 +4825,25 @@ select {
 
 .agent-summary-viewer {
   align-self: start;
+}
+
+.agent-summary-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.agent-summary-navigation {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.agent-summary-navigation button:disabled {
+  opacity: .35;
+  cursor: default;
 }
 
 .agent-attachment-body {
@@ -7090,8 +7121,14 @@ body:has(.inquiry-form-full-screen) {
 }
 
 .settings-section-nav {
-  grid-template-columns: repeat(6, minmax(max-content, 1fr));
-  display: grid;
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.settings-section-nav button {
+  flex: 1 0 max-content;
 }
 
 .settings-section-panel {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -205,6 +205,11 @@ const ICONS = {
       <path d="m6 9 6 6 6-6"></path>
     </svg>
   `,
+  chevronUp: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="m18 15-6-6-6 6"></path>
+    </svg>
+  `,
   clockArrowDown: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="M12.338 21.994A10 10 0 1 1 21.925 13.227"></path>
@@ -5463,6 +5468,7 @@ function renderAgentWorkspace(agent, blocks, options = {}) {
 
 function renderAgentSummaryView(agent, options = {}) {
   const summary = agentSummaryDetail(agent, options.summaryId);
+  const navigation = runSummaryNavigation(agent, summary.id);
   const meta = [
     summary.runNumber ? `Run #${summary.runNumber}` : "",
     summary.status || statusLabel(agent),
@@ -5472,7 +5478,13 @@ function renderAgentSummaryView(agent, options = {}) {
     <section class="agent-attachment-shell agent-summary-shell" data-agent-summary-page>
       <section class="attachment-viewer agent-attachment-viewer agent-summary-viewer" aria-label="Summary">
         <div class="agent-attachment-body">
-          <div class="section-label"><strong>Summary</strong><span>${escapeHtml(meta || agent.name || agent.key)}</span></div>
+          <div class="agent-summary-heading">
+            <div class="section-label"><strong>Summary</strong><span>${escapeHtml(meta || agent.name || agent.key)}</span></div>
+            <nav class="agent-summary-navigation" aria-label="Navigate run summaries">
+              ${renderSummaryNavigationButton(agent.key, navigation.previousId, "previous", "chevronUp")}
+              ${renderSummaryNavigationButton(agent.key, navigation.nextId, "next", "chevronDown")}
+            </nav>
+          </div>
           <div class="chip-row"><span>Current session</span><span data-agent-live-status="${escapeAttr(agent.key)}">${statusBadge(statusLabel(agent), statusClass(agent), "chip")}</span></div>
           <div class="summary-outcome-grid">
             ${kv("Outcome", summary.status || statusLabel(agent))}
@@ -5487,6 +5499,14 @@ function renderAgentSummaryView(agent, options = {}) {
     </section>
     ${options.floatingActions === false ? "" : renderAgentFloatingActions(agent, { summary: false })}
   `;
+}
+
+function renderSummaryNavigationButton(agentKey, summaryId, direction, icon) {
+  const label = `${direction === "previous" ? "Previous" : "Next"} summary`;
+  const target = summaryId
+    ? ` data-open-agent-summary="${escapeAttr(agentKey)}" data-open-agent-summary-id="${escapeAttr(summaryId)}"`
+    : " disabled";
+  return `<button class="icon-button ui-button ui-icon-button" type="button"${target} aria-label="${label}" title="${label}">${iconSvg(icon)}</button>`;
 }
 
 function renderAgentSummaryContent(content, menuScope = "agent-summary") {
@@ -5634,7 +5654,12 @@ function renderSummaryAttachmentRow(agent, attachment, index) {
   const href = attachmentHref(current);
   if (href) {
     const external = attachmentKind(current) === "link";
-    return `<a class="summary-attachment-row" href="${escapeAttr(href)}" aria-label="${escapeAttr(label)}" title="${escapeAttr(title || "Attachment")}" ${external ? 'target="_blank" rel="noreferrer"' : ""}>${content}</a>`;
+    const id = attachmentId(current);
+    const download = attachmentDownloadHref(current);
+    const downloadButton = download && id
+      ? `<button class="summary-attachment-download icon-button ui-button ui-icon-button" type="button" data-download-attachment="${escapeAttr(id)}" data-download-filename="${escapeAttr(title || "attachment")}" aria-label="Download ${escapeAttr(title || "attachment")}" title="Download attachment">${iconSvg("download")}</button>`
+      : "";
+    return `<div class="summary-attachment-item"><a class="summary-attachment-row" href="${escapeAttr(href)}" aria-label="${escapeAttr(label)}" title="${escapeAttr(title || "Attachment")}" ${external ? 'target="_blank" rel="noreferrer"' : ""}>${content}</a>${downloadButton}</div>`;
   }
 
   return `<button class="summary-attachment-row missing" type="button" data-missing-summary-attachment aria-label="${escapeAttr(label)}" title="${escapeAttr(title || "Attachment")}">${content}</button>`;
@@ -11696,6 +11721,7 @@ function agentSummaryDetail(agent, summaryId = "") {
   const block = summaryId ? blocks.find((item) => runSummaryId(item) === summaryId) : latestRunSummaryFromAgent(agent);
   if (block) {
     return {
+      id: runSummaryId(block),
       content: runSummaryDetailContent(block),
       status: block.metadata?.status || "",
       runNumber: runSummaryNumber(block),
@@ -11705,6 +11731,7 @@ function agentSummaryDetail(agent, summaryId = "") {
     };
   }
   return {
+    id: "",
     content: agentSummaryText(agent),
     status: "",
     runNumber: null,
@@ -11739,6 +11766,21 @@ function sessionCostSnapshotText(snapshot) {
 
 function runSummaryBlocks(agent) {
   return (state.conversations[agent.key]?.blocks || []).filter((block) => block?.kind === "run_summary");
+}
+
+function runSummaryNavigation(agent, summaryId = "") {
+  const blocks = runSummaryBlocks(agent);
+  if (!blocks.length) return { previousId: "", nextId: "" };
+
+  const currentIndex = summaryId
+    ? blocks.findIndex((block) => runSummaryId(block) === summaryId)
+    : blocks.length - 1;
+  if (currentIndex < 0) return { previousId: "", nextId: "" };
+
+  return {
+    previousId: currentIndex > 0 ? runSummaryId(blocks[currentIndex - 1]) : "",
+    nextId: currentIndex < blocks.length - 1 ? runSummaryId(blocks[currentIndex + 1]) : "",
+  };
 }
 
 function runSummaryId(block) {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -5,6 +5,15 @@ const DEFAULT_REFRESH_INTERVALS = {
   idleMs: 10_000,
   hiddenMs: 30_000,
 };
+const AGENT_ACTIVITY_POLL_INTERVALS = {
+  visibleMs: 3_000,
+  hiddenMs: 30_000,
+};
+const AGENT_ACTIVITY_FIELDS = [
+  "name", "project_key", "template_key", "scheduled", "schedule_key", "agent", "model", "reasoning_effort",
+  "status", "running", "unread", "awaiting_input", "blocked", "run_count", "created_at", "started_at",
+  "finished_at", "updated_at", "last_exit_code", "last_result", "summary", "archived", "archived_at",
+];
 const FORM_POLL_QUIET_MS = 3_000;
 const MAX_CONCURRENT_PR_DIFF_FETCHES = 3;
 const MAX_PRELOADED_PR_DIFFS_PER_AGENT = 6;
@@ -651,6 +660,12 @@ const state = {
   bulkArchiveSelection: new Set(),
   failureCount: 0,
   timer: null,
+  activityTimer: null,
+  activityRequestSequence: 0,
+  activityAppliedSequence: 0,
+  activityRevision: null,
+  activityAgents: new Map(),
+  activityReadyServerKeys: new Set(),
   pollDeferredUntil: 0,
   lastUpdatedAt: null,
   lastShellUpdatedAt: null,
@@ -1157,6 +1172,12 @@ function applyResourceCatalog(data) {
   const servers = Array.isArray(data?.servers) ? data.servers : [];
   state.servers = servers;
   const serverKeys = new Set(servers.map((server) => server.key));
+  state.activityReadyServerKeys.forEach((key) => {
+    if (!serverKeys.has(key)) state.activityReadyServerKeys.delete(key);
+  });
+  state.activityAgents.forEach((agent, key) => {
+    if (!serverKeys.has(agent.server_key)) state.activityAgents.delete(key);
+  });
   Object.keys(state.agentDetails).forEach((key) => {
     const detail = state.agentDetails[key];
     if (detail?.archived && !serverKeys.has(detail.server_key)) delete state.agentDetails[key];
@@ -1165,6 +1186,7 @@ function applyResourceCatalog(data) {
     (Array.isArray(server.agents) ? server.agents : [])
       .map((agent) => normalizeAgentResource(agent, server))
       .filter(Boolean));
+  state.agents = mergeAgentActivity(state.agents);
   state.projects = servers.flatMap((server) =>
     (Array.isArray(server.projects) ? server.projects : [])
       .map((project) => normalizeProjectResource(project, server))
@@ -1194,6 +1216,54 @@ function applyResourceCatalog(data) {
   if (state.filters.server && !servers.some((server) => server.key === state.filters.server)) {
     state.filters.server = "";
   }
+}
+
+function mergeAgentActivity(agents) {
+  if (!state.activityReadyServerKeys.size) return agents;
+
+  const merged = agents
+    .filter((agent) => !state.activityReadyServerKeys.has(agent.server_key) || state.activityAgents.has(agent.key))
+    .map((agent) => ({ ...agent, ...(state.activityAgents.get(agent.key) || {}) }));
+  const mergedKeys = new Set(merged.map((agent) => agent.key));
+  state.activityAgents.forEach((agent, key) => {
+    if (!mergedKeys.has(key)) merged.push(agent);
+  });
+  return merged;
+}
+
+function activityFields(agent) {
+  return AGENT_ACTIVITY_FIELDS.reduce((result, field) => {
+    if (Object.hasOwn(agent || {}, field)) result[field] = agent[field];
+    return result;
+  }, {});
+}
+
+function applyAgentActivity(data, requestSequence) {
+  if (requestSequence < state.activityAppliedSequence) return false;
+  state.activityAppliedSequence = requestSequence;
+  if (!data || !Array.isArray(data.servers)) return false;
+  if (data.revision && data.revision === state.activityRevision) return false;
+
+  const activityAgents = new Map();
+  const readyServerKeys = new Set();
+  data.servers.forEach((server) => {
+    if (!server?.ready) return;
+    readyServerKeys.add(server.key);
+    (Array.isArray(server.agents) ? server.agents : []).forEach((agent) => {
+      const normalized = normalizeAgentResource(agent, server);
+      if (normalized?.key) activityAgents.set(normalized.key, normalized);
+    });
+  });
+  state.activityRevision = data.revision || null;
+  state.activityAgents = activityAgents;
+  state.activityReadyServerKeys = readyServerKeys;
+  state.agents = mergeAgentActivity(state.agents);
+  Object.keys(state.agentDetails).forEach((key) => {
+    const activity = activityAgents.get(key);
+    if (activity) Object.assign(state.agentDetails[key], activityFields(activity));
+  });
+  syncUnreadAlert();
+  return true;
 }
 
 async function loadResourceCatalog() {
@@ -1709,6 +1779,59 @@ function schedule(ms = pollDelay()) {
   if (fullScreenEditorOpen()) return;
   const quietRemaining = formPollQuietRemaining();
   state.timer = setTimeout(refresh, Math.max(ms, quietRemaining));
+}
+
+function scheduleAgentActivity(ms = document.hidden
+  ? AGENT_ACTIVITY_POLL_INTERVALS.hiddenMs
+  : AGENT_ACTIVITY_POLL_INTERVALS.visibleMs) {
+  clearTimeout(state.activityTimer);
+  state.activityTimer = setTimeout(pollAgentActivity, ms);
+}
+
+async function pollAgentActivity() {
+  clearTimeout(state.activityTimer);
+  state.activityTimer = null;
+  const requestSequence = ++state.activityRequestSequence;
+  try {
+    const activity = await loadAgentActivity();
+    applyAgentActivity(activity, requestSequence);
+  } catch (_error) {
+    // The full refresh owns connection state; activity polling remains silent.
+  } finally {
+    scheduleAgentActivity();
+  }
+}
+
+async function loadAgentActivity() {
+  const activity = await brokerGet("/servers/activity");
+  const servers = Array.isArray(activity.servers) ? activity.servers : [];
+  const peerResults = await Promise.all(servers.map(async (server) => {
+    if (server.local) return null;
+    const token = remoteServerToken(server.key);
+    const headers = token ? { "X-Tycho-Remote-Server-Token": token } : {};
+    try {
+      const peer = await brokerGetWithHeaders(`/servers/${encodeURIComponent(server.key)}/activity`, headers);
+      return {
+        serverKey: server.key,
+        revision: peer.revision,
+        ready: peer.ready,
+        agents: peer.agents,
+      };
+    } catch (_error) {
+      return null;
+    }
+  }));
+  const peersByKey = new Map(peerResults.filter(Boolean).map((peer) => [peer.serverKey, peer]));
+  const mergedServers = servers.map((server) => {
+    const peer = peersByKey.get(server.key);
+    return peer ? { ...server, ready: peer.ready, agents: peer.agents } : server;
+  });
+  const peerRevisions = peerResults.filter(Boolean).map((peer) => `${peer.serverKey}:${peer.revision || ""}`);
+  return {
+    ...activity,
+    revision: [activity.revision || "", ...peerRevisions].join(":"),
+    servers: mergedServers,
+  };
 }
 
 function fullScreenEditorOpen() {
@@ -11355,10 +11478,16 @@ function upsertAgent(agent) {
   if (index >= 0) state.agents[index] = { ...state.agents[index], ...agent };
   else state.agents.unshift(agent);
   state.agentDetails[agent.key] = agent;
+  const activity = state.activityAgents.get(agent.key) || {};
+  state.activityAgents.set(agent.key, { ...activity, ...activityFields(agent), key: agent.key, server_key: agent.server_key });
+  if (agent.server_key) state.activityReadyServerKeys.add(agent.server_key);
+  state.activityRevision = null;
 }
 
 function removeAgent(key) {
   state.agents = state.agents.filter((agent) => agent.key !== key);
+  state.activityAgents.delete(key);
+  state.activityRevision = null;
   delete state.agentDetails[key];
 }
 
@@ -15611,8 +15740,10 @@ document.addEventListener("visibilitychange", () => {
     state.lastScrollY = window.scrollY;
     showNav();
     refresh({ force: true, preserveFocusedWorkspace: true });
+    pollAgentActivity();
   } else {
     flushComposerDraftSaves();
+    scheduleAgentActivity();
   }
 });
 
@@ -15623,6 +15754,7 @@ window.visualViewport?.addEventListener("scroll", syncFullScreenComposerViewport
 els.tokenInput.value = token();
 render();
 refresh({ force: true });
+pollAgentActivity();
 
 (function setupPullToRefresh() {
   const indicator = document.getElementById("pull-refresh");

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/test/agent_activity_snapshot_test.rb
+++ b/test/agent_activity_snapshot_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "../lib/hq/domain/agent_activity_snapshot"
+
+module AgentActivitySnapshotTest
+  module_function
+
+  FakeAgent = Struct.new(
+    :key, :name, :project_key, :template_key, :schedule_key, :agent, :model, :reasoning_effort, :status,
+    :unread, :run_count, :created_at, :started_at, :finished_at, :last_activity_at, :last_exit_code,
+    :last_result_label, :last_summary,
+    keyword_init: true
+  ) do
+    def display_name = name
+    def scheduled? = !schedule_key.nil?
+    def unread? = unread
+    def archived? = false
+    def archived_at = nil
+  end
+
+  def run!
+    snapshot = HQ::AgentActivitySnapshot.new
+    assert(snapshot.snapshot[:ready] == false, "expected a new activity snapshot to be unready")
+
+    agent = fake_agent(status: "running", unread: false)
+    assert(snapshot.replace!([agent]), "expected the first replacement to publish activity")
+    running = snapshot.snapshot
+    assert(running[:revision] == 1, "expected the first activity revision")
+    assert(running.dig(:agents, 0, :running), "expected running activity")
+    assert(!snapshot.replace!([agent]), "expected identical activity not to advance the revision")
+
+    finished = fake_agent(status: "awaiting-input", unread: true)
+    assert(snapshot.upsert!(finished), "expected changed activity to publish")
+    awaiting = snapshot.snapshot
+    assert(awaiting[:revision] == 2 && awaiting[:unread_count] == 1,
+           "expected unread activity to advance the revision")
+    assert(awaiting.dig(:agents, 0, :awaiting_input), "expected inquiry activity")
+
+    assert(snapshot.remove!(agent.key), "expected activity removal")
+    assert(snapshot.snapshot[:agents].empty?, "expected the removed agent to leave the snapshot")
+    puts "agent_activity_snapshot_test: ok"
+  end
+
+  def fake_agent(status:, unread:)
+    now = Time.now
+    FakeAgent.new(
+      key: "agent-1",
+      name: "Agent one",
+      project_key: "web",
+      template_key: "custom",
+      agent: "codex",
+      model: "gpt-5",
+      reasoning_effort: "medium",
+      status: status,
+      unread: unread,
+      run_count: 1,
+      created_at: now,
+      started_at: now,
+      finished_at: status == "running" ? nil : now,
+      last_activity_at: now,
+      last_exit_code: status == "running" ? nil : 0,
+      last_result_label: status == "awaiting-input" ? "awaiting input" : nil,
+      last_summary: "Waiting"
+    )
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+end
+
+AgentActivitySnapshotTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4115,6 +4115,9 @@ module RemoteServerTest
            "expected Conversation summary attachments to open as a menu")
     assert(css[:body].include?(".summary-attachment-list-full"),
            "expected detailed Summary pages to render full attachment lists")
+    assert(css[:body].include?(".summary-attachment-item") &&
+           css[:body].include?(".summary-attachment-download"),
+           "expected Summary attachments to pair detail links with quick download actions")
     assert(css[:body].include?(".summary-attachment-row"),
            "expected Summary attachments to render as block rows")
     assert(css[:body].include?(".attachment-text-viewer"), "expected Attachment detail to style plain text")
@@ -4774,7 +4777,10 @@ module RemoteServerTest
     assert(js[:body].include?('class="settings-section-nav ui-section-nav"') &&
            js[:body].include?('class="settings-section-panel ui-section-panel"') &&
            js[:body].include?('aria-current=') &&
-           js[:body].include?("function syncSettingsSectionNav"),
+           js[:body].include?("function syncSettingsSectionNav") &&
+           css[:body].include?(".settings-section-nav-shell") &&
+           css[:body].include?("flex-wrap: nowrap") &&
+           css[:body].include?("overflow-x: auto"),
            "expected Settings to keep a sticky in-page section navigator with active-section feedback")
     assert(response[:body].include?("ui-detail-header__back") &&
            response[:body].include?("ui-detail-header__identity") &&
@@ -5261,6 +5267,10 @@ module RemoteServerTest
            "expected Agent summary shortcut to navigate to the focused Summary page")
     assert(js[:body].include?("function renderAgentSummaryView"),
            "expected Agent summary to render as its own view")
+    assert(js[:body].include?("function runSummaryNavigation") &&
+           js[:body].include?('aria-label="${label}"') &&
+           js[:body].include?('title="${label}"'),
+           "expected focused Summary pages to navigate between run summaries")
     assert(!js[:body].include?("function toggleAgentSummary"),
            "expected Summary to use route navigation instead of a dock toggle")
     assert(js[:body].include?("function renderAgentSummaryToggle"),
@@ -5705,6 +5715,9 @@ module RemoteServerTest
            "expected Summary attachment menus to close on outside clicks")
     assert(js[:body].include?("renderSummaryAttachmentList"),
            "expected detailed Summary pages to render attachment list blocks")
+    assert(js[:body].include?('class="summary-attachment-download icon-button ui-button ui-icon-button"') &&
+           js[:body].include?('data-download-filename="${escapeAttr(title || "attachment")}"'),
+           "expected detailed Summary pages to download files without replacing their detail links")
     assert(js[:body].include?('kv("Est. Cost", sessionCostSnapshotText(summary.costSnapshot))'),
            "expected detailed Summary pages to render the finalized session-cost snapshot")
     assert(!js[:body].include?('kv("Completed", timeShort(summary.createdAt'),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -22,6 +22,7 @@ module RemoteServerTest
     assert_remote_agent_bulk_archive
     assert_remote_agent_clone_archives_source_with_editable_name
     assert_remote_agent_payload_has_revision
+    assert_remote_agent_activity_snapshot
     assert_remote_agent_payload_has_cost_snapshot
     assert_remote_metrics_query_and_backfill_routes
     assert_remote_inquiry_payload_has_stable_id_and_guarded_answer
@@ -164,6 +165,33 @@ module RemoteServerTest
              second_page.dig(:pagination, :next_page).nil? &&
              first_page.dig(:agents, 0, :key) != second_page.dig(:agents, 0, :key),
              "expected stable multi-page archive ordering")
+    end
+  end
+
+  def assert_remote_agent_activity_snapshot
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace)
+      snapshot = HQ::AgentActivitySnapshot.new
+      service = HQ::RemoteService.new(registry: registry, agent_activity_snapshot: snapshot)
+      agent = service.create_agent(
+        "project_key" => "web", "name" => "Activity agent", "prompt" => "Observe", "agent" => "codex"
+      )
+      stored = HQ::AgentStore.new([]).load.find { |candidate| candidate.key == agent[:key] }
+      stored.mark_unread!
+      HQ::AgentStore.new([]).save([stored])
+      service.agents
+
+      server = HQ::RemoteServer.new(agent_activity_snapshot: snapshot)
+      response = server.send(:route, service, "GET", "/servers/activity", {}, nil)
+      activity = response.fetch(:body)
+      local = activity.fetch(:servers).find { |entry| entry[:key] == "local" }
+      assert(activity[:unread_count] == 1, "expected aggregate activity unread count")
+      assert(local[:ready] && local.dig(:agents, 0, :name) == "Activity agent",
+             "expected the activity endpoint to expose the shared local snapshot")
+      assert(local.dig(:agents, 0, :unread), "expected activity to include unread state")
+      assert(!local.dig(:agents, 0).key?(:prompt), "expected activity to omit full agent detail")
     end
   end
 
@@ -3546,7 +3574,12 @@ module RemoteServerTest
       write_project_workspace(workspace)
       registry = registry_for_project(dir, workspace)
       notifier = RecordingPushNotifier.new
-      service = HQ::RemoteService.new(registry: registry, web_push_notifier: notifier)
+      activity_snapshot = HQ::AgentActivitySnapshot.new
+      service = HQ::RemoteService.new(
+        registry: registry,
+        web_push_notifier: notifier,
+        agent_activity_snapshot: activity_snapshot
+      )
       started_at = Time.now - 60
 
       input_agent = stale_running_agent(
@@ -3590,6 +3623,9 @@ module RemoteServerTest
 
       result = service.dispatch_agent_push_notifications!
       assert(result[:events] == 2, "expected two agent push events")
+      input_activity = activity_snapshot.snapshot[:agents].find { |agent| agent[:key] == "web-agent-1" }
+      assert(input_activity[:awaiting_input] && input_activity[:unread],
+             "expected notification reconciliation to publish finalized inquiry activity")
       assert(notifier.payloads.length == 2, "expected two push payloads")
       assert(notifier.payloads.any? { |payload| payload[:title] == "Agent requires response" },
              "expected requires-response notification")
@@ -4379,6 +4415,16 @@ module RemoteServerTest
            "expected create-only agent submission to live behind a secondary option")
     assert(js[:content_type].include?("javascript"), "expected /ui.js to return JavaScript")
     assert(js[:body].include?("DEFAULT_REFRESH_INTERVALS"), "expected UI JavaScript to define refresh defaults")
+    assert(js[:body].include?("AGENT_ACTIVITY_POLL_INTERVALS") &&
+           js[:body].include?('brokerGet("/servers/activity")') &&
+           js[:body].include?("function pollAgentActivity") &&
+           js[:body].include?("function loadAgentActivity") &&
+           js[:body].include?('`/servers/${encodeURIComponent(server.key)}/activity`'),
+           "expected the logo agent activity to poll a dedicated lightweight endpoint")
+    assert(js[:body].include?("function mergeAgentActivity") &&
+           js[:body].include?("state.activityAppliedSequence") &&
+           js[:body].include?("syncUnreadAlert();"),
+           "expected activity polling to reject stale responses and update the logo without a page render")
     assert(js[:body].include?("window.TychoRemoteHelpers"),
            "expected the main Remote UI script to use the helper namespace")
     assert(js[:body].include?('updateViaCache: "none"'),
@@ -5821,6 +5867,9 @@ module RemoteServerTest
            js[:body].scan("state.fullScreenComposerKeys.delete(key);\n  schedule();").length >= 1 &&
            js[:body].scan("state.fullScreenInquiryKeys.delete(key);\n  schedule();").length >= 1,
            "expected full-screen Conversation and inquiry forms to pause automatic polling")
+    activity_poll = js[:body][/async function pollAgentActivity\(\).*?^}/m]
+    assert(activity_poll && !activity_poll.include?("fullScreenEditorOpen"),
+           "expected logo activity polling to continue while full-screen editors are open")
     assert(js[:body].include?('class="card agent-summary-card') &&
            js[:body].include?("serverIdentityBadge(agent, { compactHealth: true })") &&
            js[:body].include?('class="agent-card-status"') &&


### PR DESCRIPTION
## Summary

- prepare Tycho v0.10.0 with complete release notes and updated project status
- keep the Settings section menu sticky in one horizontally scrollable row
- add previous/next run-summary navigation and quick Summary attachment downloads
- document the compact activity endpoints and clean up stale HQ contributor branding
- update Remote UI smoke fixtures for the activity snapshot introduced by `9109f77`

## Verification

- `mise exec ruby@3.4.7 -- bin/test`
- `TYCHO_REMOTE_UI_CAPTURE_DIR=/tmp/tycho-v010-smoke.A6lef8 mise exec ruby@3.4.7 -- bin/remote-ui-smoke`
- `node --check lib/hq/remote_ui/assets/app.js`
- `git diff --check`
- verified `HQ::VERSION` and the gemspec both resolve to `0.10.0`

Browser smoke result:

```text
PR rendering (5,000 lines): full 99.8ms sync / selection 16.4ms sync / first poll 46.9ms sync / steady poll 20.3ms sync
remote-ui-smoke: ok
```

## Notes

- Remote UI behavior and browser assets change; a running `tycho serve` process must restart after upgrade to load the coherent asset snapshot.
- No config, schema, dependency, TUI input, or harness command contract changes are introduced by this release-prep PR.
- Local `main` commit `9109f77` is included in this branch and receives its first remote CI validation here.
