### PR TITLE
Add per-server Remote UI activity circuit breaker

### DIFF
--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -712,6 +712,7 @@ const state = {
   activityRequestSequence: 0,
   activityAppliedSequence: 0,
   activityRevision: null,
+  activityPollingFailures: new Map(),
   activityAgents: new Map(),
   activityReadyServerKeys: new Set(),
   pollDeferredUntil: 0,
@@ -1239,6 +1240,9 @@ function applyResourceCatalog(data) {
       : server;
   });
   const serverKeys = new Set(servers.map((server) => server.key));
+  state.activityPollingFailures.forEach((_failure, key) => {
+    if (!serverKeys.has(key)) state.activityPollingFailures.delete(key);
+  });
   state.activityReadyServerKeys.forEach((key) => {
     if (!serverKeys.has(key)) state.activityReadyServerKeys.delete(key);
   });
@@ -1892,11 +1896,12 @@ function scheduleAgentActivity(ms = document.hidden
 }
 
 async function pollAgentActivity() {
+  const options = arguments[0] || {};
   clearTimeout(state.activityTimer);
   state.activityTimer = null;
   const requestSequence = ++state.activityRequestSequence;
   try {
-    const activity = await loadAgentActivity();
+    const activity = await loadAgentActivity(options);
     applyAgentActivity(activity, requestSequence);
   } catch (_error) {
     // The full refresh owns connection state; activity polling remains silent.
@@ -1905,15 +1910,42 @@ async function pollAgentActivity() {
   }
 }
 
-async function loadAgentActivity() {
+function activityPollingFailureMessage(failure) {
+  const status = Number(failure?.status) || 0;
+  if (failure?.stopped) {
+    return `Activity unavailable (HTTP ${status}); automatic polling stopped after ${failure.failures} failed attempts. Use Refresh to retry`;
+  }
+  return `Activity unavailable (HTTP ${status}); retrying automatically (${failure.failures} of 3)`;
+}
+
+function stoppedActivityPollingResult(serverKey, failure) {
+  return {
+    serverKey,
+    failed: true,
+    stopped: true,
+    status: failure.status,
+    failureCount: failure.failures,
+    error: activityPollingFailureMessage(failure),
+  };
+}
+
+async function loadAgentActivity(options = {}) {
   const activity = await brokerGet("/servers/activity");
   const servers = Array.isArray(activity.servers) ? activity.servers : [];
   const peerResults = await Promise.all(servers.map(async (server) => {
     if (server.local) return null;
+    if (options.serverKey && server.key !== options.serverKey) return null;
+
+    const previousFailure = state.activityPollingFailures.get(server.key);
+    if (!REMOTE_HELPERS.shouldPollServerActivity(previousFailure, options)) {
+      return stoppedActivityPollingResult(server.key, previousFailure);
+    }
+
     const token = remoteServerToken(server.key);
     const headers = token ? { "X-Tycho-Remote-Server-Token": token } : {};
     try {
       const peer = await brokerGetWithHeaders(`/servers/${encodeURIComponent(server.key)}/activity`, headers);
+      REMOTE_HELPERS.clearActivityPollingFailure(state.activityPollingFailures, server.key);
       return {
         serverKey: server.key,
         revision: peer.revision,
@@ -1921,18 +1953,27 @@ async function loadAgentActivity() {
         agents: peer.agents,
       };
     } catch (error) {
-      const status = Number(error?.status) || 0;
-      if (status >= 500 && !String(error?.message || "").includes("rejected broker credentials")) {
+      if (REMOTE_HELPERS.activityFetchFailure(error)) {
+        const failure = REMOTE_HELPERS.nextActivityPollingFailure(previousFailure, error);
+        state.activityPollingFailures.set(server.key, failure);
         const retryAfterMs = document.hidden
           ? AGENT_ACTIVITY_POLL_INTERVALS.hiddenMs
           : AGENT_ACTIVITY_POLL_INTERVALS.visibleMs;
-        console.warn("Peer activity fetch degraded", { peer: server.key, status, retryAfterMs });
+        console.warn("Peer activity fetch degraded", {
+          peer: server.key,
+          status: failure.status,
+          failures: failure.failures,
+          stopped: failure.stopped,
+          retryAfterMs,
+        });
         return {
           serverKey: server.key,
           failed: true,
-          status,
-          retryAfterMs,
-          error: `Activity unavailable (HTTP ${status}); retrying automatically`,
+          stopped: failure.stopped,
+          status: failure.status,
+          failureCount: failure.failures,
+          retryAfterMs: failure.stopped ? 0 : retryAfterMs,
+          error: activityPollingFailureMessage(failure),
         };
       }
       return null;
@@ -1940,7 +1981,7 @@ async function loadAgentActivity() {
   }));
   const mergedServers = REMOTE_HELPERS.mergeActivityServers(servers, peerResults);
   const peerRevisions = peerResults.filter(Boolean).map((peer) =>
-    `${peer.serverKey}:${peer.failed ? `error-${peer.status}` : peer.revision || ""}`);
+    `${peer.serverKey}:${peer.failed ? `error-${peer.status}-${peer.failureCount || 0}-${peer.stopped ? "stopped" : "retrying"}` : peer.revision || ""}`);
   return {
     ...activity,
     revision: [activity.revision || "", ...peerRevisions].join(":"),
@@ -13943,16 +13984,29 @@ function handleViewClick(event) {
   const refreshServer = event.target.closest("[data-refresh-server]");
   if (refreshServer) {
     closeDetailsOverlay(refreshServer.closest("[data-server-action-menu]"));
-    requestServerResourceRefresh(refreshServer.dataset.refreshServer, { force: true })
-      .then(() => schedule())
+    const serverKey = refreshServer.dataset.refreshServer;
+    Promise.all([
+      requestServerResourceRefresh(serverKey, { force: true }),
+      pollAgentActivity({ manual: true, serverKey }),
+    ])
+      .then(() => {
+        render();
+        schedule();
+      })
       .catch((error) => showGrowl(error.message, "need"));
     return;
   }
 
   const refreshAllServers = event.target.closest("[data-refresh-all-servers]");
   if (refreshAllServers) {
-    requestAllServerResourceRefreshes({ force: true })
-      .then(() => schedule())
+    Promise.all([
+      requestAllServerResourceRefreshes({ force: true }),
+      pollAgentActivity({ manual: true }),
+    ])
+      .then(() => {
+        render();
+        schedule();
+      })
       .catch((error) => showGrowl(error.message, "need"));
     return;
   }
@@ -14525,7 +14579,10 @@ function handleViewClick(event) {
   }
 
   const refreshButton = event.target.closest("[data-refresh]");
-  if (refreshButton) refresh({ force: true });
+  if (refreshButton) {
+    refresh({ force: true });
+    pollAgentActivity({ manual: true }).then(() => render());
+  }
 
   const recentButton = event.target.closest("[data-go-recent]");
   if (recentButton) {

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -517,9 +517,36 @@
     });
   }
 
+  function activityFetchFailure(error) {
+    if (error?.name === "AbortError" || error?.code === "ABORT_ERR") return false;
+
+    const status = Number(error?.status) || 0;
+    return status >= 500 && !String(error?.message || "").includes("rejected broker credentials");
+  }
+
+  function nextActivityPollingFailure(previous, error, threshold = 3) {
+    if (!activityFetchFailure(error)) return previous || null;
+
+    const failures = (Number(previous?.failures) || 0) + 1;
+    return {
+      failures,
+      status: Number(error?.status) || 0,
+      stopped: failures >= threshold,
+    };
+  }
+
+  function shouldPollServerActivity(failure, options = {}) {
+    return options.manual === true || !failure?.stopped;
+  }
+
+  function clearActivityPollingFailure(failures, serverKey) {
+    failures?.delete?.(serverKey);
+  }
+
   global.TychoRemoteHelpers = Object.freeze({
     agentComposerState,
     agentActivityTimestamp,
+    activityFetchFailure,
     agentSortUsesProjectGroups,
     attachmentBlobPath,
     attachmentContentVersion,
@@ -532,6 +559,7 @@
     attachmentTargetLabel,
     attachmentTargetsMatch,
     backRouteValue,
+    clearActivityPollingFailure,
     compareAgentsBySort,
     compareDisplayText,
     compareQuickSwitchAgents,
@@ -543,6 +571,7 @@
     elementStateKey,
     markdownHeadingSlug,
     mergeActivityServers,
+    nextActivityPollingFailure,
     normalizeAttachmentTargetForMatch,
     normalizeDiffScope,
     normalizeAgentSort,
@@ -556,6 +585,7 @@
     safeLocalStorageRemove,
     safeLocalStorageSet,
     shouldPreserveControl,
+    shouldPollServerActivity,
     textSelectionFor,
   });
 })(window);

--- a/test/remote_ui_state_reconciliation_test.rb
+++ b/test/remote_ui_state_reconciliation_test.rb
@@ -46,6 +46,38 @@ module RemoteUIStateReconciliationTest
           activityServers[1].activity_status !== 503 || activityServers[1].activity_retry_after_ms !== 3000) {
         throw new Error(`recoverable peer failure lost stale activity or retry context: ${JSON.stringify(activityServers[1])}`);
       }
+
+      let failingCircuit = null;
+      failingCircuit = helpers.nextActivityPollingFailure(failingCircuit, { status: 503, message: "unavailable" });
+      if (failingCircuit.failures !== 1 || failingCircuit.stopped || !helpers.shouldPollServerActivity(failingCircuit)) {
+        throw new Error(`first activity failure did not keep automatic polling active: ${JSON.stringify(failingCircuit)}`);
+      }
+      failingCircuit = helpers.nextActivityPollingFailure(failingCircuit, { status: 503, message: "unavailable" });
+      failingCircuit = helpers.nextActivityPollingFailure(failingCircuit, { status: 503, message: "unavailable" });
+      if (failingCircuit.failures !== 3 || !failingCircuit.stopped || helpers.shouldPollServerActivity(failingCircuit)) {
+        throw new Error(`third activity failure did not stop only that server: ${JSON.stringify(failingCircuit)}`);
+      }
+      if (!helpers.shouldPollServerActivity(failingCircuit, { manual: true })) {
+        throw new Error("manual activity refresh could not retry a stopped server");
+      }
+      const failedManualCircuit = helpers.nextActivityPollingFailure(failingCircuit, { status: 503, message: "unavailable" });
+      if (!failedManualCircuit.stopped || helpers.shouldPollServerActivity(failedManualCircuit)) {
+        throw new Error("a failed manual activity refresh resumed automatic polling");
+      }
+
+      const healthyCircuit = helpers.nextActivityPollingFailure(null, { status: 503, message: "unavailable" });
+      if (!helpers.shouldPollServerActivity(healthyCircuit) || healthyCircuit.stopped) {
+        throw new Error("a failing peer stopped healthy peer activity polling");
+      }
+      if (helpers.nextActivityPollingFailure(failingCircuit, { name: "AbortError", status: 503 }) !== failingCircuit) {
+        throw new Error("aborted activity fetch changed the server failure state");
+      }
+      const failureMap = new Map([["failing", failingCircuit]]);
+      helpers.clearActivityPollingFailure(failureMap, "failing");
+      const recoveredCircuit = failureMap.get("failing");
+      if (!helpers.shouldPollServerActivity(recoveredCircuit)) {
+        throw new Error("successful manual activity refresh did not resume automatic polling");
+      }
     JAVASCRIPT
 
     _stdout, stderr, status = Open3.capture3("node", "-e", script, HELPERS_PATH, chdir: ROOT)


### PR DESCRIPTION
## Summary
- stop automatic peer activity polling after three consecutive qualifying fetch failures
- retain polling for healthy peers and let Settings refresh actions manually recover a stopped peer
- show the stopped state and retry guidance in Settings

## Verification
- `bin/test`
- `bin/remote-ui-smoke`