### PR TITLE
Refine Remote UI agent status icons

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1097,12 +1097,13 @@ def write_smoke_script(path)
         }
         const agentStatusIconContract = await page.evaluate(() => {
           return [
-            ["stopped", "circlePause", "Stopped"],
-            ["succeeded", "circleCheck", "Succeeded"],
-            ["failed", "circleX", "Failed"],
-            ["cancelled", "circleX", "Cancelled"],
-            ["blocked", "circleX", "Blocked"],
-          ].map(([status, iconName, label]) => {
+            ["stopped", "pause", "Stopped", "rect[x='6'][y='4'][width='4'][height='16'][rx='1']", "need"],
+            ["succeeded", "check", "Succeeded", "path[d='M20 6 9 17l-5-5']", "done"],
+            ["failed", "ban", "Failed", "path[d='m4.9 4.9 14.2 14.2']", "fail"],
+            ["cancelled", "ban", "Cancelled", "path[d='m4.9 4.9 14.2 14.2']", "fail"],
+            ["blocked", "ban", "Blocked", "path[d='m4.9 4.9 14.2 14.2']", "fail"],
+            ["no_action_needed", "check", "No Action Needed", "path[d='M20 6 9 17l-5-5']", "detail"],
+          ].map(([status, iconName, label, iconPath, className]) => {
             const host = document.createElement("div");
             host.innerHTML = agentStatusBadge({ status });
             document.body.append(host);
@@ -1112,25 +1113,31 @@ def write_smoke_script(path)
               status,
               iconName: agentStatusIconName(status),
               hasSvg: Boolean(mark?.querySelector("svg")),
-              hasLucideCircle: Boolean(mark?.querySelector("circle[cx='12'][cy='12'][r='10']")),
+              hasOfficialPath: Boolean(mark?.querySelector(iconPath)),
               label: mark?.getAttribute("aria-label"),
               title: mark?.getAttribute("title"),
               visibleText: mark?.textContent.trim(),
               hasBadge: Boolean(host.querySelector(".agent-status-badge, .ui-badge, .pill, .chip")),
               border: style?.borderTopStyle,
               background: style?.backgroundColor,
+              color: style?.color,
               expectedIconName: iconName,
               expectedLabel: label,
+              expectedClassName: className,
+              className: mark?.className,
             };
             host.remove();
             return result;
           });
         });
