### PR TITLE
Add Remote UI lifecycle status icons

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5042,8 +5042,8 @@ def write_smoke_script(path)
             return {
               before,
               after: {
-                status: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
                 statusIconLabel: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("aria-label"),
+                statusIconTitle: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("title"),
                 statusIconName: agentStatusIconName("succeeded"),
                 visibleStatusText: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
                 sendPrompt: document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] button[type="submit"]`)?.textContent.trim(),
@@ -5072,8 +5072,8 @@ def write_smoke_script(path)
             focusedStatusSyncContract.before.action !== "Stop agent" ||
             !focusedStatusSyncContract.before.steadyActionPreserved ||
             !focusedStatusSyncContract.before.steadyActionFocused ||
-            focusedStatusSyncContract.after.status !== "" ||
             focusedStatusSyncContract.after.statusIconLabel !== "Succeeded" ||
+            focusedStatusSyncContract.after.statusIconTitle !== "Succeeded" ||
             focusedStatusSyncContract.after.statusIconName !== "check" ||
             focusedStatusSyncContract.after.visibleStatusText !== "" ||
             focusedStatusSyncContract.after.sendPrompt !== "Send prompt" ||

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5005,7 +5005,10 @@ def write_smoke_script(path)
           syncFocusedWorkspaceCatalog(parseRoute());
           const steadyActionAfter = document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] [data-agent-action="stop"]`);
           const before = {
-            status: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
+            statusIconLabel: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("aria-label"),
+            statusIconTitle: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"] .agent-status-icon`)?.getAttribute("title"),
+            statusIconName: agentStatusIconName("running"),
+            visibleStatusText: document.querySelector(`[data-agent-live-status="${CSS.escape(key)}"]`)?.textContent.trim(),
             action: document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] [data-agent-action="stop"]`)?.textContent.trim(),
             steadyActionPreserved: steadyActionAfter === steadyActionBefore,
             steadyActionFocused: document.activeElement === steadyActionBefore,
@@ -5068,7 +5071,10 @@ def write_smoke_script(path)
             scheduleAgentActivity();
           }
         }, agentKey);
-        if (focusedStatusSyncContract.before.status !== "Running" ||
+        if (focusedStatusSyncContract.before.statusIconLabel !== "Running" ||
+            focusedStatusSyncContract.before.statusIconTitle !== "Running" ||
+            focusedStatusSyncContract.before.statusIconName !== "sportShoe" ||
+            focusedStatusSyncContract.before.visibleStatusText !== "" ||
             focusedStatusSyncContract.before.action !== "Stop agent" ||
             !focusedStatusSyncContract.before.steadyActionPreserved ||
             !focusedStatusSyncContract.before.steadyActionFocused ||

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5648,12 +5648,14 @@ def write_smoke_script(path)
         const stalePeerAppearance = await page.locator("[data-open-agent='design-peer/peer-agent']").evaluate((row) => ({
           rowIsStale: row.classList.contains("resource-stale"),
           groupIsStale: row.closest(".agent-group")?.classList.contains("resource-stale"),
-          status: row.querySelector(".ui-status")?.textContent.trim(),
-          statusOpacity: Number.parseFloat(getComputedStyle(row.querySelector(".ui-status")).opacity),
+          statusIconLabel: row.querySelector(".agent-status-icon")?.getAttribute("aria-label"),
+          statusIconText: row.querySelector(".agent-status-icon")?.textContent.trim(),
+          statusOpacity: Number.parseFloat(getComputedStyle(row.querySelector(".agent-status-icon")).opacity),
           healthIcon: Boolean(row.closest(".agent-group")?.querySelector(".server-health-icon-badge svg")),
         }));
         if (!stalePeerAppearance.rowIsStale || !stalePeerAppearance.groupIsStale ||
-            stalePeerAppearance.status !== "Running" || stalePeerAppearance.statusOpacity >= 0.8 ||
+            stalePeerAppearance.statusIconLabel !== "Running" || stalePeerAppearance.statusIconText ||
+            stalePeerAppearance.statusOpacity >= 0.8 ||
             !stalePeerAppearance.healthIcon) {
           throw new Error(`Stale peer project and agent were not visually subdued: ${JSON.stringify(stalePeerAppearance)}`);
         }

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -545,6 +545,81 @@ def write_smoke_script(path)
         }
       }
 
+      async function assertNowStatusIcons() {
+        const result = await page.evaluate(() => {
+          const original = {
+            agents: state.agents,
+            schedules: state.schedules,
+            scheduleDaemon: state.scheduleDaemon,
+          };
+          const source = state.agents[0];
+          if (!source) throw new Error("Now status icon fixture needs an agent");
+
+          state.agents = [
+            {
+              ...source,
+              key: "running-status-icon",
+              name: "Work in flight",
+              status: "running",
+              running: true,
+              unread: false,
+              awaiting_input: false,
+              blocked: false,
+              last_result: "",
+            },
+            {
+              ...source,
+              key: "unread-status-icon",
+              name: "Fresh result",
+              status: "success",
+              running: false,
+              unread: true,
+              awaiting_input: false,
+              blocked: false,
+            },
+          ];
+          state.schedules = [];
+          state.scheduleDaemon = {};
+          renderNow();
+
+          const rows = Array.from(document.querySelectorAll(".agent-summary-card")).map((row) => {
+            const icon = row.querySelector(".agent-status-icon");
+            const styles = icon ? getComputedStyle(icon) : null;
+            return {
+              label: row.querySelector(".card-title strong")?.textContent,
+              iconClass: icon?.className || "",
+              iconLabel: icon?.getAttribute("aria-label"),
+              iconTitle: icon?.getAttribute("title"),
+              iconText: icon?.textContent.trim() || "",
+              hasPill: Boolean(icon?.parentElement?.querySelector(".ui-badge, .pill, .chip, .agent-status-badge")),
+              background: styles?.backgroundColor,
+              border: styles?.borderWidth,
+              radius: styles?.borderRadius,
+            };
+          });
+
+          state.agents = original.agents;
+          state.schedules = original.schedules;
+          state.scheduleDaemon = original.scheduleDaemon;
+          state.renderedRouteKey = null;
+          state.renderedViewHtml = "";
+          render();
+          return rows;
+        });
+
+        const running = result.find((row) => row.iconLabel === "Running");
+        const unread = result.find((row) => row.iconLabel === "Unread");
+        const iconIsStandalone = (row) => row && !row.iconText && !row.hasPill &&
+          (row.background === "rgba(0, 0, 0, 0)" || row.background === "transparent") &&
+          row.border === "0px" && row.radius === "0px";
+        if (!running?.iconClass.includes("running") || running.iconTitle !== "Running" || !iconIsStandalone(running)) {
+          throw new Error(`Now running status icon lost its standalone accessible treatment: ${JSON.stringify(running)}`);
+        }
+        if (!unread?.iconClass.includes("need") || unread.iconTitle !== "Unread" || !iconIsStandalone(unread)) {
+          throw new Error(`Now unread status icon lost its standalone accessible treatment: ${JSON.stringify(unread)}`);
+        }
+      }
+
       async function assertEditorExcludedFromRefresh(selector, label, focusSelector) {
         if (focusSelector) await page.focus(focusSelector);
         const result = await page.evaluate(({ selector, label }) => {
@@ -718,6 +793,7 @@ def write_smoke_script(path)
 
       try {
         await page.goto(`${baseUrl}/ui`, { waitUntil: "networkidle" });
+        await assertNowStatusIcons();
         if (skillsOnly) {
           await page.goto(`${baseUrl}/ui#settings`, { waitUntil: "networkidle" });
           await page.waitForSelector("#settings-skills", { state: "visible", timeout: 10_000 });
