### PR TITLE
Fix running agent empty summaries

### DIFF
--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -1028,9 +1028,9 @@ module HQ
     end
 
     def last_summary
-      return "No runs yet" unless last_run
+      return "No runs yet" if run_count.zero?
 
-      structured_summary || inquiry_message || @summary || "No runs yet"
+      structured_summary || inquiry_message || @summary || (status == "running" ? "Run in progress" : "Run summary unavailable")
     end
 
     def latest_inquiry

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -14,6 +14,8 @@ module ManagedAgentTest
   def run!
     assert_new_agents_use_unique_log_stems
     assert_lifetime_run_count_survives_retained_window
+    assert_running_agent_with_history_has_in_progress_summary
+    assert_never_run_agent_keeps_empty_summary
     assert_completed_status_finalizes_live_pid
     assert_structured_result_status_overrides_transport_exit
     assert_start_finalizes_unpolled_previous_run
@@ -102,6 +104,38 @@ module ManagedAgentTest
       assert(restored.run_count == 13, "expected a new run to advance the lifetime count past the retained window")
       assert(restored.runs.length == 10, "expected adding a run to retain only the latest 10 details")
     end
+  end
+
+  def assert_running_agent_with_history_has_in_progress_summary
+    agent = HQ::ManagedAgent.new(
+      key: "running-history-agent",
+      name: "Running history",
+      project_key: "demo",
+      template_key: "custom",
+      workspace: Dir.tmpdir,
+      prompt: "Prompt",
+      total_run_count: 2,
+      runs: [HQ::ManagedAgent::AgentRun.new(status: "running")]
+    )
+    agent.define_singleton_method(:running?) { true }
+
+    assert(agent.run_count == 2, "expected persisted lifetime run history to be retained")
+    assert(agent.last_summary == "Run in progress",
+           "expected a running agent with history not to render as never run")
+  end
+
+  def assert_never_run_agent_keeps_empty_summary
+    agent = HQ::ManagedAgent.new(
+      key: "never-run-agent",
+      name: "Never run",
+      project_key: "demo",
+      template_key: "custom",
+      workspace: Dir.tmpdir,
+      prompt: "Prompt"
+    )
+
+    assert(agent.run_count.zero?, "expected a fresh agent to have no recorded runs")
+    assert(agent.last_summary == "No runs yet", "expected a fresh agent to retain the empty state")
   end
 
   def assert_structured_result_status_overrides_transport_exit

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -22,6 +22,7 @@ module RemoteServerTest
     assert_remote_agent_bulk_archive
     assert_remote_agent_clone_archives_source_with_editable_name
     assert_remote_agent_payload_has_revision
+    assert_remote_agent_payload_distinguishes_running_history_from_never_run
     assert_remote_agent_activity_snapshot
     assert_remote_agent_payload_has_cost_snapshot
     assert_remote_memory_handoffs
@@ -752,6 +753,39 @@ module RemoteServerTest
       replace_constant(HQ, :AGENTS_FILE, old_agents_file) if old_agents_file
       replace_constant(HQ, :AGENT_LOGS_DIR, old_logs_dir) if old_logs_dir
       replace_constant(HQ, :AGENT_ARCHIVE_DIR, old_archive_dir) if old_archive_dir
+    end
+  end
+
+  def assert_remote_agent_payload_distinguishes_running_history_from_never_run
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace)
+      service = HQ::RemoteService.new(registry: registry)
+      running = HQ::ManagedAgent.new(
+        key: "running-history-payload",
+        name: "Running history payload",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: workspace,
+        prompt: "Prompt",
+        total_run_count: 2,
+        runs: [HQ::ManagedAgent::AgentRun.new(status: "running")]
+      )
+      running.define_singleton_method(:running?) { true }
+      never_run = HQ::ManagedAgent.new(
+        key: "never-run-payload",
+        name: "Never run payload",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: workspace,
+        prompt: "Prompt"
+      )
+
+      assert(service.send(:agent_payload, running)[:summary] == "Run in progress",
+             "expected Remote UI payload to show a running summary for recorded history")
+      assert(service.send(:agent_payload, never_run)[:summary] == "No runs yet",
+             "expected Remote UI payload to preserve the never-run empty state")
     end
   end
 


### PR DESCRIPTION
## Summary
- distinguish a genuine never-run agent from an agent with persisted run history
- show `Run in progress` for running agents without a completed summary
- cover the lifecycle and Remote UI payload states

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/c8108411-f285-46b4-a1af-683026006a62" />


## Verification
- `bundle exec ruby test/managed_agent_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke`
- `bin/test`