+        const noActionIcon = agentStatusIconContract.find((item) => item.status === "no_action_needed");
+        const succeededIcon = agentStatusIconContract.find((item) => item.status === "succeeded");
         if (agentStatusIconContract.some((item) =>
-          item.iconName !== item.expectedIconName || !item.hasSvg || !item.hasLucideCircle ||
+          item.iconName !== item.expectedIconName || !item.hasSvg || !item.hasOfficialPath ||
           item.label !== item.expectedLabel || item.title !== item.expectedLabel || item.visibleText ||
-          item.hasBadge || item.border !== "none" || item.background !== "rgba(0, 0, 0, 0)")) {
-          throw new Error(`Agent status icons lost their Lucide, accessibility, or unboxed treatment: ${JSON.stringify(agentStatusIconContract)}`);
+          item.hasBadge || item.border !== "none" || item.background !== "rgba(0, 0, 0, 0)" ||
+          !item.className?.includes(item.expectedClassName)) || noActionIcon?.color === succeededIcon?.color) {
+          throw new Error(`Agent status icons lost their exact Lucide, grey no-action, accessibility, or unboxed treatment: ${JSON.stringify(agentStatusIconContract)}`);
         }
         const degradedActivityContract = await page.evaluate(() => {
           const merged = window.TychoRemoteHelpers.mergeActivityServers(
@@ -4964,7 +4971,7 @@ def write_smoke_script(path)
             !focusedStatusSyncContract.before.steadyActionFocused ||
             focusedStatusSyncContract.after.status !== "" ||
             focusedStatusSyncContract.after.statusIconLabel !== "Succeeded" ||
-            focusedStatusSyncContract.after.statusIconName !== "circleCheck" ||
+            focusedStatusSyncContract.after.statusIconName !== "check" ||
             focusedStatusSyncContract.after.visibleStatusText !== "" ||
             focusedStatusSyncContract.after.sendPrompt !== "Send prompt" ||
             !focusedStatusSyncContract.after.sendPromptFocused ||

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1097,28 +1097,40 @@ def write_smoke_script(path)
         }
         const agentStatusIconContract = await page.evaluate(() => {
           return [
-            ["stopped", "⏸️", "Stopped"],
-            ["succeeded", "✅", "Succeeded"],
-            ["failed", "🚫", "Failed"],
-            ["cancelled", "🚫", "Cancelled"],
-            ["blocked", "🚫", "Blocked"],
-          ].map(([status, icon, label]) => {
+            ["stopped", "circlePause", "Stopped"],
+            ["succeeded", "circleCheck", "Succeeded"],
+            ["failed", "circleX", "Failed"],
+            ["cancelled", "circleX", "Cancelled"],
+            ["blocked", "circleX", "Blocked"],
+          ].map(([status, iconName, label]) => {
             const host = document.createElement("div");
             host.innerHTML = agentStatusBadge({ status });
-            const badge = host.querySelector(".agent-status-badge");
-            const mark = badge?.querySelector(".agent-status-icon");
-            return {
+            document.body.append(host);
+            const mark = host.querySelector(".agent-status-icon");
+            const style = mark ? getComputedStyle(mark) : null;
+            const result = {
               status,
-              icon: mark?.textContent,
-              decorative: mark?.getAttribute("aria-hidden"),
-              labelPresent: badge?.textContent.includes(label),
-              expectedIcon: icon,
+              iconName: agentStatusIconName(status),
+              hasSvg: Boolean(mark?.querySelector("svg")),
+              hasLucideCircle: Boolean(mark?.querySelector("circle[cx='12'][cy='12'][r='10']")),
+              label: mark?.getAttribute("aria-label"),
+              title: mark?.getAttribute("title"),
+              visibleText: mark?.textContent.trim(),
+              hasBadge: Boolean(host.querySelector(".agent-status-badge, .ui-badge, .pill, .chip")),
+              border: style?.borderTopStyle,
+              background: style?.backgroundColor,
+              expectedIconName: iconName,
+              expectedLabel: label,
             };
+            host.remove();
+            return result;
           });
         });
         if (agentStatusIconContract.some((item) =>
-          item.icon !== item.expectedIcon || item.decorative !== "true" || !item.labelPresent)) {
-          throw new Error(`Agent status icons lost their text or accessibility contract: ${JSON.stringify(agentStatusIconContract)}`);
+          item.iconName !== item.expectedIconName || !item.hasSvg || !item.hasLucideCircle ||
+          item.label !== item.expectedLabel || item.title !== item.expectedLabel || item.visibleText ||
+          item.hasBadge || item.border !== "none" || item.background !== "rgba(0, 0, 0, 0)")) {
+          throw new Error(`Agent status icons lost their Lucide, accessibility, or unboxed treatment: ${JSON.stringify(agentStatusIconContract)}`);
         }
         const degradedActivityContract = await page.evaluate(() => {
           const merged = window.TychoRemoteHelpers.mergeActivityServers(
@@ -4921,8 +4933,9 @@ def write_smoke_script(path)
               before,
               after: {
                 status: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
-                statusIcon: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.textContent.trim(),
-                statusIconHidden: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("aria-hidden"),
+                statusIconLabel: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("aria-label"),
+                statusIconName: agentStatusIconName("succeeded"),
+                visibleStatusText: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
                 sendPrompt: document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] button[type="submit"]`)?.textContent.trim(),
                 sendPromptFocused: document.activeElement === document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] button[type="submit"]`),
               },
@@ -4949,9 +4962,10 @@ def write_smoke_script(path)
             focusedStatusSyncContract.before.action !== "Stop agent" ||
             !focusedStatusSyncContract.before.steadyActionPreserved ||
             !focusedStatusSyncContract.before.steadyActionFocused ||
-            focusedStatusSyncContract.after.status !== "✅Succeeded" ||
-            focusedStatusSyncContract.after.statusIcon !== "✅" ||
-            focusedStatusSyncContract.after.statusIconHidden !== "true" ||
+            focusedStatusSyncContract.after.status !== "" ||
+            focusedStatusSyncContract.after.statusIconLabel !== "Succeeded" ||
+            focusedStatusSyncContract.after.statusIconName !== "circleCheck" ||
+            focusedStatusSyncContract.after.visibleStatusText !== "" ||
             focusedStatusSyncContract.after.sendPrompt !== "Send prompt" ||
             !focusedStatusSyncContract.after.sendPromptFocused ||
             focusedStatusSyncContract.conversationReads !== 0 ||

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -4003,20 +4003,39 @@ def write_smoke_script(path)
         await page.waitForSelector(".agent-row[data-open-agent]", { state: "visible", timeout: 10_000 });
         const scheduledAgentListStatus = await page.evaluate((key) => {
           const row = Array.from(document.querySelectorAll(".agent-row[data-open-agent]")).find((item) => item.dataset.openAgent === key);
-          const icon = row?.querySelector(".status-mark");
-          const label = row?.querySelector(".pill.info");
-          return {
-            found: Boolean(row && icon && label),
-            scheduleIcon: Boolean(icon?.querySelector('path[d="M8 2v4"]')),
+          const icon = row?.querySelector(":scope > .agent-status-icon");
+          const comparison = document.createElement("span");
+          comparison.className = "agent-status-icon";
+          document.body.append(comparison);
+          const mutedColor = getComputedStyle(comparison).color;
+          const result = {
+            found: Boolean(row && icon),
+            checkIcon: Boolean(icon?.querySelector('path[d="M20 6 9 17l-5-5"]')),
+            scheduleAffordance: Boolean(row?.querySelector('[data-agent-role="scheduled"]')),
+            scheduleStatusMark: Boolean(row?.querySelector(':scope > .status-mark path[d="M8 2v4"]')),
+            detailClass: icon?.classList.contains("detail"),
             iconColor: icon ? getComputedStyle(icon).color : "",
-            labelColor: label ? getComputedStyle(label).color : "",
+            mutedColor,
+            label: icon?.getAttribute("aria-label"),
+            title: icon?.getAttribute("title"),
+            visibleText: icon?.textContent.trim(),
+            hasBadge: Boolean(row?.querySelector(":scope > .pill, :scope > .chip, :scope > .ui-badge")),
           };
+          comparison.remove();
+          return result;
         }, agentKey);
-        if (!scheduledAgentListStatus.found || !scheduledAgentListStatus.scheduleIcon || scheduledAgentListStatus.iconColor !== scheduledAgentListStatus.labelColor) {
-          throw new Error(`Scheduled agent list icon does not match no-action status: ${JSON.stringify(scheduledAgentListStatus)}`);
+        if (!scheduledAgentListStatus.found || !scheduledAgentListStatus.checkIcon || !scheduledAgentListStatus.scheduleAffordance ||
+            scheduledAgentListStatus.scheduleStatusMark || !scheduledAgentListStatus.detailClass ||
+            scheduledAgentListStatus.iconColor !== scheduledAgentListStatus.mutedColor ||
+            scheduledAgentListStatus.label !== "No action" || scheduledAgentListStatus.title !== "No action" ||
+            scheduledAgentListStatus.visibleText || scheduledAgentListStatus.hasBadge) {
+          throw new Error(`Scheduled no-action agent row lost its muted standalone Check status: ${JSON.stringify(scheduledAgentListStatus)}`);
         }
         await page.evaluate((key) => {
-          scheduleForAgent(findAgent(key)).status = "stopped";
+          const agent = findAgent(key);
+          agent.last_result = "";
+          agent.status = "idle";
+          scheduleForAgent(agent).status = "stopped";
           state.renderedViewHtml = "";
           render();
         }, agentKey);

--- a/docs/design-system/DESIGN_SYSTEM.md
+++ b/docs/design-system/DESIGN_SYSTEM.md
@@ -175,7 +175,7 @@ Generated Remote UI markup uses `metadataBadge(label, "pill" | "chip")`. The sec
 | `success` | Healthy or completed state | Succeeded, scheduled, ready, clean, fresh |
 | `danger` | Failed, blocked, stopped, or invalid state | Blocked, failed, missing, stopped |
 
-Agent status badges keep their text label and add a decorative state icon where the outcome has one: `⏸️` for paused or stopped, `✅` for succeeded, and `🚫` for failed, cancelled, or blocked. The icon is `aria-hidden`; the visible label remains the accessible status.
+Remote UI agent outcomes use standalone Lucide status icons: `circlePause` for paused or stopped, `circleCheck` for succeeded, and `circleX` for failed, cancelled, or blocked. These indicators have an accessible name through `aria-label` and `title`, but no visible text, badge background, border, or padding. Terminal surfaces retain their plain status text and do not use emoji for these states.
 
 Visible labels carry the meaning. Color is reinforcement. Product status icons remain `aria-hidden` when an adjacent badge supplies the text. Neutral product states such as Idle, Fixed, and Read only still use `ui-status`; factual context uses `ui-metadata-badge`.
 

--- a/docs/design-system/DESIGN_SYSTEM.md
+++ b/docs/design-system/DESIGN_SYSTEM.md
@@ -175,7 +175,7 @@ Generated Remote UI markup uses `metadataBadge(label, "pill" | "chip")`. The sec
 | `success` | Healthy or completed state | Succeeded, scheduled, ready, clean, fresh |
 | `danger` | Failed, blocked, stopped, or invalid state | Blocked, failed, missing, stopped |
 
-Remote UI agent outcomes use standalone official Lucide status icons: `pause` for paused or stopped, `check` in the success color for succeeded or success, `ban` in the failure color for failed, cancelled, or blocked, and the same `check` shape in grey for no-action. These indicators have an accessible name through `aria-label` and `title`, but no visible text, badge background, border, or padding. Terminal surfaces retain their plain status text and do not use emoji for these states.
+Remote UI agent outcomes use standalone official Lucide status icons: `pause` for paused or stopped, `check` in the success color for succeeded or success, `ban` in the failure color for failed, cancelled, or blocked, and the same `check` shape in grey for no-action. These indicators have an accessible name through `aria-label` and `title`, but no visible text, badge background, border, or padding. Scheduled agent rows give terminal outcomes the primary icon slot and retain scheduling as a separate named icon. Terminal surfaces retain their plain status text and do not use emoji for these states.
 
 Visible labels carry the meaning. Color is reinforcement. Product status icons remain `aria-hidden` when an adjacent badge supplies the text. Neutral product states such as Idle, Fixed, and Read only still use `ui-status`; factual context uses `ui-metadata-badge`.
 

--- a/docs/design-system/DESIGN_SYSTEM.md
+++ b/docs/design-system/DESIGN_SYSTEM.md
@@ -175,7 +175,7 @@ Generated Remote UI markup uses `metadataBadge(label, "pill" | "chip")`. The sec
 | `success` | Healthy or completed state | Succeeded, scheduled, ready, clean, fresh |
 | `danger` | Failed, blocked, stopped, or invalid state | Blocked, failed, missing, stopped |
 
-Remote UI agent outcomes use standalone Lucide status icons: `circlePause` for paused or stopped, `circleCheck` for succeeded, and `circleX` for failed, cancelled, or blocked. These indicators have an accessible name through `aria-label` and `title`, but no visible text, badge background, border, or padding. Terminal surfaces retain their plain status text and do not use emoji for these states.
+Remote UI agent outcomes use standalone official Lucide status icons: `pause` for paused or stopped, `check` in the success color for succeeded or success, `ban` in the failure color for failed, cancelled, or blocked, and the same `check` shape in grey for no-action. These indicators have an accessible name through `aria-label` and `title`, but no visible text, badge background, border, or padding. Terminal surfaces retain their plain status text and do not use emoji for these states.
 
 Visible labels carry the meaning. Color is reinforcement. Product status icons remain `aria-hidden` when an adjacent badge supplies the text. Neutral product states such as Idle, Fixed, and Read only still use `ui-status`; factual context uses `ui-metadata-badge`.
 

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -2566,17 +2566,29 @@ select {
   font-weight: var(--ds-weight-medium);
 }
 
-.kv .agent-status-icon + span,
-.agent-reference-copy .agent-status-icon + span {
-  margin-left: 4px;
+.agent-status-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
 }
 
-.agent-status-badge .agent-status-icon + span {
-  margin-left: 0;
+.agent-status-icon .ui-icon {
+  width: 18px;
+  height: 18px;
 }
 
-.agent-status-badge {
-  gap: 4px;
+.agent-status-icon.done {
+  color: var(--ok);
+}
+
+.agent-status-icon.fail {
+  color: var(--danger);
+}
+
+.agent-status-icon.need {
+  color: var(--warning);
 }
 
 .status-mark[data-intent="warning"],

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -124,6 +124,26 @@ const CODE_LANGUAGE_BY_MIME = {
 const REMOTE_HELPERS = window.TychoRemoteHelpers;
 
 const ICONS = {
+  circlePause: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10"></circle>
+      <path d="M10 15V9"></path>
+      <path d="M14 15V9"></path>
+    </svg>
+  `,
+  circleCheck: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10"></circle>
+      <path d="m9 12 2 2 4-4"></path>
+    </svg>
+  `,
+  circleX: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10"></circle>
+      <path d="m15 9-6 6"></path>
+      <path d="m9 9 6 6"></path>
+    </svg>
+  `,
   archive: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <rect width="20" height="5" x="2" y="3" rx="1"></rect>
@@ -12396,12 +12416,14 @@ function statusLabel(agent) {
 }
 
 function statusClass(agent) {
+  const status = String(agent?.status || "").toLowerCase();
   if (resourceIsStale(agent)) return "detail";
   if (agent.awaiting_input || agent.unread) return "need";
   if (agent.running) return "running";
-  if (agent.blocked || agent.status === "failed") return "fail";
+  if (agent.blocked || ["failed", "error", "cancelled", "canceled", "blocked"].includes(status)) return "fail";
+  if (["paused", "stopped"].includes(status)) return "need";
   if (agent.last_result === "no action") return "info";
-  if (agent.status === "succeeded" || agent.last_result === "success") return "done";
+  if (["succeeded", "success", "completed"].includes(status) || agent.last_result === "success") return "done";
   return "detail";
 }
 
@@ -12414,26 +12436,46 @@ function agentDisplayedStatusKey(agent) {
   return String(agent?.status || "idle");
 }
 
-function agentStatusIcon(agent) {
-  return REMOTE_HELPERS.agentStatusIcon(agentDisplayedStatusKey(agent));
+function agentStatusIconName(status) {
+  switch (String(status || "").toLowerCase()) {
+    case "paused":
+    case "stopped":
+      return "circlePause";
+    case "completed":
+    case "succeeded":
+    case "success":
+      return "circleCheck";
+    case "blocked":
+    case "cancelled":
+    case "canceled":
+    case "failed":
+    case "error":
+      return "circleX";
+    default:
+      return "";
+  }
 }
 
-function agentStatusInline(agent) {
-  return statusValueInline(agentDisplayedStatusKey(agent), statusLabel(agent));
+function agentStatusIcon(status, label = titleFromKey(status)) {
+  const iconName = agentStatusIconName(status);
+  if (!iconName) return "";
+
+  const className = statusClass({ status });
+  return `<span class="agent-status-icon ${escapeAttr(className)}" data-intent="${escapeAttr(statusIntent(className))}" role="img" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}">${iconSvg(iconName)}</span>`;
 }
 
 function statusValueInline(status, label = titleFromKey(status)) {
-  const icon = REMOTE_HELPERS.agentStatusIcon(status);
-  return `${icon ? `<span class="agent-status-icon" aria-hidden="true">${escapeHtml(icon)}</span>` : ""}<span>${escapeHtml(label)}</span>`;
+  return agentStatusIcon(status, label) || `<span>${escapeHtml(label)}</span>`;
 }
 
 function agentStatusBadge(agent, kind = "pill") {
   const legacyClass = statusClass(agent);
-  return `<span class="${escapeAttr(kind)} ${escapeAttr(legacyClass)} ui-badge ui-status agent-status-badge" data-intent="${escapeAttr(statusIntent(legacyClass))}">${agentStatusInline(agent)}</span>`;
+  return agentStatusIcon(agentDisplayedStatusKey(agent), statusLabel(agent)) ||
+    `<span class="${escapeAttr(kind)} ${escapeAttr(legacyClass)} ui-badge ui-status agent-status-badge" data-intent="${escapeAttr(statusIntent(legacyClass))}">${escapeHtml(statusLabel(agent))}</span>`;
 }
 
 function agentStatusKv(agent, options = {}) {
-  return kv("Status", statusLabel(agent), { ...options, valueHtml: agentStatusInline(agent) });
+  return kv("Status", statusLabel(agent), { ...options, valueHtml: statusValueInline(agentDisplayedStatusKey(agent), statusLabel(agent)) });
 }
 
 function statusIntent(className) {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -8525,15 +8525,16 @@ function renderAgentCard(agent) {
 
 function renderAgentRow(agent, options = {}) {
   if (state.bulkArchiveMode) return renderSelectableAgentRow(agent, options);
+  const statusIcon = agentListStatusIcon(agent);
 
   return `
     <button class="agent-row ${options.delegationDepth ? "delegated-agent-row" : ""} ${resourceStaleClass(agent)}" style="--delegation-depth:${Number(options.delegationDepth || 0)}" type="button" data-open-agent="${escapeAttr(agent.key)}" aria-label="Open ${escapeAttr(agent.name || agent.key)}, ${agent.archived ? "archived, read-only, " : ""}${escapeAttr(statusLabel(agent))}${options.delegationDepth ? ", delegated agent" : ""}">
-      <span class="status-mark ${scheduledAgentIconStatusClass(agent)}" ${statusMarkAttributes(scheduledAgentIconStatusClass(agent))} aria-hidden="true">${iconSvg(agentIconName(agent))}</span>
+      ${statusIcon || agentIdentityIcon(agent)}
       <div class="row-title">
         <strong>${agentNameHtml(agent)}</strong>
         <span>${agentListSubtextHtml(agent, options)}</span>
       </div>
-      ${agentStatusBadge(agent)}
+      ${statusIcon ? "" : agentStatusBadge(agent)}
     </button>
   `;
 }
@@ -11414,7 +11415,8 @@ function showAllAgentsInSwitcher() {
 
 function renderSwitcherAgentRow(agent, index) {
   const selected = index === state.unreadPanelSelectedIndex;
-  const statusText = agentStatusBadge(agent);
+  const statusIcon = agentListStatusIcon(agent);
+  const statusText = statusIcon ? "" : agentStatusBadge(agent);
   const linkedCount = linkedAgentReferences(agent).length;
   const linkedSymbol = linkedCount
     ? `<span class="switcher-linked-symbol" data-show-linked-agents="${escapeAttr(agent.key)}" aria-label="Show linked agents" title="Show linked agents">${iconSvg("link")}</span>`
@@ -11422,7 +11424,7 @@ function renderSwitcherAgentRow(agent, index) {
 
   return `
     <button class="agent-row switcher-agent-row ${selected ? "selected" : ""}" type="button" data-open-agent="${escapeAttr(agent.key)}" data-switcher-index="${index}" ${selected ? "aria-selected=\"true\"" : ""}>
-      <span class="status-mark ${scheduledAgentIconStatusClass(agent)}" ${statusMarkAttributes(scheduledAgentIconStatusClass(agent))} aria-hidden="true">${iconSvg(agentIconName(agent))}</span>
+      ${statusIcon || agentIdentityIcon(agent)}
       <div class="row-title">
         <strong class="switcher-agent-title-line">${agentNameHtml(agent)}${linkedSymbol}</strong>
         <span>${agentListSubtextHtml(agent)}</span>
@@ -11432,8 +11434,13 @@ function renderSwitcherAgentRow(agent, index) {
   `;
 }
 
-function agentIconName(agent) {
-  return agent?.scheduled || agent?.schedule_key ? "calendarCheck2" : "robot";
+function agentListStatusIcon(agent) {
+  return agentStatusIcon(agentDisplayedStatusKey(agent), statusLabel(agent));
+}
+
+function agentIdentityIcon(agent) {
+  const className = scheduledAgentIconStatusClass(agent);
+  return `<span class="status-mark ${escapeAttr(className)}" ${statusMarkAttributes(className)} aria-hidden="true">${iconSvg(agent?.scheduled || agent?.schedule_key ? "calendarCheck2" : "robot")}</span>`;
 }
 
 function agentNameHtml(agent) {
@@ -11453,6 +11460,9 @@ function agentNameHtml(agent) {
 function agentRoleIcons(agent) {
   const delegation = agent?.delegation || {};
   const roles = [];
+  if (agent?.scheduled || agent?.schedule_key) {
+    roles.push({ className: "scheduled", icon: "calendarCheck2", label: "Scheduled agent", role: "scheduled" });
+  }
   if (Array.isArray(delegation.children) && delegation.children.length) {
     roles.push({ className: "orchestrator", icon: "hardHat", label: "Orchestrator", role: "orchestrator" });
   }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -124,24 +124,21 @@ const CODE_LANGUAGE_BY_MIME = {
 const REMOTE_HELPERS = window.TychoRemoteHelpers;
 
 const ICONS = {
-  circlePause: `
+  pause: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="10"></circle>
-      <path d="M10 15V9"></path>
-      <path d="M14 15V9"></path>
+      <rect width="4" height="16" x="14" y="4" rx="1"></rect>
+      <rect width="4" height="16" x="6" y="4" rx="1"></rect>
     </svg>
   `,
-  circleCheck: `
+  check: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="10"></circle>
-      <path d="m9 12 2 2 4-4"></path>
+      <path d="M20 6 9 17l-5-5"></path>
     </svg>
   `,
-  circleX: `
+  ban: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="10"></circle>
-      <path d="m15 9-6 6"></path>
-      <path d="m9 9 6 6"></path>
+      <path d="m4.9 4.9 14.2 14.2"></path>
     </svg>
   `,
   archive: `
@@ -12440,17 +12437,18 @@ function agentStatusIconName(status) {
   switch (String(status || "").toLowerCase()) {
     case "paused":
     case "stopped":
-      return "circlePause";
+      return "pause";
     case "completed":
     case "succeeded":
     case "success":
-      return "circleCheck";
+    case "no_action_needed":
+      return "check";
     case "blocked":
     case "cancelled":
     case "canceled":
     case "failed":
     case "error":
-      return "circleX";
+      return "ban";
     default:
       return "";
   }

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -490,26 +490,6 @@
     };
   }
 
-  function agentStatusIcon(status) {
-    switch (String(status || "").toLowerCase()) {
-      case "paused":
-      case "stopped":
-        return "⏸️";
-      case "completed":
-      case "succeeded":
-      case "success":
-        return "✅";
-      case "blocked":
-      case "cancelled":
-      case "canceled":
-      case "failed":
-      case "error":
-        return "🚫";
-      default:
-        return "";
-    }
-  }
-
   function mergeActivityServers(servers, peerResults) {
     const peersByKey = new Map(
       (Array.isArray(peerResults) ? peerResults : []).filter(Boolean).map((peer) => [peer.serverKey, peer])
@@ -539,7 +519,6 @@
 
   global.TychoRemoteHelpers = Object.freeze({
     agentComposerState,
-    agentStatusIcon,
     agentActivityTimestamp,
     agentSortUsesProjectGroups,
     attachmentBlobPath,

--- a/lib/hq/ui/rendering/styles.rb
+++ b/lib/hq/ui/rendering/styles.rb
@@ -35,12 +35,12 @@ module HQ
           pending: "\u{f111}",
           dim: "\u{f111}",
           running: "\u{f0150}",
-          succeeded: "✅",
-          failed: "🚫",
-          stopped: "⏸️",
+          succeeded: "\u{f058}",
+          failed: "\u{f057}",
+          stopped: "\u{f04d}",
           awaiting_input: "\u{f059}",
           partial: "\u{f0c8}",
-          blocked: "🚫",
+          blocked: "\u{f05e}",
           unknown: "\u{f111}"
         }.freeze
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5108,14 +5108,16 @@ module RemoteServerTest
            "expected inline schedules to avoid unavailable message-file requests")
     assert(js[:body].include?("calendarCheck2"),
            "expected Remote UI schedule surfaces to use the calendar-check-2 icon")
-    assert(js[:body].include?("function agentIconName") &&
-           js[:body].include?("? \"calendarCheck2\" : \"robot\""),
-           "expected Remote UI scheduled agent rows to use the schedule icon")
+    assert(js[:body].include?("function agentListStatusIcon") &&
+           js[:body].include?("function agentIdentityIcon") &&
+           js[:body].include?('label: "Scheduled agent", role: "scheduled"') &&
+           js[:body].include?("statusIcon || agentIdentityIcon(agent)"),
+           "expected scheduled agent rows to preserve scheduling without replacing terminal status icons")
     assert(js[:body].include?("function scheduledAgentIconStatusClass") &&
            js[:body].include?("if (!schedule) return statusClass(agent);") &&
            js[:body].include?('if (scheduleStatus === "stopped") return "fail";') &&
            js[:body].include?('if (scheduleStatus === "paused"') &&
-           js[:body].include?('status-mark ${scheduledAgentIconStatusClass(agent)}'),
+           js[:body].include?('status-mark ${escapeAttr(className)}'),
            "expected stopped and paused schedules to override associated agent icon colors")
     assert(js[:body].include?('class="schedule-details" data-state-key="schedule-now-details"'),
            "expected Remote UI schedule rows to be collapsed by default")

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4470,12 +4470,16 @@ module RemoteServerTest
            js[:body].include?('fail: "danger"'),
            "expected one semantic mapping for legacy product status classes")
     assert(js[:body].include?("function agentStatusBadge") &&
-           js[:body].include?('class="agent-status-icon" aria-hidden="true"') &&
+           js[:body].include?("function agentStatusIconName") &&
+           js[:body].include?('return "circlePause"') &&
+           js[:body].include?('return "circleCheck"') &&
+           js[:body].include?('return "circleX"') &&
+           js[:body].include?('role="img" aria-label="${escapeAttr(label)}"') &&
            js[:body].include?("agentStatusBadge(agent") &&
-           helpers_js[:body].include?('return "⏸️"'.b) &&
-           helpers_js[:body].include?('return "✅"'.b) &&
-           helpers_js[:body].include?('return "🚫"'.b),
-           "expected agent status surfaces to pair accessible text with the requested status icons")
+           !helpers_js[:body].include?("✅".b) &&
+           !helpers_js[:body].include?("⏸️".b) &&
+           !helpers_js[:body].include?("🚫".b),
+           "expected agent status surfaces to use accessible Lucide icons without emoji")
     assert(js[:body].scan("statusBadge(").length >= 25 &&
            js[:body].scan("statusMarkAttributes(").length >= 15,
            "expected representative agent, schedule, setup, project, and diff states to use the semantic status contract")

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4471,15 +4471,18 @@ module RemoteServerTest
            "expected one semantic mapping for legacy product status classes")
     assert(js[:body].include?("function agentStatusBadge") &&
            js[:body].include?("function agentStatusIconName") &&
-           js[:body].include?('return "circlePause"') &&
-           js[:body].include?('return "circleCheck"') &&
-           js[:body].include?('return "circleX"') &&
+           js[:body].include?('return "pause"') &&
+           js[:body].include?('return "check"') &&
+           js[:body].include?('return "ban"') &&
+           js[:body].include?('<path d="M20 6 9 17l-5-5"></path>') &&
+           js[:body].include?('<path d="m4.9 4.9 14.2 14.2"></path>') &&
+           js[:body].include?('case "no_action_needed":') &&
            js[:body].include?('role="img" aria-label="${escapeAttr(label)}"') &&
            js[:body].include?("agentStatusBadge(agent") &&
            !helpers_js[:body].include?("✅".b) &&
            !helpers_js[:body].include?("⏸️".b) &&
            !helpers_js[:body].include?("🚫".b),
-           "expected agent status surfaces to use accessible Lucide icons without emoji")
+           "expected agent status surfaces to use exact accessible Lucide icons without emoji")
     assert(js[:body].scan("statusBadge(").length >= 25 &&
            js[:body].scan("statusMarkAttributes(").length >= 15,
            "expected representative agent, schedule, setup, project, and diff states to use the semantic status contract")

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -16,7 +16,41 @@ module RemoteUIAssetSnapshotTest
     assert_delegation_ui_uses_typed_safe_references
     assert_delegation_callbacks_are_chronological_events
     assert_archived_agents_are_reference_only_and_read_only
+    assert_agent_status_icons_use_lucide_without_badges
     puts "remote_ui_asset_snapshot_test: ok"
+  end
+
+  def assert_agent_status_icons_use_lucide_without_badges
+    javascript = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.js"))
+    css = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.css"))
+    helpers = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app_helpers.js"))
+    required = [
+      "circlePause:",
+      "circleCheck:",
+      "circleX:",
+      'return "circlePause"',
+      'return "circleCheck"',
+      'return "circleX"',
+      'role="img" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}"',
+      "function agentStatusIcon(status, label",
+      ".agent-status-icon {"
+    ]
+    missing = required.reject { |fragment| javascript.include?(fragment) || css.include?(fragment) }
+    raise "missing Lucide status icon contract: #{missing.join(", ")}" unless missing.empty?
+
+    forbidden = ["✅", "⏸️", "🚫"]
+    present = forbidden.select { |emoji| javascript.include?(emoji) || helpers.include?(emoji) }
+    raise "status icons must not use emoji: #{present.join(", ")}" unless present.empty?
+
+    icon_renderer = javascript[/function agentStatusIcon\(status, label.*?^}/m]
+    raise "missing agent status indicator renderer" unless icon_renderer
+    raise "status icon renderer must not emit badge styling" if icon_renderer.include?("ui-badge")
+
+    icon_styles = css[/\.agent-status-icon \{.*?^}/m]
+    raise "missing standalone status icon styles" unless icon_styles
+    forbidden_styles = %w[background border padding border-radius]
+    styled = forbidden_styles.select { |property| icon_styles.include?(property) }
+    raise "status icon styles must not create a badge: #{styled.join(", ")}" unless styled.empty?
   end
 
   def assert_delegation_callbacks_are_chronological_events

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -35,6 +35,8 @@ module RemoteUIAssetSnapshotTest
       'return "check"',
       'return "ban"',
       'case "no_action_needed":',
+      "function agentListStatusIcon(agent)",
+      'label: "Scheduled agent", role: "scheduled"',
       ".agent-status-icon.done",
       ".agent-status-icon.fail",
       "color: var(--muted);",

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -25,18 +25,25 @@ module RemoteUIAssetSnapshotTest
     css = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.css"))
     helpers = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app_helpers.js"))
     required = [
-      "circlePause:",
-      "circleCheck:",
-      "circleX:",
-      'return "circlePause"',
-      'return "circleCheck"',
-      'return "circleX"',
+      "pause:",
+      "check:",
+      "ban:",
+      '<rect width="4" height="16" x="14" y="4" rx="1"></rect>',
+      '<path d="M20 6 9 17l-5-5"></path>',
+      '<path d="m4.9 4.9 14.2 14.2"></path>',
+      'return "pause"',
+      'return "check"',
+      'return "ban"',
+      'case "no_action_needed":',
+      ".agent-status-icon.done",
+      ".agent-status-icon.fail",
+      "color: var(--muted);",
       'role="img" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}"',
       "function agentStatusIcon(status, label",
       ".agent-status-icon {"
     ]
     missing = required.reject { |fragment| javascript.include?(fragment) || css.include?(fragment) }
-    raise "missing Lucide status icon contract: #{missing.join(", ")}" unless missing.empty?
+    raise "missing exact Lucide status icon contract: #{missing.join(", ")}" unless missing.empty?
 
     forbidden = ["✅", "⏸️", "🚫"]
     present = forbidden.select { |emoji| javascript.include?(emoji) || helpers.include?(emoji) }

--- a/test/remote_ui_state_reconciliation_test.rb
+++ b/test/remote_ui_state_reconciliation_test.rb
@@ -29,21 +29,6 @@ module RemoteUIStateReconciliationTest
         throw new Error(`catalog reconciliation did not mark the merged detail stale: ${JSON.stringify(reconciled)}`);
       }
 
-      const statusChecks = [
-        ["stopped", "⏸️"],
-        ["paused", "⏸️"],
-        ["succeeded", "✅"],
-        ["success", "✅"],
-        ["failed", "🚫"],
-        ["cancelled", "🚫"],
-        ["blocked", "🚫"],
-        ["running", ""],
-      ];
-      for (const [status, expected] of statusChecks) {
-        const actual = helpers.agentStatusIcon(status);
-        if (actual !== expected) throw new Error(`${status}: expected ${expected}, got ${actual}`);
-      }
-
       const activityServers = helpers.mergeActivityServers(
         [
           { key: "healthy", ready: true, agents: [{ key: "healthy-old" }] },

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -44,6 +44,7 @@ module RenderingTest
     assert_rendered_lines_fit_screen_width
     assert_list_sidebar_renders_agent_names
     assert_list_sidebar_renders_project_status_icons
+    assert_terminal_agent_status_icons_do_not_use_emoji
     assert_list_sidebar_scrolls_to_selected_agent
     assert_agent_unread_cursor_and_chat_clear
     assert_finished_agent_poll_marks_unread
@@ -121,6 +122,13 @@ module RenderingTest
     ENV["TYCHO_CONFIG_PATH"] = old_config_path if defined?(old_config_path)
     FileUtils.rm_rf(fixture_dir) if defined?(fixture_dir)
     FileUtils.rm_rf(TEST_LOGS_ROOT)
+  end
+
+  def assert_terminal_agent_status_icons_do_not_use_emoji
+    icons = HQ::UI::Rendering::Styles::STATUS_ICONS
+    %i[succeeded failed stopped blocked].each do |key|
+      assert(!["✅", "⏸️", "🚫"].include?(icons.fetch(key)), "expected #{key} TUI status to avoid emoji")
+    end
   end
 
   def write_rendering_config_fixture(dir)


### PR DESCRIPTION
## Summary
- replace completed-agent emoji treatments with standalone accessible Lucide SVG indicators
- remove badge chrome and visible outcome text from these icon treatments across Remote UI surfaces
- keep terminal status labels free of emoji and add regression coverage

## Verification
- `bin/test`
- `bundle exec ruby test/rendering_test.rb`
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke`

Fizzy card: https://fizzy.startkit.tech/1/cards/138
Follow-up to #79.