### PR TITLE
Prepare v0.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.10.1 - 2026-08-27
+
+### Highlights
+
+- Keep agent conversations live while a harness runs: Tycho now projects
+  sequenced events into its durable conversation journal as they arrive, with
+  loading feedback while history is opening.
+- Let users queue follow-up prompts for a running agent. Queue entries persist
+  and preserve submission order across refreshes and retryable start failures;
+  the Remote UI keeps the composer usable and displays optimistic entries until
+  the server confirms them.
+- Make delegated-agent work clearer and safer. Direct user messages explicitly
+  take over a child session, parent prompts can reclaim it, and both the Remote
+  UI and agent switcher provide direct parent/child navigation.
+- Improve Remote UI agent health and lifecycle visibility with reliability
+  cards, clearer status icons, stale-state treatment, and refresh safeguards.
+- Rank agent search results and highlight the matched text, so the most useful
+  result is easier to find quickly. (#85)
+
+### Fixes
+
+- Keep attachment popovers above surrounding Remote UI content and preserve a
+  consistent mobile inquiry header.
+
 ## 0.10.0 - 2026-08-15
 
 ### Highlights

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-08-21
+2026-08-27
 
 ## Strategic Direction
 
@@ -94,7 +94,7 @@ Key references:
 
 ## Current Focus
 
-**v0.10 release**: remote CLI control, server-owned credentials, structured
+**v0.10.1 release**: remote CLI control, server-owned credentials, structured
 output correction, auditable usage metrics, project workspace browsing, Tycho
 skill installation, pull-request context, and durable agent delegation are
 complete. Ownership-aware takeover/report routing now includes edge-local
@@ -110,7 +110,12 @@ optimistic entries until the server accepts their stable client IDs, and keeps
 Stop in the shared top action row across conversation and attachment layouts.
 Terminal runs claim pending entries as one ordered follow-up prompt, while
 inquiries and retryable start failures retain the queue without silently
-advancing the conversation.
+advancing the conversation. The release also keeps live agent conversations in
+a durable incremental journal, makes delegation takeover and parent reclaim
+explicit, surfaces linked-agent navigation, improves Remote UI lifecycle and
+reliability visibility, and ranks agent search results with matched-text
+highlights. Schedule-management work remains on `wip/tui-schedule-management`
+for a later release.
 
 ## Roadmap
 

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
## Summary
- bump Tycho to v0.10.1
- document the user-visible changes since v0.10.0, including ranked agent search (#85)
- update the current release milestone; schedule-management work remains on `wip/tui-schedule-management`

## Validation
- `mise exec ruby@3.4.7 -- bin/test`

## Compatibility
- Patch release; no public config or command contract changes.