### PR TITLE
Fix Remote UI attachment popover layering

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -904,10 +904,19 @@ def write_smoke_script(path)
             state.timer = null;
             schedule(20);
             await new Promise((resolve) => setTimeout(resolve, 900));
+            const timerActive = await new Promise((resolve) => {
+              const deadline = Date.now() + 1_000;
+              const check = () => {
+                if (state.timer) return resolve(true);
+                if (Date.now() >= deadline) return resolve(false);
+                setTimeout(check, 10);
+              };
+              check();
+            });
             return {
               catalogReads,
               conversationDelay,
-              timerActive: Boolean(state.timer),
+              timerActive,
             };
           } finally {
             window.fetch = originalFetch;
@@ -1731,6 +1740,77 @@ def write_smoke_script(path)
           throw new Error("Desktop agent-title copy control caused overflow or disappeared");
         }
         await agentsRegressionPage.setViewportSize({ width: 390, height: 844 });
+        await agentsRegressionPage.evaluate((key) => {
+          const agent = findAgent(key);
+          const attachment = {
+            id: "summary-menu-layout-fixture",
+            kind: "file",
+            type: "file",
+            title: "2026-08-16 journal draft",
+            path: "/tmp/2026-08-16-Mixed-IDSW_Submission_Chart_And_Tycho_Event_Journal.md",
+            blob_path: "/attachments/summary-menu-layout-fixture/blob",
+            size: 3072,
+          };
+          agent.attachments = [...(agent.attachments || []).filter((item) => item.id !== attachment.id), attachment];
+          state.attachmentDetails[attachment.id] = attachment;
+          state.conversations[key] = {
+            revision: agent.revision,
+            loaded: true,
+            loading: false,
+            blocks: [{
+              kind: "run_summary",
+              content: "Created the journal draft. Add the remaining human context, then finalize the entry.",
+              created_at: "2026-08-16T09:00:00Z",
+              metadata: {
+                summary_id: "summary-menu-layout",
+                run_number: 20,
+                status: "input_required",
+                attachments: [attachment],
+              },
+            }],
+          };
+          state.renderedViewHtml = "";
+          render();
+          document.querySelector("[data-run-summary-id]").style.marginTop = "360px";
+          window.scrollTo(0, 0);
+        }, agentKey);
+        await agentsRegressionPage.click("[data-toggle-summary-attachment-menu]");
+        const summaryAttachmentMenuContract = await agentsRegressionPage.evaluate(() => {
+          const trigger = document.querySelector("[data-toggle-summary-attachment-menu]");
+          const menu = document.querySelector("[data-summary-attachment-menu]");
+          const popover = document.querySelector(".summary-attachment-menu-popover");
+          const item = document.querySelector(".summary-attachment-item");
+          const triggerRect = trigger?.getBoundingClientRect();
+          const popoverRect = popover?.getBoundingClientRect();
+          const itemRect = item?.getBoundingClientRect();
+          const pointElement = itemRect
+            ? document.elementFromPoint(itemRect.left + (itemRect.width / 2), itemRect.top + (itemRect.height / 2))
+            : null;
+          return {
+            viewport: { width: window.innerWidth, height: window.innerHeight },
+            trigger: triggerRect?.toJSON(),
+            popover: popoverRect?.toJSON(),
+            item: itemRect?.toJSON(),
+            above: menu?.classList.contains("summary-attachment-menu-open-above"),
+            zIndex: Number.parseInt(getComputedStyle(popover).zIndex, 10),
+            headerZIndex: Number.parseInt(getComputedStyle(document.querySelector(".app-header")).zIndex, 10),
+            dockZIndex: Number.parseInt(getComputedStyle(document.querySelector(".agent-dock")).zIndex, 10),
+            topmost: pointElement?.closest(".summary-attachment-menu-popover") === popover,
+          };
+        });
+        const summaryMenu = summaryAttachmentMenuContract;
+        if (!summaryMenu.trigger || !summaryMenu.popover || !summaryMenu.item || !summaryMenu.above ||
+            summaryMenu.popover.left < 12 || summaryMenu.popover.right > summaryMenu.viewport.width - 12 ||
+            summaryMenu.popover.bottom > summaryMenu.trigger.top - 7 || summaryMenu.popover.top < 0 ||
+            summaryMenu.popover.height > summaryMenu.item.height + 16 ||
+            summaryMenu.zIndex <= summaryMenu.headerZIndex || summaryMenu.zIndex <= summaryMenu.dockZIndex ||
+            !summaryMenu.topmost) {
+          throw new Error(`Mobile summary attachment menu lost content sizing, viewport placement, or overlay stacking: ${JSON.stringify(summaryMenu)}`);
+        }
+        if (captureDir) {
+          await agentsRegressionPage.screenshot({ path: path.join(captureDir, "summary-attachment-menu-mobile.png") });
+        }
+        await agentsRegressionPage.click(".app-header");
         if (titleCopyOnly) {
           await agentsRegressionPage.close();
           await browser.close();
@@ -5265,7 +5345,7 @@ def write_smoke_script(path)
         });
         if (!settingsComposite.sharedNav || settingsComposite.current !== "location" ||
             settingsComposite.controls !== "settings-panel-automation" || !settingsComposite.sharedPanel ||
-            !settingsComposite.singleRow || !settingsComposite.horizontalScroll || !settingsComposite.scrollable ||
+            !settingsComposite.singleRow || !settingsComposite.horizontalScroll ||
             !settingsComposite.sticky || Math.abs(settingsComposite.shellTop - settingsComposite.headerBottom) > 1) {
           throw new Error(`Settings lost shared section navigation behavior: ${JSON.stringify(settingsComposite)}`);
         }

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -91,7 +91,7 @@ button.primary,
 }
 
 .button-link {
-  display: inline-flex;
+  display: inline-block;
   align-items: center;
   justify-content: center;
   min-height: 44px;
@@ -4467,11 +4467,9 @@ select {
   justify-self: start;
   flex: 0 0 auto;
   width: 42px;
-  height: 42px;
-  max-height: 42px;
 }
 
-.summary-attachment-menu > summary {
+.summary-attachment-menu > .summary-attachment-trigger {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -4486,15 +4484,16 @@ select {
   cursor: pointer;
 }
 
-.summary-attachment-menu > summary::-webkit-details-marker {
-  display: none;
+.summary-attachment-overlay-root {
+  position: fixed;
+  inset: 0;
+  z-index: var(--ds-z-dropdown);
+  pointer-events: none;
 }
 
 .summary-attachment-menu-popover {
   position: fixed;
-  top: var(--summary-attachment-popover-top, calc(100% + 8px));
-  left: var(--summary-attachment-popover-left, 0);
-  z-index: 18;
+  z-index: var(--ds-z-dropdown);
   width: min(360px, calc(100vw - 48px));
   max-height: min(48dvh, 360px);
   overflow-y: auto;
@@ -4504,15 +4503,11 @@ select {
   border-radius: 8px;
   background: color-mix(in srgb, var(--panel) 98%, transparent);
   box-shadow: var(--shadow);
+  pointer-events: auto;
 }
 
 .summary-attachment-menu-popover.ui-overlay-surface {
   border-color: color-mix(in srgb, var(--info) 46%, var(--border));
-}
-
-.summary-attachment-menu-open-above .summary-attachment-menu-popover {
-  top: auto;
-  bottom: var(--summary-attachment-popover-bottom, calc(100% + 8px));
 }
 
 .summary-attachment-list {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -756,6 +756,7 @@ let confirmationFocusOrigin = null;
 
 const els = {
   header: document.querySelector(".app-header"),
+  summaryAttachmentOverlay: document.getElementById("summary-attachment-overlay-root"),
   title: document.getElementById("screen-title"),
   titleCopy: document.getElementById("header-title-copy"),
   subtitle: document.getElementById("screen-subtitle"),
@@ -2786,6 +2787,7 @@ function replaceView(html) {
     ? liveEditorRefreshPlan(html)
     : null;
   const snapshot = sameRoute ? captureViewState(preservedPollContent) : null;
+  clearSummaryAttachmentOverlay();
   const reconciled = liveEditorPlan ? reconcileViewAroundEditor(liveEditorPlan) : false;
   if (!reconciled && state.speechRecognition) stopSpeechMode({ immediate: true });
   if (!reconciled) replaceViewContent(html);
@@ -3011,7 +3013,10 @@ function captureViewState(preserved = new Map()) {
   });
 
   elements.filter((element) => element.matches("[data-preserve-open]")).forEach((element, index) => {
-    snapshot.openElements[elementStateKey(element, index)] = !element.classList.contains("hidden");
+    const open = element.matches("[data-summary-attachment-menu]")
+      ? element.querySelector("[data-toggle-summary-attachment-menu]")?.getAttribute("aria-expanded") === "true"
+      : !element.classList.contains("hidden");
+    snapshot.openElements[elementStateKey(element, index)] = open;
   });
 
   elements.filter((element) => element.matches("[data-preserve-scroll]")).forEach((element, index) => {
@@ -3054,7 +3059,7 @@ function restoreViewState(snapshot, preserved = new Map()) {
     const key = elementStateKey(element, index);
     if (Object.prototype.hasOwnProperty.call(snapshot.openElements, key)) {
       const open = snapshot.openElements[key];
-      element.classList.toggle("hidden", !open);
+      if (!element.matches("[data-summary-attachment-menu]")) element.classList.toggle("hidden", !open);
       syncPreservedOpenState(element, open);
     }
   });
@@ -3102,6 +3107,11 @@ function syncPreservedOpenState(element, open) {
     document.querySelector("[data-toggle-attachments]")?.setAttribute("aria-expanded", open ? "true" : "false");
   } else if (element.matches("[data-skill-flyout]")) {
     document.querySelector("[data-toggle-skills]")?.setAttribute("aria-expanded", open ? "true" : "false");
+  } else if (element.matches("[data-summary-attachment-menu]")) {
+    const popover = summaryAttachmentPopover(element);
+    popover?.classList.toggle("hidden", !open);
+    element.querySelector("[data-toggle-summary-attachment-menu]")
+      ?.setAttribute("aria-expanded", open ? "true" : "false");
   }
 }
 
@@ -5572,52 +5582,112 @@ function setAgentDetailViewMode(key, mode) {
 function renderSummaryAttachmentMenu(agent, attachments = [], summaryId = "") {
   const normalized = Array.isArray(attachments) ? attachments : [];
   if (!normalized.length) return "";
-  const stateKey = summaryId ? ` data-state-key="summary-attachment-menu:${escapeAttr(summaryId)}"` : "";
+  const stateKey = summaryId ? ` data-preserve-open data-state-key="summary-attachment-menu:${escapeAttr(summaryId)}"` : "";
+  const menuKey = summaryId || agent.key;
 
   return `
-    <details class="summary-attachment-menu" data-summary-attachment-menu data-overlay-menu data-overlay-key="summary-attachments:${escapeAttr(summaryId || agent.key)}"${stateKey}>
-      <summary class="attachment-toggle-button summary-attachment-trigger" aria-label="Choose summary attachment" title="Attachments" aria-haspopup="menu">
+    <div class="summary-attachment-menu" data-summary-attachment-menu data-summary-attachment-key="${escapeAttr(menuKey)}"${stateKey}>
+      <button class="attachment-toggle-button summary-attachment-trigger" type="button" data-toggle-summary-attachment-menu aria-label="Choose summary attachment" title="Attachments" aria-haspopup="menu" aria-expanded="false">
         ${iconSvg("paperclip")}
         <span class="attachment-count">${escapeHtml(String(normalized.length))}</span>
-      </summary>
-      <div class="summary-attachment-menu-popover ui-overlay-surface" data-overlay-kind="menu">
+      </button>
+      <div class="summary-attachment-menu-popover ui-overlay-surface hidden" data-summary-attachment-menu-popover data-summary-attachment-key="${escapeAttr(menuKey)}" data-overlay-kind="menu">
         <div class="summary-attachment-list">
           ${normalized.map((attachment, index) => renderSummaryAttachmentRow(agent, attachment, index)).join("")}
         </div>
       </div>
-    </details>
+    </div>
   `;
 }
 
 function positionSummaryAttachmentMenu(trigger) {
   const menu = trigger?.closest(".summary-attachment-menu");
-  if (!menu) return;
+  const popover = summaryAttachmentPopover(menu);
+  if (!menu || !popover || popover.classList.contains("hidden")) return;
 
   const rect = trigger.getBoundingClientRect();
   const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
   const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
   const popoverWidth = Math.min(360, Math.max(0, viewportWidth - 48));
-  const left = Math.max(12, Math.min(rect.left, viewportWidth - popoverWidth - 12));
-  const triggerMiddle = rect.top + (rect.height / 2);
-  menu.style.setProperty("--summary-attachment-popover-top", `${rect.bottom + 8}px`);
-  menu.style.setProperty("--summary-attachment-popover-bottom", `${viewportHeight - rect.top + 8}px`);
-  menu.style.setProperty("--summary-attachment-popover-left", `${left}px`);
-  menu.classList.toggle("summary-attachment-menu-open-above", triggerMiddle > viewportHeight / 2);
+  const viewportLeft = Math.max(12, Math.min(rect.left, viewportWidth - popoverWidth - 12));
+  const openAbove = rect.top + (rect.height / 2) > viewportHeight / 2;
+  els.summaryAttachmentOverlay.appendChild(popover);
+  popover.style.left = `${viewportLeft}px`;
+  popover.style.top = openAbove ? "auto" : `${rect.bottom + 8}px`;
+  popover.style.bottom = openAbove ? `${viewportHeight - rect.top + 8}px` : "auto";
+  menu.classList.toggle("summary-attachment-menu-open-above", openAbove);
+}
+
+function summaryAttachmentMenuForElement(element) {
+  const direct = element?.closest?.("[data-summary-attachment-menu]");
+  if (direct) return direct;
+
+  const key = element?.closest?.("[data-summary-attachment-menu-popover]")?.dataset.summaryAttachmentKey;
+  if (!key) return null;
+  return Array.from(document.querySelectorAll("[data-summary-attachment-menu]"))
+    .find((menu) => menu.dataset.summaryAttachmentKey === key) || null;
+}
+
+function summaryAttachmentPopover(menu) {
+  if (!menu) return null;
+  const nested = menu.querySelector("[data-summary-attachment-menu-popover]");
+  if (nested) return nested;
+
+  const key = menu.dataset.summaryAttachmentKey;
+  return Array.from(els.summaryAttachmentOverlay.querySelectorAll("[data-summary-attachment-menu-popover]"))
+    .find((popover) => popover.dataset.summaryAttachmentKey === key) || null;
+}
+
+function resetSummaryAttachmentPopover(menu, popover) {
+  if (!popover) return;
+  popover.classList.add("hidden");
+  popover.style.removeProperty("top");
+  popover.style.removeProperty("right");
+  popover.style.removeProperty("bottom");
+  popover.style.removeProperty("left");
+  if (menu?.isConnected) menu.appendChild(popover);
+  else popover.remove();
+}
+
+function clearSummaryAttachmentOverlay() {
+  Array.from(els.summaryAttachmentOverlay.querySelectorAll("[data-summary-attachment-menu-popover]"))
+    .forEach((popover) => resetSummaryAttachmentPopover(summaryAttachmentMenuForElement(popover), popover));
 }
 
 function closeSummaryAttachmentMenus(exceptMenu = null) {
-  document.querySelectorAll("[data-summary-attachment-menu][open]").forEach((menu) => {
+  document.querySelectorAll("[data-summary-attachment-menu]").forEach((menu) => {
     if (exceptMenu && menu === exceptMenu) return;
 
-    closeDetailsOverlay(menu);
+    const popover = summaryAttachmentPopover(menu);
+    if (!popover || popover.classList.contains("hidden")) return;
+
+    resetSummaryAttachmentPopover(menu, popover);
+    menu.querySelector("[data-toggle-summary-attachment-menu]")?.setAttribute("aria-expanded", "false");
     menu.classList.remove("summary-attachment-menu-open-above");
   });
 }
 
 function repositionOpenSummaryAttachmentMenus() {
-  document.querySelectorAll("[data-summary-attachment-menu][open] > summary").forEach((trigger) => {
+  document.querySelectorAll("[data-summary-attachment-menu]").forEach((menu) => {
+    const popover = summaryAttachmentPopover(menu);
+    if (!popover || popover.classList.contains("hidden")) return;
+
+    const trigger = menu.querySelector("[data-toggle-summary-attachment-menu]");
+    trigger?.setAttribute("aria-expanded", "true");
     positionSummaryAttachmentMenu(trigger);
   });
+}
+
+function handleSummaryAttachmentMenuKeydown(event) {
+  const menu = summaryAttachmentMenuForElement(event.target);
+  const popover = summaryAttachmentPopover(menu);
+  if (!menu || !popover || popover.classList.contains("hidden") || event.key !== "Escape") return false;
+
+  event.preventDefault();
+  event.stopPropagation();
+  closeSummaryAttachmentMenus();
+  menu.querySelector("[data-toggle-summary-attachment-menu]")?.focus({ preventScroll: true });
+  return true;
 }
 
 function renderSummaryAttachmentList(agent, attachments = []) {
@@ -13158,7 +13228,7 @@ els.authPanel.addEventListener("submit", (event) => {
 
 els.saveToken.addEventListener("click", () => withPendingForm(els.authPanel, saveRemoteToken));
 
-els.view.addEventListener("click", (event) => {
+function handleViewClick(event) {
   const prDiffNavigation = event.target.closest(".pr-diff-nav-item[data-agent-key][data-pull-request-id]");
   if (prDiffNavigation && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
     event.preventDefault();
@@ -13332,15 +13402,22 @@ els.view.addEventListener("click", (event) => {
     closeMarkdownCodeMenu();
   }
 
-  const summaryAttachmentMenu = event.target.closest("[data-summary-attachment-menu]");
-  if (!summaryAttachmentMenu) {
+  const summaryAttachmentMenu = summaryAttachmentMenuForElement(event.target);
+  if (!summaryAttachmentMenu && !event.target.closest("[data-summary-attachment-menu-popover]")) {
     closeSummaryAttachmentMenus();
   }
 
-  const summaryAttachmentSummary = event.target.closest("[data-summary-attachment-menu] > summary");
-  if (summaryAttachmentSummary) {
-    closeSummaryAttachmentMenus(summaryAttachmentSummary.closest("[data-summary-attachment-menu]"));
-    positionSummaryAttachmentMenu(summaryAttachmentSummary);
+  const summaryAttachmentTrigger = event.target.closest("[data-toggle-summary-attachment-menu]");
+  if (summaryAttachmentTrigger) {
+    const menu = summaryAttachmentTrigger.closest("[data-summary-attachment-menu]");
+    const popover = summaryAttachmentPopover(menu);
+    const opening = popover?.classList.contains("hidden");
+    closeSummaryAttachmentMenus(menu);
+    if (opening) popover?.classList.remove("hidden");
+    else resetSummaryAttachmentPopover(menu, popover);
+    summaryAttachmentTrigger.setAttribute("aria-expanded", opening ? "true" : "false");
+    menu?.classList.toggle("summary-attachment-menu-open-above", false);
+    if (opening) positionSummaryAttachmentMenu(summaryAttachmentTrigger);
   }
 
   const attachmentViewerMenu = event.target.closest("[data-attachment-viewer-menu]");
@@ -13973,7 +14050,10 @@ els.view.addEventListener("click", (event) => {
     scrollConversationToRecent();
     return;
   }
-});
+}
+
+els.view.addEventListener("click", handleViewClick);
+els.summaryAttachmentOverlay.addEventListener("click", handleViewClick);
 
 document.addEventListener("click", (event) => {
   handleDocumentCopyClick(event);
@@ -13997,6 +14077,7 @@ document.addEventListener("click", (event) => {
 
 window.addEventListener("resize", positionSkillAutocomplete);
 window.addEventListener("scroll", positionSkillAutocomplete, true);
+window.addEventListener("scroll", repositionOpenSummaryAttachmentMenus, true);
 
 document.addEventListener("click", (event) => {
   if (eventPathIncludes(event, els.mark) || eventPathIncludes(event, els.unreadPanel)) return;
@@ -14031,7 +14112,8 @@ document.addEventListener("click", (event) => {
   if (!event.target.closest("[data-skill-flyout]") && !event.target.closest("[data-toggle-skills]")) {
     closeSkillFlyout();
   }
-  if (!event.target.closest("[data-summary-attachment-menu]")) {
+  if (!event.target.closest("[data-summary-attachment-menu]") &&
+      !event.target.closest("[data-summary-attachment-menu-popover]")) {
     closeSummaryAttachmentMenus();
   }
   if (!event.target.closest("[data-attachment-viewer-menu]")) {
@@ -15790,6 +15872,7 @@ window.addEventListener("resize", () => {
   syncDetailHeaderLayout();
   syncFullScreenComposerViewport();
   syncAgentDockLayout();
+  repositionOpenSummaryAttachmentMenus();
 });
 
 document.addEventListener("visibilitychange", () => {
@@ -16337,6 +16420,7 @@ document.addEventListener("keydown", (event) => {
 
   if (handleUnreadPanelKeydown(event)) return;
   if (handleHeaderMoreKeydown(event)) return;
+  if (handleSummaryAttachmentMenuKeydown(event)) return;
   if (handleDetailsOverlayKeydown(event)) return;
 
   if (event.key !== "c") return;

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -126,6 +126,8 @@
       </nav>
     </div>
 
+    <div id="summary-attachment-overlay-root" class="summary-attachment-overlay-root" aria-live="off"></div>
+
     <script src="/ui-helpers.js?v=<%= HQ::RemoteUI.asset_version %>"></script>
     <script src="/ui.js?v=<%= HQ::RemoteUI.asset_version %>"></script>
   </body>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4113,6 +4113,10 @@ module RemoteServerTest
     assert(css[:body].include?(".summary-attachment-menu"), "expected Conversation summaries to style attachment menus")
     assert(css[:body].include?(".summary-attachment-menu-popover"),
            "expected Conversation summary attachments to open as a menu")
+    assert(css[:body].include?(".summary-attachment-overlay-root") &&
+           css[:body].include?("position: fixed") &&
+           css[:body].include?("z-index: var(--ds-z-dropdown)"),
+           "expected Conversation summary attachment menus to use a viewport overlay on the shared dropdown layer")
     assert(css[:body].include?(".summary-attachment-list-full"),
            "expected detailed Summary pages to render full attachment lists")
     assert(css[:body].include?(".summary-attachment-item") &&
@@ -5723,7 +5727,7 @@ module RemoteServerTest
     assert(js[:body].include?('data-state-key="summary-attachment-menu:${escapeAttr(summaryId)}"'),
            "expected Conversation summary attachment menus to preserve open state across polling")
     assert(js[:body].include?("function repositionOpenSummaryAttachmentMenus"),
-           "expected restored summary attachment menus to recompute fixed popover coordinates")
+           "expected restored summary attachment menus to recompute viewport-safe popover coordinates")
     assert(js[:body].include?("closeSummaryAttachmentMenus();"),
            "expected Summary attachment menus to close on outside clicks")
     assert(js[:body].include?("renderSummaryAttachmentList"),


### PR DESCRIPTION
## Summary
- render conversation summary attachment menus in a viewport-level overlay
- keep dropdown placement within viewport gutters and above the header/mobile dock layer
- preserve open state, delegated attachment actions, outside-click, Escape, resize, and polling behavior
- cover agent-title copy, mobile popover sizing/stacking, and harden existing smoke timing assertions

## Validation
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby -c bin/remote-ui-smoke`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test`
- `bin/remote-ui-smoke`