### PR TITLE
Rank and highlight agent search

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -41,6 +41,7 @@ def write_fixture(dir)
     projects:
       - key: web
         name: Web
+        group: Personal
         path: #{workspace.inspect}
         agent: codex
         pr_url: https://github.com/example/web/pull/123
@@ -2337,6 +2338,22 @@ def write_smoke_script(path)
           }));
           throw new Error(`Unscheduled agent missing from combined list: ${JSON.stringify(agentState)} / ${error.message}`);
         }
+        await agentsRegressionPage.fill("#agent-filter", "unscheduled");
+        if (await agentsRegressionPage.locator(".agent-row[data-open-agent]").count() !== 1 ||
+            await agentsRegressionPage.locator(".agent-name-label .agent-search-match").innerText() !== "Unscheduled") {
+          throw new Error("Agents filter did not isolate and highlight an agent-name match");
+        }
+        await agentsRegressionPage.fill("#agent-filter", "web");
+        if (await agentsRegressionPage.locator(".agent-group-project-title .agent-search-match").count() !== 1 ||
+            await agentsRegressionPage.locator(".agent-group-project-title .agent-search-match").innerText() !== "Web") {
+          throw new Error("Agents filter did not highlight a project-name match");
+        }
+        await agentsRegressionPage.fill("#agent-filter", "personal");
+        if (await agentsRegressionPage.locator(".agent-row[data-open-agent]").count() < 2 ||
+            await agentsRegressionPage.locator(".agent-search-match").count() !== 0) {
+          throw new Error("Agents filter exposed an invisible group-name match");
+        }
+        await agentsRegressionPage.fill("#agent-filter", "");
         await agentsRegressionPage.goto(`${baseUrl}/ui#agent/${encodeURIComponent(agentKey)}`, { waitUntil: "networkidle" });
         await agentsRegressionPage.waitForSelector("#prompt-input", { state: "visible", timeout: 10_000 });
         await agentsRegressionPage.click("#header-mark");
@@ -2355,8 +2372,18 @@ def write_smoke_script(path)
         const switcherSearchNodeStable = await agentsRegressionPage.locator("#unread-agent-search").evaluate((input) => input.__tychoSearchNodeProbe === true);
         if (!switcherSearchNodeStable) throw new Error("Agent switcher search replaced its focused input while typing");
         await agentsRegressionPage.waitForSelector(`[data-open-agent='${unscheduledAgentKey}']`, { state: "visible", timeout: 10_000 });
