### PR TITLE
Implement Fizzy Remote UI reliability batch

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1077,7 +1077,8 @@ def write_smoke_script(path)
             applyResourceCatalog(resource("revision-2"));
             return {
               unchangedPreserved,
-              changedInvalidated: !state.agentDetails["agent-detail-revision-fixture"],
+              changedPreserved: state.agentDetails["agent-detail-revision-fixture"]?.attachments?.[0]?.id === "existing-attachment",
+              changedMarkedStale: state.agentDetails["agent-detail-revision-fixture"]?.detail_stale === true,
             };
           } finally {
             state.agents = saved.agents;
@@ -1089,8 +1090,62 @@ def write_smoke_script(path)
             state.servers = saved.servers;
           }
         });
-        if (!agentDetailRevisionContract.unchangedPreserved || !agentDetailRevisionContract.changedInvalidated) {
+        if (!agentDetailRevisionContract.unchangedPreserved ||
+            !agentDetailRevisionContract.changedPreserved ||
+            !agentDetailRevisionContract.changedMarkedStale) {
           throw new Error(`Agent detail cache did not follow catalog revisions: ${JSON.stringify(agentDetailRevisionContract)}`);
+        }
+        const agentStatusIconContract = await page.evaluate(() => {
+          return [
+            ["stopped", "⏸️", "Stopped"],
+            ["succeeded", "✅", "Succeeded"],
+            ["failed", "🚫", "Failed"],
+            ["cancelled", "🚫", "Cancelled"],
+            ["blocked", "🚫", "Blocked"],
+          ].map(([status, icon, label]) => {
+            const host = document.createElement("div");
+            host.innerHTML = agentStatusBadge({ status });
+            const badge = host.querySelector(".agent-status-badge");
+            const mark = badge?.querySelector(".agent-status-icon");
+            return {
+              status,
+              icon: mark?.textContent,
+              decorative: mark?.getAttribute("aria-hidden"),
+              labelPresent: badge?.textContent.includes(label),
+              expectedIcon: icon,
+            };
+          });
+        });
+        if (agentStatusIconContract.some((item) =>
+          item.icon !== item.expectedIcon || item.decorative !== "true" || !item.labelPresent)) {
+          throw new Error(`Agent status icons lost their text or accessibility contract: ${JSON.stringify(agentStatusIconContract)}`);
+        }
+        const degradedActivityContract = await page.evaluate(() => {
+          const merged = window.TychoRemoteHelpers.mergeActivityServers(
+            [
+              { key: "healthy", name: "Healthy", status: "online", agents: [{ key: "old" }] },
+              { key: "failing", name: "Failing", status: "online", agents: [{ key: "retained" }] },
+            ],
+            [
+              { serverKey: "healthy", ready: true, agents: [{ key: "fresh" }] },
+              { serverKey: "failing", failed: true, status: 503, retryAfterMs: 3000, error: "Activity unavailable; retrying automatically" },
+            ]
+          );
+          const host = document.createElement("div");
+          host.innerHTML = renderServerRow(merged[1]);
+          return {
+            healthyUpdated: merged[0].agents[0].key === "fresh",
+            failingRetained: merged[1].agents[0].key === "retained",
+            health: host.querySelector(".ui-status")?.textContent.trim(),
+            signal: host.querySelector("[role='status']")?.textContent.trim(),
+            retryAfterMs: merged[1].activity_retry_after_ms,
+          };
+        });
+        if (!degradedActivityContract.healthyUpdated || !degradedActivityContract.failingRetained ||
+            degradedActivityContract.health !== "Degraded" ||
+            !degradedActivityContract.signal?.includes("retrying automatically") ||
+            degradedActivityContract.retryAfterMs !== 3000) {
+          throw new Error(`Peer activity degradation is not isolated or actionable: ${JSON.stringify(degradedActivityContract)}`);
         }
         const daemonMenuLayout = await page.evaluate(() => {
           const details = document.querySelector("[data-state-key='schedule-now-details']");
@@ -3892,6 +3947,22 @@ def write_smoke_script(path)
         if (scheduleHeaderGeometry.scheduleRight > scheduleHeaderGeometry.contextLeft || scheduleHeaderGeometry.topDelta > 1) {
           throw new Error(`Schedule menu is not beside the page context: ${JSON.stringify(scheduleHeaderGeometry)}`);
         }
+        await page.click("[data-header-schedule-menu] > summary");
+        await page.click("[data-remove-agent-schedule]");
+        await page.waitForSelector("#confirmation-dialog[open]", { state: "visible", timeout: 10_000 });
+        const removeScheduleConfirmation = await page.evaluate(() => ({
+          title: document.querySelector("#confirmation-title")?.textContent,
+          description: document.querySelector("#confirmation-description")?.textContent,
+          confirmLabel: document.querySelector("[data-confirmation-accept]")?.textContent,
+          cancelFocused: document.activeElement?.hasAttribute("data-confirmation-cancel"),
+        }));
+        if (!removeScheduleConfirmation.title?.includes("Remove schedule from") ||
+            !removeScheduleConfirmation.description?.includes("full session history") ||
+            removeScheduleConfirmation.confirmLabel !== "Remove schedule" ||
+            !removeScheduleConfirmation.cancelFocused) {
+          throw new Error(`Schedule removal confirmation is incomplete: ${JSON.stringify(removeScheduleConfirmation)}`);
+        }
+        await page.click("[data-confirmation-cancel]");
         const scheduleStatusColors = await page.evaluate((key) => {
           const agent = findAgent(key);
           agent.last_result = "no action";
@@ -4850,6 +4921,8 @@ def write_smoke_script(path)
               before,
               after: {
                 status: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
+                statusIcon: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.textContent.trim(),
+                statusIconHidden: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("aria-hidden"),
                 sendPrompt: document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] button[type="submit"]`)?.textContent.trim(),
                 sendPromptFocused: document.activeElement === document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] button[type="submit"]`),
               },
@@ -4876,7 +4949,9 @@ def write_smoke_script(path)
             focusedStatusSyncContract.before.action !== "Stop agent" ||
             !focusedStatusSyncContract.before.steadyActionPreserved ||
             !focusedStatusSyncContract.before.steadyActionFocused ||
-            focusedStatusSyncContract.after.status !== "Succeeded" ||
+            focusedStatusSyncContract.after.status !== "✅Succeeded" ||
+            focusedStatusSyncContract.after.statusIcon !== "✅" ||
+            focusedStatusSyncContract.after.statusIconHidden !== "true" ||
             focusedStatusSyncContract.after.sendPrompt !== "Send prompt" ||
             !focusedStatusSyncContract.after.sendPromptFocused ||
             focusedStatusSyncContract.conversationReads !== 0 ||

--- a/docs/SCHEDULED_RUNS.md
+++ b/docs/SCHEDULED_RUNS.md
@@ -36,6 +36,7 @@ Each schedule has two editable prompt fields: a system message for the schedule-
 - No-action outcomes: scheduled agents should return structured status `no_action_needed` only when a successful observational check finds no new condition requiring action and completes no requested action or deliverable. Completed changes, answers, commits, reviews, and deliverables use `success` even when no next step remains. Tycho records a no-action result as the schedule's last outcome but does not mark the agent unread or send success/push notifications.
 - Schedule prompt parity: the backend exposes one title-aware schedule system-message template through `/setup`; the Remote UI consumes it and keeps an equivalent compatibility fallback for older servers.
 - Resume behavior: resuming a stopped schedule keeps the schedule-owned session, records a resume boundary, and waits until the next scheduled run.
+- Removal behavior: deleting a schedule detaches its active agent in the same persisted operation. The agent, transcript, attachments, and native session stay available as an ordinary conversation while future automatic runs stop.
 - Success notifications: notify only on first success and first success after failure, including the next scheduled run time.
 
 ## Current Design
@@ -240,6 +241,7 @@ GET  /schedules/:key
 POST /schedules/:key/run
 POST /schedules/:key/pause
 POST /schedules/:key/resume
+DELETE /schedules/:key
 POST /schedules/reload
 POST /schedules/daemon/start
 POST /schedules/daemon/stop

--- a/docs/design-system/DESIGN_SYSTEM.md
+++ b/docs/design-system/DESIGN_SYSTEM.md
@@ -175,6 +175,8 @@ Generated Remote UI markup uses `metadataBadge(label, "pill" | "chip")`. The sec
 | `success` | Healthy or completed state | Succeeded, scheduled, ready, clean, fresh |
 | `danger` | Failed, blocked, stopped, or invalid state | Blocked, failed, missing, stopped |
 
+Agent status badges keep their text label and add a decorative state icon where the outcome has one: `⏸️` for paused or stopped, `✅` for succeeded, and `🚫` for failed, cancelled, or blocked. The icon is `aria-hidden`; the visible label remains the accessible status.
+
 Visible labels carry the meaning. Color is reinforcement. Product status icons remain `aria-hidden` when an adjacent badge supplies the text. Neutral product states such as Idle, Fixed, and Read only still use `ui-status`; factual context uses `ui-metadata-badge`.
 
 The migration keeps legacy `need`, `running`, `done`, `fail`, `info`, and `detail` classes as layout/color adapters. `statusIntent` is the single mapping to semantic intent; new code should not add another status-class vocabulary.

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -423,11 +423,18 @@ module HQ
     end
 
     def scheduled?
-      @template_key.to_s == "scheduled"
+      !@schedule_key.to_s.empty?
     end
 
     def associate_schedule!(schedule_key)
       @schedule_key = normalize_schedule_key(schedule_key)
+    end
+
+    def detach_schedule!(template_key: nil)
+      @schedule_key = nil
+      replacement = template_key.to_s.strip
+      @template_key = replacement if @template_key.to_s == "scheduled" && !replacement.empty?
+      self
     end
 
     def reconcile_project_group!(value)

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -99,6 +99,27 @@ module HQ
       result
     end
 
+    def remove(key)
+      schedule = find_schedule!(key)
+      agents = load_agents
+      detached = agents.select { |agent| agent.schedule_key.to_s == schedule.key }
+      state = store.load[schedule.key]
+
+      FileTransaction.run([schedule_registry.path, store.path, AGENTS_FILE]) do
+        schedule_registry.delete(schedule.key)
+        store.delete(schedule.key)
+        detached.each do |agent|
+          project = @projects.find { |candidate| candidate.key == agent.project_key }
+          agent.detach_schedule!(template_key: project&.agent_templates&.first&.key)
+        end
+        @agent_store.save(agents) if detached.any?
+      end
+
+      publish("schedule.removed", schedule, state || ScheduleState.new(key: schedule.key),
+              agent_keys: detached.map(&:key))
+      { schedule: schedule_payload(schedule, state || ScheduleState.new(key: schedule.key)), agents: detached }
+    end
+
     def create_agent_loop!(agent:, agents:, schedule_key:, name:, interval_minutes:, ends_at:, message:, now: Time.now)
       raise LoopStartError, "Stop the running agent before starting a loop" if agent.running?
       unless agent.schedule_key.to_s.empty?

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -1407,10 +1407,11 @@ module HQ
       end
     end
 
-    def initialize(registry:, server_url: nil, timeout: RemoteClient::DEFAULT_TIMEOUT)
+    def initialize(registry:, server_url: nil, timeout: RemoteClient::DEFAULT_TIMEOUT, logger: HQ.logger)
       @registry = registry
       @server_url = server_url.to_s
       @timeout = timeout
+      @logger = logger
       @credential_resolver = RemoteCredentialResolver.new(store: RemoteCredentialStore.new(registry: registry))
     end
 
@@ -1426,15 +1427,31 @@ module HQ
         raise RemoteServer::Error.new("Peer access is limited to agents, projects, and attachments", status: 404)
       end
 
-      RemoteClient.new(
+      response = RemoteClient.new(
         config,
         timeout: @timeout,
         token_override: remote_server_token(request),
         credential_resolver: @credential_resolver
       ).request(method, path, body:, query: request&.query)
+      log_recoverable_activity_failure(config.key, method, path, response) if response[:status].to_i >= 500
+      response
     end
 
     private
+
+    def log_recoverable_activity_failure(peer_key, method, path, response)
+      return unless path.to_s.split("/").reject(&:empty?).first == "activity"
+      response_body = response[:body]
+      error = if response_body.is_a?(Hash)
+                response_body[:error] || response_body["error"]
+              end
+      return if error.to_s.include?("rejected broker credentials")
+
+      @logger.warn("RemoteBroker") do
+        "Peer activity fetch failed peer=#{peer_key.inspect} method=#{method.to_s.upcase} " \
+          "path=#{path.to_s.inspect} status=#{response[:status].to_i}; treating as recoverable"
+      end
+    end
 
     def remote_configs
       Array(@registry.remote_servers)
@@ -2244,9 +2261,15 @@ module HQ
     end
 
     def delete_schedule(key)
-      schedule_registry.delete(key)
-      ScheduleStore.new.delete(key)
-      { deleted: true, key: key.to_s }
+      result = scheduler.remove(key)
+      detached_agents = result.fetch(:agents)
+      {
+        deleted: true,
+        key: key.to_s,
+        detached_agent_keys: detached_agents.map(&:key),
+        agents: detached_agents.map { |agent| agent_payload(agent) },
+        agent: detached_agents.one? ? agent_payload(detached_agents.first) : nil
+      }
     rescue ScheduleRegistry::Error => e
       raise Error.new(e.message, status: 404)
     end

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1196,6 +1196,13 @@ textarea {
   margin-top: 0;
 }
 
+.server-activity-error {
+  display: block;
+  margin-top: 4px;
+  color: var(--warning);
+  font-size: 12px;
+}
+
 .server-target-line {
   min-width: 0;
   overflow: hidden;
@@ -2557,6 +2564,19 @@ select {
 .ui-status {
   background: color-mix(in srgb, currentColor 9%, var(--panel-soft));
   font-weight: var(--ds-weight-medium);
+}
+
+.kv .agent-status-icon + span,
+.agent-reference-copy .agent-status-icon + span {
+  margin-left: 4px;
+}
+
+.agent-status-badge .agent-status-icon + span {
+  margin-left: 0;
+}
+
+.agent-status-badge {
+  gap: 4px;
 }
 
 .status-mark[data-intent="warning"],

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1016,6 +1016,7 @@ function serverMetadataBadge(server) {
 
 function serverHealthLabel(server) {
   if (!server) return "Loading";
+  if (server.activity_error) return "Degraded";
   if (server.stale) return "Stale";
   return {
     online: "Online",
@@ -1026,6 +1027,7 @@ function serverHealthLabel(server) {
 }
 
 function serverHealthClass(server) {
+  if (server?.activity_error) return "need";
   if (server?.stale) return "detail";
   if (server?.status === "unauthorized") return "need";
   if (server?.status === "online") return "done";
@@ -1060,7 +1062,8 @@ function serverHealthIconBadge(server) {
   const label = serverHealthLabel(server);
   const className = serverHealthClass(server);
   const iconName = server?.status === "online" && !server?.stale ? "wifi" : "wifiOff";
-  return `<span class="chip ${escapeAttr(className)} ui-badge ui-status server-health-icon-badge" data-intent="${escapeAttr(statusIntent(className))}" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}">
+  const detail = server?.activity_error ? `${label}: ${server.activity_error}` : label;
+  return `<span class="chip ${escapeAttr(className)} ui-badge ui-status server-health-icon-badge" data-intent="${escapeAttr(statusIntent(className))}" aria-label="${escapeAttr(detail)}" title="${escapeAttr(detail)}">
     ${iconSvg(iconName)}
   </span>`;
 }
@@ -1206,7 +1209,18 @@ function localProjects() {
 
 function applyResourceCatalog(data) {
   const servers = Array.isArray(data?.servers) ? data.servers : [];
-  state.servers = servers;
+  const previousServers = new Map(state.servers.map((server) => [server.key, server]));
+  state.servers = servers.map((server) => {
+    const previous = previousServers.get(server.key);
+    return previous?.activity_error
+      ? {
+          ...server,
+          activity_error: previous.activity_error,
+          activity_status: previous.activity_status,
+          activity_retry_after_ms: previous.activity_retry_after_ms,
+        }
+      : server;
+  });
   const serverKeys = new Set(servers.map((server) => server.key));
   state.activityReadyServerKeys.forEach((key) => {
     if (!serverKeys.has(key)) state.activityReadyServerKeys.delete(key);
@@ -1231,14 +1245,7 @@ function applyResourceCatalog(data) {
     const detail = state.agentDetails[agent.key];
     if (!detail) return;
 
-    const detailRevision = String(detail.revision || "");
-    const catalogRevision = String(agent.revision || "");
-    if (detailRevision && catalogRevision && detailRevision !== catalogRevision) {
-      delete state.agentDetails[agent.key];
-      return;
-    }
-
-    Object.assign(detail, agent);
+    state.agentDetails[agent.key] = REMOTE_HELPERS.reconcileAgentDetail(detail, agent);
   });
   const activeAgentKeys = new Set(state.agents.map((agent) => agent.key));
   prunePullRequestDiffState(activeAgentKeys);
@@ -1323,6 +1330,17 @@ function applyAgentActivity(data, requestSequence) {
     });
   });
   state.activityRevision = data.revision || null;
+  const activityServers = new Map(data.servers.map((server) => [server.key, server]));
+  state.servers = state.servers.map((server) => {
+    const activityServer = activityServers.get(server.key);
+    if (!activityServer) return server;
+    return {
+      ...server,
+      activity_error: activityServer.activity_error || null,
+      activity_status: activityServer.activity_status || null,
+      activity_retry_after_ms: activityServer.activity_retry_after_ms || null,
+    };
+  });
   state.activityAgents = activityAgents;
   state.activityReadyServerKeys = readyServerKeys;
   state.agents = mergeAgentActivity(state.agents);
@@ -1885,16 +1903,27 @@ async function loadAgentActivity() {
         ready: peer.ready,
         agents: peer.agents,
       };
-    } catch (_error) {
+    } catch (error) {
+      const status = Number(error?.status) || 0;
+      if (status >= 500 && !String(error?.message || "").includes("rejected broker credentials")) {
+        const retryAfterMs = document.hidden
+          ? AGENT_ACTIVITY_POLL_INTERVALS.hiddenMs
+          : AGENT_ACTIVITY_POLL_INTERVALS.visibleMs;
+        console.warn("Peer activity fetch degraded", { peer: server.key, status, retryAfterMs });
+        return {
+          serverKey: server.key,
+          failed: true,
+          status,
+          retryAfterMs,
+          error: `Activity unavailable (HTTP ${status}); retrying automatically`,
+        };
+      }
       return null;
     }
   }));
-  const peersByKey = new Map(peerResults.filter(Boolean).map((peer) => [peer.serverKey, peer]));
-  const mergedServers = servers.map((server) => {
-    const peer = peersByKey.get(server.key);
-    return peer ? { ...server, ready: peer.ready, agents: peer.agents } : server;
-  });
-  const peerRevisions = peerResults.filter(Boolean).map((peer) => `${peer.serverKey}:${peer.revision || ""}`);
+  const mergedServers = REMOTE_HELPERS.mergeActivityServers(servers, peerResults);
+  const peerRevisions = peerResults.filter(Boolean).map((peer) =>
+    `${peer.serverKey}:${peer.failed ? `error-${peer.status}` : peer.revision || ""}`);
   return {
     ...activity,
     revision: [activity.revision || "", ...peerRevisions].join(":"),
@@ -1978,7 +2007,7 @@ function syncFocusedWorkspaceCatalog(route = parseRoute()) {
   if (state.agentSettingsOpen) setAgentSettings(agent);
 
   document.querySelectorAll(`[data-agent-live-status="${CSS.escape(agent.key)}"]`).forEach((element) => {
-    element.innerHTML = statusBadge(statusLabel(agent), statusClass(agent), "chip");
+    element.innerHTML = agentStatusBadge(agent, "chip");
   });
 
   const composer = document.querySelector(`#composer[data-agent-key="${CSS.escape(agent.key)}"]`);
@@ -2029,6 +2058,13 @@ async function refresh(options = {}) {
     const previousAgents = state.agents;
     applyResourceCatalog(catalogData);
     if (preservedInquiryAgent) state.agentDetails[inquiryAgentKey] = preservedInquiryAgent;
+    const focusedAgent = preserveWorkspace ? focusedWorkspaceAgent(parseRoute()) : null;
+    if (focusedAgent?.detail_stale) {
+      await ensureAgentDetail(focusedAgent.key);
+      const refreshedDetail = state.agentDetails[focusedAgent.key];
+      const catalogAgent = state.agents.find((agent) => agent.key === focusedAgent.key);
+      if (refreshedDetail && catalogAgent) Object.assign(refreshedDetail, activityFields(catalogAgent));
+    }
     state.resourceRevision = catalogData.revision;
     const nextAgents = state.agents;
     const routeBeforeRefresh = parseRoute();
@@ -2212,7 +2248,7 @@ async function ensureRouteData(options = {}) {
 
 async function ensureAgentDetail(agentKey, force = false) {
   if (!agentKey) return;
-  if (!force && state.agentDetails[agentKey]) return;
+  if (!force && state.agentDetails[agentKey] && !state.agentDetails[agentKey].detail_stale) return;
 
   const data = await apiGet(`/agents/${encodeURIComponent(agentKey)}`);
   if (data.agent) state.agentDetails[agentKey] = data.agent;
@@ -5143,6 +5179,7 @@ function renderServerRow(server) {
             ${statusBadge(serverHealthLabel(server), className, "chip")}
             ${tokenPill}
           </span>
+          ${server.activity_error ? `<span class="server-activity-error" role="status">${escapeHtml(server.activity_error)}.</span>` : ""}
         </div>
         <div class="server-row-actions">
           ${actions}
@@ -5563,9 +5600,9 @@ function renderAgentSummaryView(agent, options = {}) {
               ${renderSummaryNavigationButton(agent.key, navigation.nextId, "next", "chevronDown")}
             </nav>
           </div>
-          <div class="chip-row"><span>Current session</span><span data-agent-live-status="${escapeAttr(agent.key)}">${statusBadge(statusLabel(agent), statusClass(agent), "chip")}</span></div>
+          <div class="chip-row"><span>Current session</span><span data-agent-live-status="${escapeAttr(agent.key)}">${agentStatusBadge(agent, "chip")}</span></div>
           <div class="summary-outcome-grid">
-            ${kv("Outcome", summary.status || statusLabel(agent))}
+            ${kv("Outcome", summary.status || statusLabel(agent), { valueHtml: statusValueInline(summary.status || agentDisplayedStatusKey(agent), summary.status || statusLabel(agent)) })}
             ${kv("Total Runs", agent.run_count || 0)}
             ${kv("Est. Cost", sessionCostSnapshotText(summary.costSnapshot))}
             ${kv("Attachments", summary.attachments?.length || 0)}
@@ -5889,7 +5926,7 @@ function renderAgentReference(reference, options = {}) {
   const serverHealth = serverDisconnected(server) ? "Offline" : serverHealthLabel(server);
   const label = reference.name || (reference.state === "hidden" ? "Hidden agent" : reference.agent_key || "Agent");
   const reportStatus = reference.connected === false ? " · Reports disconnected" : "";
-  const content = `<span class="status-mark ${escapeAttr(statusClass({ status: reference.status || reference.state }))}" aria-hidden="true">${iconSvg("botMessageSquare")}</span><span class="agent-reference-copy"><strong>${agentReferenceNameHtml(reference, options.relationshipRole)}</strong><span>${escapeHtml(status)} · ${escapeHtml(serverDisplayName(server))} · ${escapeHtml(serverHealth)}${escapeHtml(reportStatus)}</span></span>`;
+  const content = `<span class="status-mark ${escapeAttr(statusClass({ status: reference.status || reference.state }))}" aria-hidden="true">${iconSvg("botMessageSquare")}</span><span class="agent-reference-copy"><strong>${agentReferenceNameHtml(reference, options.relationshipRole)}</strong><span>${statusValueInline(reference.status || reference.state, status)} · ${escapeHtml(serverDisplayName(server))} · ${escapeHtml(serverHealth)}${escapeHtml(reportStatus)}</span></span>`;
   const unavailable = ["missing", "hidden"].includes(reference.state) || serverDisconnected(server);
   const className = `agent-reference${options.embedded ? " embedded" : ""}`;
   if (unavailable) return `<span class="${className} unavailable" aria-label="${escapeAttr(`${label}, ${status}, ${serverHealth}`)}">${content}</span>`;
@@ -7347,7 +7384,7 @@ function renderAgentArchive(key) {
         ${kv("Harness", agent.agent || "agent")}
         ${kv("Model", agent.model || "default")}
         ${kv("Effort", agent.reasoning_effort || "default")}
-        ${kv("Status", statusLabel(agent))}
+        ${agentStatusKv(agent)}
         ${kv("Runs", agent.run_count)}
       </div>
       <div class="button-row form-actions ui-form-actions archive-actions">
@@ -8462,7 +8499,7 @@ function renderAgentCard(agent) {
       </div>
       <div class="agent-card-status">
         ${serverIdentityBadge(agent, { compactHealth: true })}
-        ${statusBadge(statusLabel(agent), statusClass(agent))}
+        ${agentStatusBadge(agent)}
       </div>
       <p class="card-copy agent-card-excerpt">${escapeHtml(truncate(agent.summary || agent.last_result || "No run summary yet.", 140))}</p>
     </button>
@@ -8479,7 +8516,7 @@ function renderAgentRow(agent, options = {}) {
         <strong>${agentNameHtml(agent)}</strong>
         <span>${agentListSubtextHtml(agent, options)}</span>
       </div>
-      ${statusBadge(statusLabel(agent), statusClass(agent))}
+      ${agentStatusBadge(agent)}
     </button>
   `;
 }
@@ -8498,7 +8535,7 @@ function renderSelectableAgentRow(agent, options = {}) {
         <strong>${agentNameHtml(agent)}</strong>
         <span>${agentListSubtextHtml(agent, options)}</span>
       </div>
-      ${statusBadge(label, className)}
+      ${disabled ? statusBadge(label, className) : agentStatusBadge(agent)}
     </label>
   `;
 }
@@ -10462,7 +10499,7 @@ function kv(label, value, options = {}) {
   return `
     <div class="kv ${options.copyable ? "kv-copyable" : ""}">
       <span>${escapeHtml(label)}</span>
-      <strong class="wrap-anywhere">${escapeHtml(display)}</strong>
+      <strong class="wrap-anywhere">${options.valueHtml || escapeHtml(display)}</strong>
       ${copyButton}
     </div>
   `;
@@ -10909,6 +10946,14 @@ function renderAgentScheduleMenu(agent, schedule) {
       icon: "pencil",
       attrs: `data-edit-schedule="${escapeAttr(schedule.key)}"`,
     }),
+    moreMenuSeparator(),
+    moreMenuButton({
+      label: "Remove schedule",
+      sublabel: "Keep this conversation and its history",
+      icon: "trash2",
+      attrs: `data-remove-agent-schedule="${escapeAttr(schedule.key)}" data-agent-key="${escapeAttr(agent.key)}"`,
+      danger: true,
+    }),
   ];
 
   return `
@@ -11352,7 +11397,7 @@ function showAllAgentsInSwitcher() {
 
 function renderSwitcherAgentRow(agent, index) {
   const selected = index === state.unreadPanelSelectedIndex;
-  const statusText = statusBadge(statusLabel(agent), statusClass(agent));
+  const statusText = agentStatusBadge(agent);
   const linkedCount = linkedAgentReferences(agent).length;
   const linkedSymbol = linkedCount
     ? `<span class="switcher-linked-symbol" data-show-linked-agents="${escapeAttr(agent.key)}" aria-label="Show linked agents" title="Show linked agents">${iconSvg("link")}</span>`
@@ -11371,7 +11416,7 @@ function renderSwitcherAgentRow(agent, index) {
 }
 
 function agentIconName(agent) {
-  return agent?.scheduled || agent?.template_key === "scheduled" || agent?.schedule_key ? "calendarCheck2" : "robot";
+  return agent?.scheduled || agent?.schedule_key ? "calendarCheck2" : "robot";
 }
 
 function agentNameHtml(agent) {
@@ -11764,7 +11809,7 @@ function agentSettingsHtml(agent) {
 
   return `
     <div class="agent-settings-grid">
-      ${settings.map(([label, value]) => copyableKv(label, value)).join("")}
+      ${settings.map(([label, value]) => label === "Status" ? agentStatusKv(agent, { copyable: true }) : copyableKv(label, value)).join("")}
     </div>
   `;
 }
@@ -12358,6 +12403,37 @@ function statusClass(agent) {
   if (agent.last_result === "no action") return "info";
   if (agent.status === "succeeded" || agent.last_result === "success") return "done";
   return "detail";
+}
+
+function agentDisplayedStatusKey(agent) {
+  if (agent?.awaiting_input) return "awaiting-input";
+  if (agent?.running) return "running";
+  if (agent?.blocked) return "blocked";
+  if (agent?.unread) return "unread";
+  if (agent?.last_result === "no action") return "no_action_needed";
+  return String(agent?.status || "idle");
+}
+
+function agentStatusIcon(agent) {
+  return REMOTE_HELPERS.agentStatusIcon(agentDisplayedStatusKey(agent));
+}
+
+function agentStatusInline(agent) {
+  return statusValueInline(agentDisplayedStatusKey(agent), statusLabel(agent));
+}
+
+function statusValueInline(status, label = titleFromKey(status)) {
+  const icon = REMOTE_HELPERS.agentStatusIcon(status);
+  return `${icon ? `<span class="agent-status-icon" aria-hidden="true">${escapeHtml(icon)}</span>` : ""}<span>${escapeHtml(label)}</span>`;
+}
+
+function agentStatusBadge(agent, kind = "pill") {
+  const legacyClass = statusClass(agent);
+  return `<span class="${escapeAttr(kind)} ${escapeAttr(legacyClass)} ui-badge ui-status agent-status-badge" data-intent="${escapeAttr(statusIntent(legacyClass))}">${agentStatusInline(agent)}</span>`;
+}
+
+function agentStatusKv(agent, options = {}) {
+  return kv("Status", statusLabel(agent), { ...options, valueHtml: agentStatusInline(agent) });
 }
 
 function statusIntent(className) {
@@ -13270,6 +13346,15 @@ els.headerSchedule.addEventListener("click", (event) => {
     return;
   }
 
+  const removeAgentScheduleButton = event.target.closest("[data-remove-agent-schedule]");
+  if (removeAgentScheduleButton) {
+    closeHeaderScheduleMenu();
+    deleteSchedule(removeAgentScheduleButton.dataset.removeAgentSchedule, {
+      agentKey: removeAgentScheduleButton.dataset.agentKey,
+    });
+    return;
+  }
+
   const scheduleAction = event.target.closest("[data-schedule-action]");
   if (scheduleAction) {
     closeHeaderScheduleMenu();
@@ -14133,6 +14218,14 @@ function handleViewClick(event) {
   const deleteScheduleButton = event.target.closest("[data-delete-schedule]");
   if (deleteScheduleButton) {
     deleteSchedule(deleteScheduleButton.dataset.deleteSchedule);
+    return;
+  }
+
+  const removeAgentScheduleButton = event.target.closest("[data-remove-agent-schedule]");
+  if (removeAgentScheduleButton) {
+    deleteSchedule(removeAgentScheduleButton.dataset.removeAgentSchedule, {
+      agentKey: removeAgentScheduleButton.dataset.agentKey,
+    });
     return;
   }
 
@@ -15132,21 +15225,26 @@ function runScheduleAction(scheduleAction) {
   });
 }
 
-async function deleteSchedule(key) {
+async function deleteSchedule(key, options = {}) {
   if (!key) return;
   const schedule = (state.schedules || []).find((item) => String(item.key || "") === String(key));
   const label = schedule?.name || key;
+  const agent = options.agentKey ? findAgent(options.agentKey) : null;
   const confirmed = await confirmAction({
-    title: `Delete ${label}?`,
-    description: "Future runs from this schedule will stop. Existing agent sessions and their history are kept.",
-    confirmLabel: "Delete schedule",
+    title: agent ? `Remove schedule from ${agent.name || agent.key}?` : `Delete ${label}?`,
+    description: "Future automatic runs will stop. The agent and its full session history will remain available for ordinary prompts and runs.",
+    confirmLabel: agent ? "Remove schedule" : "Delete schedule",
   });
   if (!confirmed) return;
 
   mutate(async () => {
-    await apiDelete(`/schedules/${encodeURIComponent(key)}`);
+    const data = await apiDelete(`/schedules/${encodeURIComponent(key)}`);
     state.schedules = (state.schedules || []).filter((schedule) => String(schedule.key || "") !== String(key));
-    setConnection("Schedule deleted");
+    const detachedAgents = Array.isArray(data.agents) ? data.agents : [data.agent].filter(Boolean);
+    detachedAgents.forEach((detachedAgent) => {
+      if (detachedAgent?.key) upsertAgent(detachedAgent);
+    });
+    setConnection(agent ? "Schedule removed; conversation kept" : "Schedule deleted");
     render();
   });
 }

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -476,8 +476,70 @@
     return "composer";
   }
 
+  function reconcileAgentDetail(detail, catalogAgent) {
+    if (!detail) return catalogAgent || null;
+    if (!catalogAgent) return detail;
+
+    const revisionChanged = Boolean(
+      detail.revision && catalogAgent.revision && detail.revision !== catalogAgent.revision
+    );
+    return {
+      ...detail,
+      ...catalogAgent,
+      ...(revisionChanged ? { detail_stale: true } : {}),
+    };
+  }
+
+  function agentStatusIcon(status) {
+    switch (String(status || "").toLowerCase()) {
+      case "paused":
+      case "stopped":
+        return "⏸️";
+      case "completed":
+      case "succeeded":
+      case "success":
+        return "✅";
+      case "blocked":
+      case "cancelled":
+      case "canceled":
+      case "failed":
+      case "error":
+        return "🚫";
+      default:
+        return "";
+    }
+  }
+
+  function mergeActivityServers(servers, peerResults) {
+    const peersByKey = new Map(
+      (Array.isArray(peerResults) ? peerResults : []).filter(Boolean).map((peer) => [peer.serverKey, peer])
+    );
+    return (Array.isArray(servers) ? servers : []).map((server) => {
+      const peer = peersByKey.get(server.key);
+      if (!peer) return server;
+      if (peer.failed) {
+        return {
+          ...server,
+          ready: false,
+          activity_error: peer.error || "Activity temporarily unavailable",
+          activity_status: peer.status || 0,
+          activity_retry_after_ms: peer.retryAfterMs || 0,
+        };
+      }
+      return {
+        ...server,
+        ready: peer.ready,
+        agents: peer.agents,
+        activity_error: null,
+        activity_status: null,
+        activity_retry_after_ms: null,
+      };
+    });
+  }
+
   global.TychoRemoteHelpers = Object.freeze({
     agentComposerState,
+    agentStatusIcon,
     agentActivityTimestamp,
     agentSortUsesProjectGroups,
     attachmentBlobPath,
@@ -501,10 +563,12 @@
     draftableTextControl,
     elementStateKey,
     markdownHeadingSlug,
+    mergeActivityServers,
     normalizeAttachmentTargetForMatch,
     normalizeDiffScope,
     normalizeAgentSort,
     parseRoute,
+    reconcileAgentDetail,
     routeHash,
     routeStateKey,
     restoreControlState,

--- a/lib/hq/ui/rendering/status_helpers.rb
+++ b/lib/hq/ui/rendering/status_helpers.rb
@@ -91,6 +91,9 @@ module HQ
           "no_action_needed" => { label: "no action", style: :dim },
           "error" => { label: "error", style: :fail },
           "failed" => { label: "error", style: :fail },
+          "cancelled" => { label: "cancelled", style: :fail },
+          "canceled" => { label: "cancelled", style: :fail },
+          "paused" => { label: "paused", style: :maintenance },
           "stopped" => { label: "stopped", style: :maintenance },
           "partial" => { label: "partial", style: :warning },
           "blocked" => { label: "blocked", style: :fail },
@@ -104,8 +107,8 @@ module HQ
           when "running" then Styles::STATUS_ICONS[:running]
           when "succeeded", "success", "completed" then Styles::STATUS_ICONS[:succeeded]
           when "no_action_needed" then Styles::STATUS_ICONS[:dim]
-          when "failed", "error" then Styles::STATUS_ICONS[:failed]
-          when "stopped" then Styles::STATUS_ICONS[:stopped]
+          when "failed", "error", "cancelled", "canceled" then Styles::STATUS_ICONS[:failed]
+          when "paused", "stopped" then Styles::STATUS_ICONS[:stopped]
           when "awaiting-input", "input_required" then Styles::STATUS_ICONS[:awaiting_input]
           when "partial" then Styles::STATUS_ICONS[:partial]
           when "blocked" then Styles::STATUS_ICONS[:blocked]

--- a/lib/hq/ui/rendering/styles.rb
+++ b/lib/hq/ui/rendering/styles.rb
@@ -35,12 +35,12 @@ module HQ
           pending: "\u{f111}",
           dim: "\u{f111}",
           running: "\u{f0150}",
-          succeeded: "\u{f058}",
-          failed: "\u{f057}",
-          stopped: "\u{f04d}",
+          succeeded: "✅",
+          failed: "🚫",
+          stopped: "⏸️",
           awaiting_input: "\u{f059}",
           partial: "\u{f0c8}",
-          blocked: "\u{f05e}",
+          blocked: "🚫",
           unknown: "\u{f111}"
         }.freeze
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -62,6 +62,7 @@ module RemoteServerTest
     assert_remote_broker_lists_configured_servers
     assert_remote_resource_catalog_combines_and_retains_peer_resources
     assert_remote_broker_proxies_configured_server_requests
+    assert_remote_broker_logs_recoverable_activity_5xx
     assert_remote_broker_proxies_loopback_peer_requests
     assert_remote_server_persists_added_servers
     assert_remote_server_allows_tailnet_ad_hoc_servers
@@ -2604,6 +2605,32 @@ module RemoteServerTest
       assert(loop_state.last_target_key == loop_agent[:key] && loop_state.run_count == 1,
              "expected the immediate first loop run to use the existing session")
 
+      loop_memory_before_removal = File.binread(
+        service.send(:load_all_agents).find { |item| item.key == loop_agent[:key] }.memory_path
+      )
+      removed_loop = server.send(:route, service, "DELETE", "/schedules/review-loop", {}, nil)
+      assert(removed_loop.dig(:body, :deleted), "expected conversation schedule removal to delete the schedule")
+      assert(removed_loop.dig(:body, :detached_agent_keys) == [loop_agent[:key]],
+             "expected schedule removal to identify the preserved session")
+      assert(removed_loop.dig(:body, :agents, 0, :key) == loop_agent[:key],
+             "expected schedule removal to return every detached agent for immediate reconciliation")
+      assert(removed_loop.dig(:body, :agent, :key) == loop_agent[:key] &&
+             removed_loop.dig(:body, :agent, :schedule_key).nil? &&
+             removed_loop.dig(:body, :agent, :scheduled) == false,
+             "expected schedule removal to return an immediately detached agent payload")
+      detached_loop_agent = service.send(:load_all_agents).find { |item| item.key == loop_agent[:key] }
+      assert(detached_loop_agent && detached_loop_agent.schedule_key.nil? && !detached_loop_agent.scheduled?,
+             "expected the scheduled session to remain active as an ordinary agent")
+      assert(File.binread(detached_loop_agent.memory_path) == loop_memory_before_removal,
+             "expected schedule removal to preserve the complete session memory")
+      assert(!HQ::ScheduleStore.new.load.key?("review-loop") &&
+             YAML.safe_load_file(HQ::SCHEDULES_FILE).fetch("schedules").none? { |item| item["key"] == "review-loop" },
+             "expected schedule removal to stop future automatic runs in config and runtime state")
+      ordinary_prompt = service.submit_prompt(loop_agent[:key], "prompt" => "Continue manually.", "start" => false)
+      assert(ordinary_prompt.dig(:agent, :schedule_key).nil? &&
+             ordinary_prompt.fetch(:conversation).any? { |block| block[:content] == "Continue manually." },
+             "expected the detached agent to accept ordinary prompts without losing history")
+
       paused = server.send(:route, service, "POST", "/schedules/weekday/pause", {}, nil)
       assert(paused.dig(:body, :schedule, :paused), "expected schedule pause route")
 
@@ -3393,6 +3420,55 @@ module RemoteServerTest
                "expected loopback peer API request to be proxied")
         assert(!requests.last.fetch(:headers, {}).key?("authorization"),
                "expected ad hoc loopback peer proxy to avoid forwarding browser authorization")
+      end
+    end
+  end
+
+  def assert_remote_broker_logs_recoverable_activity_5xx
+    handler = lambda do |request|
+      assert(request[:path] == "/activity", "expected focused peer activity request")
+      {
+        status: 503,
+        content_type: "application/json",
+        body: JSON.generate(error: "temporary failure for super-secret")
+      }
+    end
+
+    with_fixture_http_server(handler) do |target_url|
+      Dir.mktmpdir("tycho-peer-activity") do |dir|
+        workspace = File.join(dir, "workspace")
+        write_project_workspace(workspace)
+        config_path = File.join(dir, "hq.yml")
+        prompts_path = File.join(dir, "system_prompts.yml")
+        File.write(config_path, <<~YAML)
+          projects:
+            - key: web
+              name: Web
+              path: #{workspace}
+          remote_servers:
+            - key: failing-peer
+              name: Failing peer
+              url: #{target_url}
+        YAML
+        File.write(prompts_path, "custom: Default prompt for %{project_key}.\n")
+        registry = HQ::Registry.new(path: config_path, system_prompts_path: prompts_path)
+        log_output = StringIO.new
+        logger = Logger.new(log_output)
+        broker = HQ::RemoteBroker.new(registry: registry, logger: logger)
+        request = HQ::RemoteServer.const_get(:Request).new(
+          method: "GET",
+          path: "/servers/failing-peer/activity",
+          headers: { "x-tycho-remote-server-token" => "super-secret" },
+          body: ""
+        )
+
+        response = broker.proxy("failing-peer", "GET", "/activity", {}, request)
+        assert(response[:status] == 503, "expected peer 5xx activity responses to remain recoverable broker results")
+        log = log_output.string
+        assert(log.include?("failing-peer") && log.include?("/activity") && log.include?("status=503") &&
+               log.include?("treating as recoverable"),
+               "expected peer activity failure logs to include safe peer, path, status, and recovery context")
+        assert(!log.include?("super-secret"), "expected peer activity failure logs to omit credentials")
       end
     end
   end
@@ -4393,6 +4469,13 @@ module RemoteServerTest
            js[:body].include?('done: "success"') &&
            js[:body].include?('fail: "danger"'),
            "expected one semantic mapping for legacy product status classes")
+    assert(js[:body].include?("function agentStatusBadge") &&
+           js[:body].include?('class="agent-status-icon" aria-hidden="true"') &&
+           js[:body].include?("agentStatusBadge(agent") &&
+           helpers_js[:body].include?('return "⏸️"'.b) &&
+           helpers_js[:body].include?('return "✅"'.b) &&
+           helpers_js[:body].include?('return "🚫"'.b),
+           "expected agent status surfaces to pair accessible text with the requested status icons")
     assert(js[:body].scan("statusBadge(").length >= 25 &&
            js[:body].scan("statusMarkAttributes(").length >= 15,
            "expected representative agent, schedule, setup, project, and diff states to use the semantic status contract")
@@ -4495,6 +4578,12 @@ module RemoteServerTest
            js[:body].include?("state.activityAppliedSequence") &&
            js[:body].include?("syncUnreadAlert();"),
            "expected activity polling to reject stale responses and update the logo without a page render")
+    assert(js[:body].include?("REMOTE_HELPERS.mergeActivityServers") &&
+           js[:body].include?("Peer activity fetch degraded") &&
+           js[:body].include?("retrying automatically") &&
+           js[:body].include?('return "Degraded"') &&
+           js[:body].include?("server-activity-error"),
+           "expected peer activity 5xx failures to degrade independently with an automatic retry signal")
     assert(js[:body].include?("window.TychoRemoteHelpers"),
            "expected the main Remote UI script to use the helper namespace")
     assert(js[:body].include?('updateViaCache: "none"'),
@@ -4565,7 +4654,7 @@ module RemoteServerTest
     assert(js[:body].include?("kv-copy-button"),
            "expected copyable key/value rows to render a copy control")
     assert(js[:body].include?('["Raw log", agent.log_path]') &&
-           js[:body].include?("settings.map(([label, value]) => copyableKv(label, value))"),
+           js[:body].include?('label === "Status" ? agentStatusKv(agent, { copyable: true }) : copyableKv(label, value)'),
            "expected Conversation settings rows to be copyable")
     assert(js[:body].include?('copyableKv("Path", project.path)') &&
            js[:body].include?('copyableKv("Templates",'),
@@ -4681,7 +4770,7 @@ module RemoteServerTest
     assert(js[:body].scan("window.confirm").length == 1,
            "expected window.confirm to remain only as the unsupported-browser fallback")
     assert(js[:body].include?('confirmLabel: "Remove response style"') &&
-           js[:body].include?('confirmLabel: "Delete schedule"') &&
+           js[:body].include?('confirmLabel: agent ? "Remove schedule" : "Delete schedule"') &&
            js[:body].include?('confirmLabel: "Delete attachment"'),
            "expected representative destructive workflows to use explicit confirmation labels")
     assert(helpers_js[:body].include?("function parseBackToRoute"),
@@ -5045,6 +5134,11 @@ module RemoteServerTest
            js[:body].include?('label: "Run now"') &&
            js[:body].include?('const toggleAction = blocked ? "resume" : "pause"'),
            "expected scheduled agent headers to expose run and pause/resume controls")
+    assert(js[:body].include?('label: "Remove schedule"') &&
+           js[:body].include?("data-remove-agent-schedule") &&
+           js[:body].include?("Schedule removed; conversation kept") &&
+           js[:body].include?("The agent and its full session history will remain available"),
+           "expected scheduled conversations to remove automation with confirmed history-preserving UX")
     assert(js[:body].include?("data-new-schedule"),
            "expected Remote UI to expose schedule creation")
     assert(js[:body].include?("${renderScheduleDaemonActions(daemon, schedules)}") &&
@@ -5402,9 +5496,10 @@ module RemoteServerTest
            js[:body].include?("function transplantPreservedPollContent") &&
            js[:body].include?("data-preserve-poll-content"),
            "expected scheduled polling to retain unchanged attachment content DOM")
-    assert(js[:body].include?("detailRevision !== catalogRevision") &&
-           js[:body].include?("delete state.agentDetails[agent.key]"),
-           "expected catalog revision changes to invalidate stale agent attachment details")
+    assert(js[:body].include?("REMOTE_HELPERS.reconcileAgentDetail(detail, agent)") &&
+           js[:body].include?("focusedAgent?.detail_stale") &&
+           js[:body].include?("await ensureAgentDetail(focusedAgent.key)"),
+           "expected catalog revision changes to retain attachments while refreshing stale focused details")
     assert(js[:body].include?("function preserveWorkspaceDuringPoll") &&
            js[:body].include?("if (options.forceAttachment) return false") &&
            js[:body].include?("if (options.force && !options.preserveFocusedWorkspace) return false") &&

--- a/test/remote_ui_state_reconciliation_test.rb
+++ b/test/remote_ui_state_reconciliation_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RemoteUIStateReconciliationTest
+  module_function
+
+  ROOT = File.expand_path("..", __dir__)
+  HELPERS_PATH = File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app_helpers.js")
+
+  def run!
+    script = <<~'JAVASCRIPT'
+      const fs = require("fs");
+      const vm = require("vm");
+      const context = { window: {}, URL, URLSearchParams };
+      vm.createContext(context);
+      vm.runInContext(fs.readFileSync(process.argv[1], "utf8"), context);
+
+      const helpers = context.window.TychoRemoteHelpers;
+      const attachment = { id: "report", type: "file", path: "/tmp/report.md" };
+      const detail = { key: "agent-1", revision: "old", attachments: [attachment], workspace: "/tmp/work" };
+      const catalog = { key: "agent-1", revision: "new", status: "succeeded", summary: "Done" };
+      const reconciled = helpers.reconcileAgentDetail(detail, catalog);
+
+      if (reconciled.attachments?.[0]?.id !== "report") {
+        throw new Error("catalog reconciliation dropped existing detail attachments");
+      }
+      if (reconciled.revision !== "new" || reconciled.status !== "succeeded" || reconciled.detail_stale !== true) {
+        throw new Error(`catalog reconciliation did not mark the merged detail stale: ${JSON.stringify(reconciled)}`);
+      }
+
+      const statusChecks = [
+        ["stopped", "⏸️"],
+        ["paused", "⏸️"],
+        ["succeeded", "✅"],
+        ["success", "✅"],
+        ["failed", "🚫"],
+        ["cancelled", "🚫"],
+        ["blocked", "🚫"],
+        ["running", ""],
+      ];
+      for (const [status, expected] of statusChecks) {
+        const actual = helpers.agentStatusIcon(status);
+        if (actual !== expected) throw new Error(`${status}: expected ${expected}, got ${actual}`);
+      }
+
+      const activityServers = helpers.mergeActivityServers(
+        [
+          { key: "healthy", ready: true, agents: [{ key: "healthy-old" }] },
+          { key: "failing", ready: true, agents: [{ key: "retained" }] },
+        ],
+        [
+          { serverKey: "healthy", ready: true, revision: "2", agents: [{ key: "healthy-new" }] },
+          { serverKey: "failing", failed: true, status: 503, retryAfterMs: 3000, error: "Activity unavailable" },
+        ]
+      );
+      if (activityServers[0].agents[0].key !== "healthy-new") {
+        throw new Error("failing peer prevented a healthy peer activity update");
+      }
+      if (activityServers[1].agents[0].key !== "retained" || activityServers[1].ready !== false ||
+          activityServers[1].activity_status !== 503 || activityServers[1].activity_retry_after_ms !== 3000) {
+        throw new Error(`recoverable peer failure lost stale activity or retry context: ${JSON.stringify(activityServers[1])}`);
+      }
+    JAVASCRIPT
+
+    _stdout, stderr, status = Open3.capture3("node", "-e", script, HELPERS_PATH, chdir: ROOT)
+    raise "Remote UI state reconciliation regression failed: #{stderr.strip}" unless status.success?
+
+    puts "remote_ui_state_reconciliation_test: ok"
+  end
+end
+
+RemoteUIStateReconciliationTest.run! if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary

- isolate remote activity HTTP 5xx failures per peer, keep healthy activity flowing, retain stale peer data, show automatic-retry degradation, and log safe peer/status context
- remove a scheduled conversation's schedule transactionally while preserving the agent, transcript, attachments, and native session for ordinary prompts and runs
- preserve detail-only attachment state during catalog reconciliation and refresh stale focused detail without letting older detail overwrite live activity fields
- add accessible status icons across Remote UI and TUI surfaces: ⏸️ paused/stopped, ✅ succeeded, and 🚫 failed/cancelled/blocked

## Root cause for attachment disappearance

Resource polling deleted the cached full agent detail whenever the lightweight catalog revision changed. The focused conversation could then render from catalog-only state, which has no attachments, until navigation or reload fetched the full detail again. Reconciliation now preserves detail-only fields, marks the detail stale, refetches it on the focused route, and reapplies the live catalog status fields.

## Validation

- `mise x ruby@3.4.7 -- bin/test`
- `bin/remote-ui-smoke`
- `TYCHO_REMOTE_UI_SMOKE_RENDERING_ONLY=1 bin/remote-ui-smoke`
- `git diff --check`

The full isolated Chrome/Playwright smoke covers schedule-removal confirmation, attachment persistence across polling/navigation, peer degradation with healthy-peer updates, and status-icon text/accessibility behavior.

## Fizzy cards

- [#133 — Handle 5xx errors when fetching activities from other servers](https://fizzy.startkit.tech/1/cards/133)
- [#134 — Allow removing an agent schedule](https://fizzy.startkit.tech/1/cards/134)
- [#136 — Investigate attachments disappearing until page refresh](https://fizzy.startkit.tech/1/cards/136)
- [#138 — Use icons for agent statuses](https://fizzy.startkit.tech/1/cards/138)