@@ -1622,7 +1698,11 @@ def write_smoke_script(path)
           const excerptStyle = excerpt ? getComputedStyle(excerpt) : null;
           const result = {
             found: Boolean(card && status && excerpt && subtitle),
-            statusLabel: status?.querySelector(":scope > .ui-status")?.textContent.trim(),
+            statusIconLabel: status?.querySelector(".agent-status-icon")?.getAttribute("aria-label"),
+            statusIconTitle: status?.querySelector(".agent-status-icon")?.getAttribute("title"),
+            statusIconClass: status?.querySelector(".agent-status-icon")?.className,
+            statusIconText: status?.querySelector(".agent-status-icon")?.textContent.trim(),
+            statusPill: Boolean(status?.querySelector(".agent-status-badge")),
             ownerIcon: Boolean(status?.querySelector(".server-metadata-badge svg")),
             healthLabel: status?.querySelector(".server-health-icon-badge")?.getAttribute("aria-label"),
             healthIcon: Boolean(status?.querySelector(".server-health-icon-badge svg")),
@@ -1636,7 +1716,11 @@ def write_smoke_script(path)
           return result;
         }, agentKey);
         if (!nowAgentCardContract.found ||
-            nowAgentCardContract.statusLabel !== "Running" ||
+            nowAgentCardContract.statusIconLabel !== "Running" ||
+            nowAgentCardContract.statusIconTitle !== "Running" ||
+            !nowAgentCardContract.statusIconClass?.includes("running") ||
+            nowAgentCardContract.statusIconText ||
+            nowAgentCardContract.statusPill ||
             !nowAgentCardContract.ownerIcon ||
             nowAgentCardContract.healthLabel !== "Online" ||
             !nowAgentCardContract.healthIcon ||

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -2583,6 +2583,10 @@ select {
   color: var(--ok);
 }
 
+.agent-status-icon.running {
+  color: var(--accent);
+}
+
 .agent-status-icon.fail {
   color: var(--danger);
 }

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -2933,7 +2933,7 @@ select {
   font-weight: 600;
 }
 
-.resource-stale :is(.status-mark, .ui-status, .server-identity-badge) {
+.resource-stale :is(.agent-status-icon, .status-mark, .ui-status, .server-identity-badge) {
   opacity: 0.68;
 }
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -160,6 +160,12 @@ const ICONS = {
       <path d="M9.5 22 21.414 9.415A2 2 0 0 0 21.2 6.4l-5.61-4.208A1 1 0 0 0 14 3v2a2 2 0 0 1-1.394 1.906L8.677 8.053A1 1 0 0 0 8 9c-.155 6.393-2.082 9-4 9a2 2 0 0 0 0 4h14"></path>
     </svg>
   `,
+  messageSquareDot: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M12.7 3H4a2 2 0 0 0-2 2v16.286a.71.71 0 0 0 1.212.502l2.202-2.202A2 2 0 0 1 6.828 19H20a2 2 0 0 0 2-2v-4.7"></path>
+      <circle cx="19" cy="6" r="3"></circle>
+    </svg>
+  `,
   arrowDownAZ: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
       <path d="m3 16 4 4 4-4"></path>
@@ -12486,6 +12492,10 @@ function agentDisplayedStatusKey(agent) {
 
 function agentStatusIconName(status) {
   switch (String(status || "").toLowerCase()) {
+    case "unread":
+      return "messageSquareDot";
+    case "running":
+      return "sportShoe";
     case "paused":
     case "stopped":
       return "pause";
@@ -12509,7 +12519,8 @@ function agentStatusIcon(status, label = titleFromKey(status)) {
   const iconName = agentStatusIconName(status);
   if (!iconName) return "";
 
-  const className = statusClass({ status });
+  const normalizedStatus = String(status).toLowerCase();
+  const className = normalizedStatus === "unread" ? "need" : normalizedStatus === "running" ? "running" : statusClass({ status });
   return `<span class="agent-status-icon ${escapeAttr(className)}" data-intent="${escapeAttr(statusIntent(className))}" role="img" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}">${iconSvg(iconName)}</span>`;
 }
 

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -53,6 +53,7 @@ module RemoteUIAssetSnapshotTest
       ".agent-status-icon.done",
       ".agent-status-icon.running",
       ".agent-status-icon.fail",
+      ".resource-stale :is(.agent-status-icon, .status-mark, .ui-status, .server-identity-badge)",
       "color: var(--muted);",
       "color: var(--accent);",
       'normalizedStatus === "unread" ? "need"',

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -28,18 +28,35 @@ module RemoteUIAssetSnapshotTest
       "pause:",
       "check:",
       "ban:",
+      "messageSquareDot:",
+      "sportShoe:",
       '<rect width="4" height="16" x="14" y="4" rx="1"></rect>',
       '<path d="M20 6 9 17l-5-5"></path>',
       '<path d="m4.9 4.9 14.2 14.2"></path>',
+      '<path d="M12.7 3H4a2 2 0 0 0-2 2v16.286a.71.71 0 0 0 1.212.502l2.202-2.202A2 2 0 0 1 6.828 19H20a2 2 0 0 0 2-2v-4.7"></path>',
+      '<circle cx="19" cy="6" r="3"></circle>',
+      '<path d="m15 10.42 4.8-5.07"></path>',
       'return "pause"',
       'return "check"',
       'return "ban"',
+      'case "unread":',
+      'return "messageSquareDot"',
+      'case "running":',
+      'return "sportShoe"',
       'case "no_action_needed":',
       "function agentListStatusIcon(agent)",
+      "const statusIcon = agentListStatusIcon(agent);",
+      "function renderNow()",
+      "const unreadSection = unread.length > 0",
+      "const runningSection = running.length > 0",
       'label: "Scheduled agent", role: "scheduled"',
       ".agent-status-icon.done",
+      ".agent-status-icon.running",
       ".agent-status-icon.fail",
       "color: var(--muted);",
+      "color: var(--accent);",
+      'normalizedStatus === "unread" ? "need"',
+      'normalizedStatus === "running" ? "running"',
       'role="img" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}"',
       "function agentStatusIcon(status, label",
       ".agent-status-icon {"
@@ -54,6 +71,7 @@ module RemoteUIAssetSnapshotTest
     icon_renderer = javascript[/function agentStatusIcon\(status, label.*?^}/m]
     raise "missing agent status indicator renderer" unless icon_renderer
     raise "status icon renderer must not emit badge styling" if icon_renderer.include?("ui-badge")
+    raise "status icon renderer must not emit visible status text" if icon_renderer.include?("escapeHtml(label)")
 
     icon_styles = css[/\.agent-status-icon \{.*?^}/m]
     raise "missing standalone status icon styles" unless icon_styles


### PR DESCRIPTION
Closes Fizzy #138

## Summary
- map unread and running agent lifecycle states to standalone Lucide icons
- retain lifecycle colors and accessible labels without status-pill chrome
- cover Now, agent list, switcher, and browser smoke contracts

## Verification
- `BUNDLER_VERSION=4.0.16 bin/test`
- `BUNDLER_VERSION=4.0.16 bin/remote-ui-smoke`