-        if (await agentsRegressionPage.locator(".switcher-agent-row").count() !== 1) {
-          throw new Error("Agent switcher search did not filter the agent list");
+        if (await agentsRegressionPage.locator(".switcher-agent-row").count() !== 1 ||
+            await agentsRegressionPage.locator(".switcher-agent-row .agent-name-label .agent-search-match").innerText() !== "Unscheduled") {
+          throw new Error("Agent switcher search did not filter and highlight the agent-name match");
+        }
+        await agentsRegressionPage.fill("#unread-agent-search", "web");
+        if (await agentsRegressionPage.locator(".switcher-agent-row .row-title > span .agent-search-match").count() !== switcherAgentCount) {
+          throw new Error("Agent switcher search did not highlight project-name matches");
+        }
+        await agentsRegressionPage.fill("#unread-agent-search", "personal");
+        if (await agentsRegressionPage.locator(".switcher-agent-row").count() !== switcherAgentCount ||
+            await agentsRegressionPage.locator(".switcher-agent-row .agent-search-match").count() !== 0) {
+          throw new Error("Agent switcher exposed an invisible group-name match");
         }
         await agentsRegressionPage.press("#unread-agent-search", "Escape");
         if (await agentsRegressionPage.locator("#unread-agent-search").inputValue() !== "" ||

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -453,6 +453,13 @@ h3 {
   white-space: nowrap;
 }
 
+.agent-search-match {
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: inherit;
+  padding: 0 1px;
+}
+
 .row-title .agent-name-label,
 .card-title .agent-name-label,
 .agent-reference-copy .agent-name-label {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -4813,7 +4813,7 @@ function renderFlatAgentList(agents, query) {
 
   return `
     <section class="agent-group agent-flat-list ui-collection-group ui-surface" aria-label="Agents">
-      ${agents.map((agent) => renderAgentRow(agent, { serverIcon: true })).join("")}
+      ${agents.map((agent) => renderAgentRow(agent, { serverIcon: true, query })).join("")}
     </section>
   `;
 }
@@ -4823,7 +4823,7 @@ function renderGroupedAgentLedger(groups, query) {
 
   return `
     <section class="agent-ledger ui-collection-group ui-surface" aria-label="Agents grouped by project">
-      ${groups.map((group) => renderAgentGroup(group.projectKey, group.agents)).join("")}
+      ${groups.map((group) => renderAgentGroup(group.projectKey, group.agents, query)).join("")}
     </section>
   `;
 }
@@ -8723,9 +8723,12 @@ function renderAgentSection(title, subtitle, agents, emptyText) {
   `;
 }
 
-function renderAgentGroup(projectKey, agents) {
+function renderAgentGroup(projectKey, agents, query = "") {
   const project = findProject(projectKey);
   const projectName = project?.name || projectKey;
+  const orderedAgents = query
+    ? agents.map((agent) => ({ agent, depth: 0 }))
+    : delegationOrderedAgents(agents);
   const groupClassName = ["agent-group", agents.length ? "" : "empty", resourceStaleClass(project || agents[0])]
     .filter(Boolean)
     .join(" ");
@@ -8733,12 +8736,12 @@ function renderAgentGroup(projectKey, agents) {
     <section class="${groupClassName}">
       <div class="group-title">
         <div class="agent-group-project">
-          ${renderAgentGroupProjectTitle(projectKey, projectName, !!project)}
+          ${renderAgentGroupProjectTitle(projectKey, projectName, !!project, query)}
           ${serverIdentityBadge(project || agents[0], { compactHealth: true })}
         </div>
         ${project ? `<button class="icon-button agent-group-create ui-button ui-icon-button" type="button" data-create-agent="${escapeAttr(projectKey)}" aria-label="New agent for ${escapeAttr(projectName)}">${iconSvg("plus")}<span class="sr-only">New agent</span></button>` : ""}
       </div>
-      ${delegationOrderedAgents(agents).map(({ agent, depth }) => renderAgentRow(agent, { delegationDepth: depth })).join("")}
+      ${orderedAgents.map(({ agent, depth }) => renderAgentRow(agent, { delegationDepth: depth, query })).join("")}
     </section>
   `;
 }
@@ -8759,8 +8762,10 @@ function delegationOrderedAgents(agents) {
   return result;
 }
 
-function renderAgentGroupProjectTitle(projectKey, projectName, linked) {
-  const title = `${iconSvg("folder")}<span>${escapeHtml(projectName)}</span>`;
+function renderAgentGroupProjectTitle(projectKey, projectName, linked, query = "") {
+  const project = findProject(projectKey);
+  const highlightQuery = projectSearchMatch(project, query)?.field === "project_name" ? query : "";
+  const title = `${iconSvg("folder")}<span>${highlightSearchText(projectName, highlightQuery)}</span>`;
   if (!linked) return `<strong class="agent-group-project-title">${title}</strong>`;
 
   const projectHref = routeHash({ type: "project", key: projectKey });
@@ -8791,7 +8796,7 @@ function renderAgentRow(agent, options = {}) {
     <button class="agent-row ${options.delegationDepth ? "delegated-agent-row" : ""} ${resourceStaleClass(agent)}" style="--delegation-depth:${Number(options.delegationDepth || 0)}" type="button" data-open-agent="${escapeAttr(agent.key)}" aria-label="Open ${escapeAttr(agent.name || agent.key)}, ${agent.archived ? "archived, read-only, " : ""}${escapeAttr(statusLabel(agent))}${options.delegationDepth ? ", delegated agent" : ""}">
       ${statusIcon || agentIdentityIcon(agent)}
       <div class="row-title">
-        <strong>${agentNameHtml(agent)}</strong>
+        <strong>${agentNameHtml(agent, options.query)}</strong>
         <span>${agentListSubtextHtml(agent, options)}</span>
       </div>
       ${statusIcon ? "" : agentStatusBadge(agent)}
@@ -10938,18 +10943,16 @@ function agentProjectGroups(query) {
   ]);
 
   return [...projectKeys]
-    .sort(compareAgentProjectKeysForCurrentSort)
     .map((projectKey) => agentProjectGroup(projectKey, agentsByProject[projectKey] || [], query))
-    .filter(Boolean);
+    .filter(Boolean)
+    .sort((left, right) => {
+      const byMatch = query ? left.matchPriority - right.matchPriority : 0;
+      return byMatch || compareAgentProjectKeysForCurrentSort(left.projectKey, right.projectKey);
+    });
 }
 
 function sortedAgentList(query) {
-  return serverFilteredAgents()
-    .filter((agent) => {
-      const project = findProject(agent.project_key);
-      return !query || (project && projectMatches(project, query)) || agentMatches(agent, query);
-    })
-    .sort(compareAgentsForCurrentSort);
+  return rankMatchingAgents(serverFilteredAgents(), query, compareAgentsForCurrentSort);
 }
 
 function serverFilteredAgents() {
@@ -10973,15 +10976,17 @@ function currentAgentSortOption() {
 
 function agentProjectGroup(projectKey, agents, query) {
   const project = findProject(projectKey);
-  const projectMatch = project ? projectMatches(project, query) : String(projectKey || "").toLowerCase().includes(query);
-  const filteredAgents = agents
-    .filter((agent) => !query || projectMatch || agentMatches(agent, query))
-    .sort(compareAgentsForCurrentSort);
+  const projectMatch = projectSearchMatch(project, query);
+  const filteredAgents = rankMatchingAgents(agents, query, compareAgentsForCurrentSort);
 
   if (query && !projectMatch && filteredAgents.length === 0) return null;
   if (!query && !project && filteredAgents.length === 0) return null;
 
-  return { projectKey, agents: filteredAgents };
+  const matchPriority = filteredAgents.reduce(
+    (priority, agent) => Math.min(priority, agentSearchMatch(agent, query)?.priority ?? Infinity),
+    projectMatch?.priority ?? Infinity
+  );
+  return { projectKey, agents: filteredAgents, matchPriority };
 }
 
 function agentsForProject(projectKey) {
@@ -11044,32 +11049,21 @@ function agentPriority(agent) {
   return 1;
 }
 
-function agentMatches(agent, query) {
-  if (!query) return true;
-  return [
-    agent.name,
-    agent.key,
-    agent.project_key,
-    agent.template_key,
-    agent.agent,
-    agent.model,
-    agent.reasoning_effort,
-    agent.status,
-    agent.last_result,
-    agent.summary,
-  ].some((value) => String(value || "").toLowerCase().includes(query));
+function agentSearchMatch(agent, query) {
+  return REMOTE_HELPERS.agentSearchMatch(agent, findProject(agent?.project_key), query);
 }
 
-function projectMatches(project, query) {
-  if (!query) return true;
-  return [
-    project.name,
-    project.key,
-    project.group,
-    project.status,
-    project.branch,
-    project.commit_hash,
-  ].some((value) => String(value || "").toLowerCase().includes(query));
+function projectSearchMatch(project, query) {
+  return REMOTE_HELPERS.projectSearchMatch(project, query);
+}
+
+function rankMatchingAgents(agents, query, fallbackCompare) {
+  return REMOTE_HELPERS.rankMatchingAgents(
+    agents,
+    query,
+    (agent) => findProject(agent.project_key),
+    fallbackCompare
+  );
 }
 
 function moreMenuHtml(items) {
@@ -11716,10 +11710,7 @@ function filterQuickSwitchAgents(agents = quickSwitchPanelAgents(), query = stat
   const normalizedQuery = String(query || "").trim().toLowerCase();
   if (!normalizedQuery) return agents;
 
-  return agents.filter((agent) => {
-    const project = findProject(agent.project_key);
-    return agentMatches(agent, normalizedQuery) || (project && projectMatches(project, normalizedQuery));
-  });
+  return rankMatchingAgents(agents, normalizedQuery, compareQuickSwitchAgents);
 }
 
 function focusUnreadPanelSearch(selectionStart = null, selectionEnd = null) {
@@ -11778,8 +11769,8 @@ function renderSwitcherAgentRow(agent, index) {
     <button class="agent-row switcher-agent-row ${selected ? "selected" : ""}" type="button" data-open-agent="${escapeAttr(agent.key)}" data-switcher-index="${index}" ${selected ? "aria-selected=\"true\"" : ""}>
       ${statusIcon || agentIdentityIcon(agent)}
       <div class="row-title">
-        <strong class="switcher-agent-title-line">${agentNameHtml(agent)}${linkedSymbol}</strong>
-        <span>${agentListSubtextHtml(agent)}</span>
+        <strong class="switcher-agent-title-line">${agentNameHtml(agent, state.unreadPanelQuery)}${linkedSymbol}</strong>
+        <span>${agentListSubtextHtml(agent, { query: state.unreadPanelQuery })}</span>
       </div>
       <span class="switcher-agent-tools">${statusText}</span>
     </button>
@@ -11795,8 +11786,9 @@ function agentIdentityIcon(agent) {
   return `<span class="status-mark ${escapeAttr(className)}" ${statusMarkAttributes(className)} aria-hidden="true">${iconSvg(agent?.scheduled || agent?.schedule_key ? "calendarCheck2" : "robot")}</span>`;
 }
 
-function agentNameHtml(agent) {
+function agentNameHtml(agent, query = "") {
   const roleIcons = agentRoleIcons(agent);
+  const highlightQuery = agent?.name && agentSearchMatch(agent, query)?.field === "agent_name" ? query : "";
   const icons = roleIcons.map(({ className, icon, label, role }) => `
     <span class="agent-name-role-icon ${className}" data-agent-role="${role}" role="img" aria-label="${label}" title="${label}">${iconSvg(icon)}</span>
   `).join("");
@@ -11804,7 +11796,7 @@ function agentNameHtml(agent) {
   return `
     <span class="agent-name-inline">
       ${icons ? `<span class="agent-name-role-icons">${icons}</span>` : ""}
-      <span class="agent-name-label">${escapeHtml(agent?.name || agent?.key)}</span>
+      <span class="agent-name-label">${highlightSearchText(agent?.name || agent?.key, highlightQuery)}</span>
     </span>
   `;
 }
@@ -13162,11 +13154,23 @@ function agentUpdatedAt(agent) {
 }
 
 function agentListSubtextHtml(agent, options = {}) {
-  const parts = agentMetaParts(agent).map((part, index) => {
-    if (!options.serverIcon || state.servers.length <= 1 || index !== 1) return escapeHtml(part);
+  const project = findProject(agent.project_key);
+  const projectLabel = agentProjectLabel(agent);
+  const highlightProject = projectSearchMatch(project, options.query)?.field === "project_name";
+  const metaParts = agentMetaParts(agent);
+  if (projectLabel) {
+    const projectIndex = agent.archived ? 1 : 0;
+    metaParts[projectIndex] = { text: projectLabel, highlight: highlightProject };
+  }
+  const parts = metaParts.map((part, index) => {
+    const text = typeof part === "object" ? part.text : part;
+    const html = typeof part === "object" && part.highlight
+      ? highlightSearchText(text, options.query)
+      : escapeHtml(text);
+    if (!options.serverIcon || state.servers.length <= 1 || index !== 1) return html;
 
     const server = resourceServer(agent.server_key);
-    return `<span class="agent-server-inline" title="${escapeAttr(serverDisplayName(server))}">${iconSvg(serverIconName(server))}<span>${escapeHtml(part)}</span></span>`;
+    return `<span class="agent-server-inline" title="${escapeAttr(serverDisplayName(server))}">${iconSvg(serverIconName(server))}<span>${html}</span></span>`;
   });
   return [relativeTimeHtml(agentUpdatedAt(agent)), ...parts].filter(Boolean).join(" / ");
 }
@@ -13257,6 +13261,14 @@ function escapeHtml(value) {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
+}
+
+function highlightSearchText(value, query) {
+  return REMOTE_HELPERS.highlightSearchParts(value, query)
+    .map(({ text, highlighted }) => highlighted
+      ? `<mark class="agent-search-match">${escapeHtml(text)}</mark>`
+      : escapeHtml(text))
+    .join("");
 }
 
 function escapeAttr(value) {

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -61,6 +61,63 @@
     return compareAgentsByUpdatedAt(a, b, "desc");
   }
 
+  function agentSearchMatch(agent, project, query) {
+    const normalizedQuery = String(query || "").trim().toLowerCase();
+    if (!normalizedQuery) return null;
+
+    const candidates = [
+      { field: "agent_name", priority: 0, value: agent?.name },
+      { field: "project_name", priority: 1, value: project?.name },
+      { field: "group_name", priority: 2, value: project?.group },
+    ];
+    const candidate = candidates.find(({ value }) =>
+      String(value || "").toLowerCase().includes(normalizedQuery));
+    return candidate ? { field: candidate.field, priority: candidate.priority } : null;
+  }
+
+  function projectSearchMatch(project, query) {
+    return agentSearchMatch(null, project, query);
+  }
+
+  function highlightSearchParts(value, query) {
+    const text = String(value || "");
+    const normalizedQuery = String(query || "").trim().toLowerCase();
+    if (!normalizedQuery) return [{ text, highlighted: false }];
+
+    const normalizedText = text.toLowerCase();
+    const parts = [];
+    let cursor = 0;
+    let matchIndex = normalizedText.indexOf(normalizedQuery);
+    while (matchIndex >= 0) {
+      if (matchIndex > cursor) parts.push({ text: text.slice(cursor, matchIndex), highlighted: false });
+      const matchEnd = matchIndex + normalizedQuery.length;
+      parts.push({ text: text.slice(matchIndex, matchEnd), highlighted: true });
+      cursor = matchEnd;
+      matchIndex = normalizedText.indexOf(normalizedQuery, cursor);
+    }
+    if (cursor < text.length) parts.push({ text: text.slice(cursor), highlighted: false });
+    return parts.length ? parts : [{ text, highlighted: false }];
+  }
+
+  function rankMatchingAgents(agents, query, projectFor, fallbackCompare) {
+    const normalizedQuery = String(query || "").trim().toLowerCase();
+    if (!normalizedQuery) return [...agents].sort(fallbackCompare);
+
+    return agents
+      .map((agent, sourceIndex) => ({
+        agent,
+        match: agentSearchMatch(agent, projectFor(agent), normalizedQuery),
+        sourceIndex,
+      }))
+      .filter(({ match }) => match)
+      .sort((left, right) => (
+        left.match.priority - right.match.priority ||
+        fallbackCompare(left.agent, right.agent) ||
+        left.sourceIndex - right.sourceIndex
+      ))
+      .map(({ agent }) => agent);
+  }
+
   function compareAgentsBySort(a, b, sort, config = {}) {
     switch (normalizeAgentSort(sort, config)) {
       case "agent_name_desc":
@@ -546,6 +603,7 @@
   global.TychoRemoteHelpers = Object.freeze({
     agentComposerState,
     agentActivityTimestamp,
+    agentSearchMatch,
     activityFetchFailure,
     agentSortUsesProjectGroups,
     attachmentBlobPath,
@@ -570,12 +628,15 @@
     draftableTextControl,
     elementStateKey,
     markdownHeadingSlug,
+    highlightSearchParts,
     mergeActivityServers,
     nextActivityPollingFailure,
     normalizeAttachmentTargetForMatch,
     normalizeDiffScope,
     normalizeAgentSort,
     parseRoute,
+    projectSearchMatch,
+    rankMatchingAgents,
     reconcileAgentDetail,
     routeHash,
     routeStateKey,

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4917,7 +4917,7 @@ module RemoteServerTest
     assert(!js[:body].include?(["This", "server"].join(" ")) &&
            js[:body].include?('return server.local ? "Host"'),
            "expected local ownership text to use Host")
-    assert(js[:body].include?('renderAgentRow(agent, { serverIcon: true })') &&
+    assert(js[:body].include?('renderAgentRow(agent, { serverIcon: true, query })') &&
            js[:body].include?('class="agent-server-inline"') &&
            css[:body].include?(".agent-server-inline > .ui-icon"),
            "expected flat Agent rows to show the local or peer server icon")
@@ -6020,7 +6020,7 @@ module RemoteServerTest
     assert(css[:body].include?(".message.user.parent-agent-message .message-role") &&
            css[:body].include?("text-transform: none;"),
            "expected parent-authored messages to retain the right-aligned user treatment with an agent signature")
-    assert(js[:body].include?('class="switcher-agent-title-line">${agentNameHtml(agent)}${linkedSymbol}') &&
+    assert(js[:body].include?('class="switcher-agent-title-line">${agentNameHtml(agent, state.unreadPanelQuery)}${linkedSymbol}') &&
            js[:body].include?('aria-label="Show linked agents"') &&
            !js[:body].include?('${iconSvg("link")}<span>${escapeHtml(String(linkedCount))}</span>'),
            "expected Quick Agents to place a count-free linked control beside the agent name")
@@ -6157,8 +6157,8 @@ module RemoteServerTest
            "expected Agents tab group sorting to compare project display names")
     assert(helpers_js[:body].include?("function compareAgentsByName"),
            "expected Agents tab to sort agents alphabetically within each project group")
-    assert(js[:body].include?("projectMatches(project, query)"),
-           "expected Agents tab filtering to match project fields")
+    assert(js[:body].include?("rankMatchingAgents(serverFilteredAgents(), query, compareAgentsForCurrentSort)"),
+           "expected Agents tab filtering to use ranked agent search")
     assert(!js[:body].include?("No managed agents"),
            "expected Agents tab to omit redundant zero-agent empty rows")
     assert(js[:body].include?("agent-group-create"),

--- a/test/remote_ui_agent_search_test.rb
+++ b/test/remote_ui_agent_search_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RemoteUIAgentSearchTest
+  module_function
+
+  ROOT = File.expand_path("..", __dir__)
+  HELPERS_PATH = File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app_helpers.js")
+
+  def run!
+    script = <<~'JAVASCRIPT'
+      const fs = require("fs");
+      const vm = require("vm");
+      const context = { window: {}, URL, URLSearchParams };
+      vm.createContext(context);
+      vm.runInContext(fs.readFileSync(process.argv[1], "utf8"), context);
+
+      const helpers = context.window.TychoRemoteHelpers;
+      const project = { name: "Tycho Project", group: "Personal" };
+
+      const nameMatch = helpers.agentSearchMatch({ name: "Personal Agent" }, project, "personal");
+      const projectMatch = helpers.agentSearchMatch({ name: "Other Agent" }, { name: "Personal Project", group: "Work" }, "personal");
+      const groupMatch = helpers.agentSearchMatch({ name: "Other Agent" }, project, "personal");
+      const hiddenMatch = helpers.agentSearchMatch(
+        { name: "Other Agent", key: "personal-key", summary: "personal summary" },
+        { name: "Other Project", group: "Work", branch: "personal-branch" },
+        "personal"
+      );
+
+      if (nameMatch?.field !== "agent_name" || nameMatch.priority !== 0) {
+        throw new Error(`agent-name match did not rank first: ${JSON.stringify(nameMatch)}`);
+      }
+      if (projectMatch?.field !== "project_name" || projectMatch.priority !== 1) {
+        throw new Error(`project-name match did not rank second: ${JSON.stringify(projectMatch)}`);
+      }
+      if (groupMatch?.field !== "group_name" || groupMatch.priority !== 2) {
+        throw new Error(`group-name match did not rank third: ${JSON.stringify(groupMatch)}`);
+      }
+      if (hiddenMatch !== null) {
+        throw new Error(`hidden fields still matched agent search: ${JSON.stringify(hiddenMatch)}`);
+      }
+
+      const projects = {
+        agent: { name: "Other Project", group: "Work" },
+        project: { name: "Personal Project", group: "Work" },
+        group: { name: "Other Project", group: "Personal" },
+        hidden: { name: "Other Project", group: "Work" },
+      };
+      const ranked = helpers.rankMatchingAgents(
+        [
+          { key: "group", name: "Group Agent" },
+          { key: "hidden", name: "Other Agent", summary: "Personal summary" },
+          { key: "project", name: "Project Agent" },
+          { key: "agent", name: "Personal Agent" },
+        ],
+        "personal",
+        (agent) => projects[agent.key],
+        (left, right) => left.name.localeCompare(right.name)
+      );
+      if (ranked.map((agent) => agent.key).join(",") !== "agent,project,group") {
+        throw new Error(`agent search was not filtered and ranked by visible priority: ${JSON.stringify(ranked)}`);
+      }
+
+      const parts = helpers.highlightSearchParts("A <Personal> & personal", "personal");
+      if (parts.filter((part) => part.highlighted).length !== 2 || parts.map((part) => part.text).join("") !== "A <Personal> & personal") {
+        throw new Error(`visible match ranges were not preserved safely: ${JSON.stringify(parts)}`);
+      }
+    JAVASCRIPT
+
+    _stdout, stderr, status = Open3.capture3("node", "-e", script, HELPERS_PATH, chdir: ROOT)
+    raise "Remote UI agent search regression failed: #{stderr.strip}" unless status.success?
+
+    puts "remote_ui_agent_search_test: ok"
+  end
+end
+
+RemoteUIAgentSearchTest.run! if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary

- restrict agent filtering to agent name, project name, and project group
- rank matches in that order while preserving the selected sort as the tie-breaker
- highlight visible agent-name and project-name matches; keep group-name matches invisible
- cover the Agents tab and Quick Agents switcher with shared regression tests

The separate TUI schedule-management work is intentionally excluded.

## Verification

- `PATH=/Users/didik/.local/share/mise/installs/ruby/4.0.0/bin:$PATH bin/test` — passed
- `PATH=/Users/didik/.local/share/mise/installs/ruby/4.0.0/bin:$PATH bundle exec ruby bin/remote-ui-smoke` — passed in isolated Chrome fixtures

The browser smoke visibly verifies agent-name highlighting, project-name highlighting, and unhighlighted group-name matches in both the Agents tab and Quick Agents switcher.