### PR TITLE
Unify mobile inquiry header

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -4581,6 +4581,17 @@ def write_smoke_script(path)
         }
         await page.click(".mobile-inquiry > summary");
         await page.waitForSelector("#inquiry-form", { state: "visible", timeout: 10_000 });
+        const expandedInquiryHeader = await page.evaluate(() => ({
+          banners: document.querySelectorAll(".mobile-inquiry > #inquiry-form .inquiry-banner").length,
+          fullScreenInHeader: Boolean(document.querySelector(".mobile-inquiry > summary [data-toggle-inquiry-full-screen]")),
+          title: document.querySelector(".mobile-inquiry > summary strong")?.textContent,
+          subtitle: document.querySelector(".mobile-inquiry > summary .mobile-inquiry-summary-copy > span")?.textContent,
+        }));
+        if (expandedInquiryHeader.banners !== 0 || !expandedInquiryHeader.fullScreenInHeader ||
+            expandedInquiryHeader.title !== "Answer required" ||
+            expandedInquiryHeader.subtitle !== "Choose the next step.") {
+          throw new Error(`Expanded mobile inquiry duplicated or changed its header: ${JSON.stringify(expandedInquiryHeader)}`);
+        }
         await page.evaluate(() => {
           state.renderedViewHtml = "";
           render();

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -6383,7 +6383,7 @@ body:has(.inquiry-form-full-screen) {
 
 .mobile-inquiry > summary {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 8px;
   border: 1px solid color-mix(in srgb, var(--warning) 55%, var(--border));
@@ -6423,6 +6423,12 @@ body:has(.inquiry-form-full-screen) {
   place-items: center;
   color: var(--muted);
   transition: transform 120ms ease;
+}
+
+.mobile-inquiry > summary .mobile-inquiry-full-screen-button {
+  position: static;
+  width: 36px;
+  min-height: 36px;
 }
 
 .mobile-inquiry[open] > summary {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -6858,19 +6858,24 @@ function renderInquiryForm(agent, options = {}) {
   const fields = inquiryFields(inquiry);
   const fullScreen = state.fullScreenInquiryKeys.has(agent.key);
   const disclosureKey = `${agent.key}:${inquiryId}`;
+  const compact = !fullScreen && window.matchMedia?.("(max-width: 640px)").matches;
   const modalAttributes = fullScreen
     ? ' role="dialog" aria-modal="true" aria-label="Full-screen inquiry" data-editor-modal data-inquiry-modal'
     : ' aria-label="Agent inquiry"';
+  const fullScreenButton = fullScreen
+    ? `<button class="icon-button inquiry-close-button ui-button ui-icon-button" type="button" data-toggle-inquiry-full-screen="${escapeAttr(agent.key)}" aria-label="Close full-screen inquiry" title="Close full-screen inquiry">${iconSvg("x")}</button>`
+    : `<button class="inquiry-full-screen-button${compact ? " mobile-inquiry-full-screen-button" : ""} ui-button ui-icon-button" type="button" data-toggle-inquiry-full-screen="${escapeAttr(agent.key)}" aria-label="Open full-screen inquiry" title="Full-screen inquiry">${iconSvg("maximize2")}</button>`;
+  const inquiryBanner = `
+    <section class="inquiry-banner">
+      <span class="inquiry-mark" aria-hidden="true">${iconSvg("badgeQuestionMark")}</span>
+      <p>${escapeHtml(inquiry.message || "Respond to the agent before it continues.")}</p>
+    </section>
+  `;
   const form = `
     <form id="inquiry-form" class="inquiry-form${fullScreen ? " inquiry-form-full-screen" : ""}" data-ds-form="inquiry" data-agent-key="${escapeAttr(agent.key)}" data-inquiry-id="${escapeAttr(inquiryId)}" aria-describedby="inquiry-validation" novalidate${modalAttributes}>
-      ${fullScreen
-        ? `<button class="icon-button inquiry-close-button ui-button ui-icon-button" type="button" data-toggle-inquiry-full-screen="${escapeAttr(agent.key)}" aria-label="Close full-screen inquiry" title="Close full-screen inquiry">${iconSvg("x")}</button>`
-        : `<button class="inquiry-full-screen-button ui-button ui-icon-button" type="button" data-toggle-inquiry-full-screen="${escapeAttr(agent.key)}" aria-label="Open full-screen inquiry" title="Full-screen inquiry">${iconSvg("maximize2")}</button>`}
+      ${compact ? "" : fullScreenButton}
       <div class="inquiry-form-content">
-        <section class="inquiry-banner">
-          <span class="inquiry-mark" aria-hidden="true">${iconSvg("badgeQuestionMark")}</span>
-          <p>${escapeHtml(inquiry.message || "Respond to the agent before it continues.")}</p>
-        </section>
+        ${compact ? "" : inquiryBanner}
         <div class="inquiry-fields">
           ${fields.map(renderInquiryField).join("")}
           ${renderInquiryFeedbackField()}
@@ -6894,7 +6899,6 @@ function renderInquiryForm(agent, options = {}) {
       </div>
     </form>
   `;
-  const compact = !fullScreen && window.matchMedia?.("(max-width: 640px)").matches;
   if (!compact) return form;
 
   return `
@@ -6905,6 +6909,7 @@ function renderInquiryForm(agent, options = {}) {
           <strong>Answer required</strong>
           <span>${escapeHtml(inquiry.message || "Respond to the agent before it continues.")}</span>
         </span>
+        ${fullScreenButton}
         <span class="mobile-inquiry-chevron" aria-hidden="true">${iconSvg("chevronDown")}</span>
       </summary>
       ${form}
@@ -14733,6 +14738,7 @@ function handleViewClick(event) {
 
   const inquiryFullScreenToggle = event.target.closest("[data-toggle-inquiry-full-screen]");
   if (inquiryFullScreenToggle) {
+    event.preventDefault();
     const key = inquiryFullScreenToggle.dataset.toggleInquiryFullScreen;
     setInquiryFullScreen(key, !state.fullScreenInquiryKeys.has(key));
     return;

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4698,8 +4698,11 @@ module RemoteServerTest
     assert(js[:body].include?('class="mobile-inquiry"') &&
            js[:body].include?('data-state-key="mobile-inquiry:') &&
            js[:body].include?("Answer required") &&
+           js[:body].include?('${compact ? "" : inquiryBanner}') &&
+           js[:body].include?('${fullScreenButton}') &&
+           css[:body].include?(".mobile-inquiry > summary .mobile-inquiry-full-screen-button") &&
            css[:body].include?(".mobile-inquiry > summary"),
-           "expected mobile inquiry answers to start in a collapsible disclosure")
+           "expected mobile inquiry answers to use one collapsible header with the full-screen action")
     assert(js[:body].include?("Leave feedback") &&
            js[:body].include?('name="feedback"') &&
            js[:body].include?("const feedback = String(new FormData(form).get(\"feedback\")"),


### PR DESCRIPTION
## Summary

- use the mobile inquiry disclosure as the single expanded header
- keep the existing “Answer required” title and agent-authored question subtitle
- move the full-screen action into the disclosure header
- preserve desktop and full-screen inquiry banners

## Verification

- `mise exec ruby@3.4.7 -- bundle exec ruby test/remote_server_test.rb`
- `mise exec ruby@3.4.7 -- bin/remote-ui-smoke`
- `mise exec ruby@3.4.7 -- bin/test`

## Screenshots

To be attached by the operator.