### PR TITLE
Test CI on Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - "3.2"
-          - "3.4"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "4.0"
           bundler-cache: true
       - run: bin/test


### PR DESCRIPTION
## Summary
- run CI only on Ruby 4.0
- remove Ruby 3.2 and 3.4 CI jobs to reduce GitHub Actions usage
- leave the documented Ruby 3.2+ runtime requirement unchanged; CI coverage is intentionally narrower

## Verification
- `bin/test` on Ruby 4.0.6
- GitHub Actions CI passed on Ruby 4.0