### PR TITLE
Add PWA loading shell

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -471,6 +471,52 @@ def write_smoke_script(path)
       });
       page.on("pageerror", (error) => errors.push(error.message));
 
+      async function assertInitialLoadingShell() {
+        const desktopPage = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+        const mobilePage = await browser.newPage({ viewport: { width: 390, height: 844 }, isMobile: true });
+        const pwaContext = await browser.newContext({ viewport: { width: 390, height: 844 }, isMobile: true });
+        const pwaPage = await pwaContext.newPage();
+        try {
+          await Promise.all([desktopPage, mobilePage, pwaPage].map((candidate) => candidate.route("**/ui.js?*", async (route) => {
+            await new Promise((resolve) => setTimeout(resolve, 350));
+            await route.continue();
+          })));
+          await Promise.all([desktopPage, mobilePage, pwaPage].map((candidate) => candidate.emulateMedia({ reducedMotion: candidate === mobilePage ? "reduce" : "no-preference" })));
+          await Promise.all([desktopPage.goto(`${baseUrl}/`, { waitUntil: "commit" }), mobilePage.goto(`${baseUrl}/`, { waitUntil: "commit" }), pwaPage.goto(`${baseUrl}/`, { waitUntil: "commit" })]);
+          await Promise.all([desktopPage, mobilePage, pwaPage].map((candidate) => candidate.waitForSelector("#tycho-boot-shell[data-state='loading']", { state: "visible", timeout: 10_000 })));
+          const initialStates = await Promise.all([desktopPage, mobilePage, pwaPage].map(async (candidate) => candidate.evaluate(() => {
+            const shell = document.getElementById("tycho-boot-shell");
+            const app = document.getElementById("app");
+            return {
+              state: shell?.dataset.state,
+              visible: Boolean(shell && !shell.hidden && getComputedStyle(shell).display !== "none"),
+              busy: app?.getAttribute("aria-busy"),
+              animation: getComputedStyle(shell?.querySelector(".tycho-boot-mark")).animationName,
+            };
+          })));
+          if (!initialStates.every((state) => state.state === "loading" && state.visible && state.busy === "true")) {
+            throw new Error(`Initial loading shell was not visible before application JavaScript: ${JSON.stringify(initialStates)}`);
+          }
+          if (initialStates[1].animation !== "none") throw new Error("Reduced-motion loading shell still animates");
+          if (captureDir) {
+            await desktopPage.screenshot({ path: path.join(captureDir, "pwa-loading-shell-desktop.png"), fullPage: false });
+            await mobilePage.screenshot({ path: path.join(captureDir, "pwa-loading-shell-mobile-reduced-motion.png"), fullPage: false });
+            await pwaPage.screenshot({ path: path.join(captureDir, "pwa-loading-shell-pwa.png"), fullPage: false });
+          }
+          await Promise.all([desktopPage, mobilePage, pwaPage].map((candidate) => candidate.waitForSelector("#tycho-boot-shell[hidden]", { state: "attached", timeout: 10_000 })));
+          const manifest = await pwaPage.evaluate(async () => (await fetch("/manifest.webmanifest")).json());
+          if (manifest.display !== "standalone" || manifest.background_color !== "#282a36") {
+            throw new Error(`Installed-PWA fallback contract changed: ${JSON.stringify(manifest)}`);
+          }
+        } finally {
+          await desktopPage.close();
+          await mobilePage.close();
+          await pwaContext.close();
+        }
+      }
+
+      await assertInitialLoadingShell();
+
       async function captureVisibleComposer(filename) {
         if (!captureDir) return;
         const composer = page.locator("#composer:not([hidden])");

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -517,6 +517,42 @@ def write_smoke_script(path)
 
       await assertInitialLoadingShell();
 
+      async function assertLoadingShellFailureRecovery() {
+        const failurePage = await browser.newPage({ viewport: { width: 390, height: 844 } });
+        let failureMode = "offline";
+        try {
+          await failurePage.route("**/servers/resources", async (route) => {
+            if (failureMode === "offline") return route.abort("failed");
+            if (failureMode === "failed") {
+              return route.fulfill({ status: 500, contentType: "application/json", body: JSON.stringify({ error: "Fixture service failed" }) });
+            }
+            return route.continue();
+          });
+          await failurePage.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
+          await failurePage.waitForSelector("#tycho-boot-shell[data-state='offline']", { state: "visible", timeout: 10_000 });
+          const offlineCopy = await failurePage.locator("#tycho-boot-message").innerText();
+          if (!offlineCopy.includes("offline")) throw new Error(`Offline startup copy was not actionable: ${offlineCopy}`);
+          failureMode = "success";
+          await failurePage.locator("#tycho-boot-retry").click();
+          await failurePage.waitForSelector("#tycho-boot-shell[hidden]", { state: "attached", timeout: 10_000 });
+
+          failureMode = "failed";
+          await failurePage.reload({ waitUntil: "domcontentloaded" });
+          await failurePage.waitForSelector("#tycho-boot-shell[data-state='failed']", { state: "visible", timeout: 10_000 });
+          const failedCopy = await failurePage.locator("#tycho-boot-message").innerText();
+          if (!failedCopy.includes("Fixture service failed") || failedCopy.includes("offline")) {
+            throw new Error(`Non-network startup failure lost its cause: ${failedCopy}`);
+          }
+          failureMode = "success";
+          await failurePage.locator("#tycho-boot-retry").click();
+          await failurePage.waitForSelector("#tycho-boot-shell[hidden]", { state: "attached", timeout: 10_000 });
+        } finally {
+          await failurePage.close();
+        }
+      }
+
+      await assertLoadingShellFailureRecovery();
+
       async function captureVisibleComposer(filename) {
         if (!captureDir) return;
         const composer = page.locator("#composer:not([hidden])");

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -814,6 +814,10 @@ let confirmationResolver = null;
 let confirmationFocusOrigin = null;
 
 const els = {
+  bootShell: document.getElementById("tycho-boot-shell"),
+  bootMessage: document.getElementById("tycho-boot-message"),
+  bootRetry: document.getElementById("tycho-boot-retry"),
+  app: document.getElementById("app"),
   header: document.querySelector(".app-header"),
   summaryAttachmentOverlay: document.getElementById("summary-attachment-overlay-root"),
   title: document.getElementById("screen-title"),
@@ -838,6 +842,35 @@ const els = {
   quickAgentDialog: document.getElementById("quick-agent-dialog"),
   confirmationDialog: document.getElementById("confirmation-dialog"),
 };
+
+const BOOT_TIMEOUT_MS = 15_000;
+let bootTimeout = null;
+
+function setBootShell(stateName, message) {
+  if (!els.bootShell || els.bootShell.hidden) return;
+  els.bootShell.dataset.state = stateName;
+  els.bootShell.setAttribute("aria-label", message);
+  if (els.bootMessage) els.bootMessage.textContent = message;
+}
+
+function dismissBootShell() {
+  if (!els.bootShell || els.bootShell.hidden) return;
+  window.clearTimeout(bootTimeout);
+  els.app?.setAttribute("aria-busy", "false");
+  els.bootShell.classList.add("is-leaving");
+  window.setTimeout(() => {
+    els.bootShell.hidden = true;
+  }, 180);
+}
+
+function failBootShell(error) {
+  const message = String(error?.message || "Remote UI is unavailable.");
+  const offline = navigator.onLine === false || error?.status === undefined;
+  setBootShell(offline ? "offline" : "failed", offline
+    ? "You appear to be offline. Check your connection, then try again."
+    : `Tycho could not finish loading: ${message}`);
+  els.app?.setAttribute("aria-busy", "false");
+}
 
 function initialAgentSort() {
   return normalizeAgentSort(sessionStorageValue(AGENT_SORT_STORAGE_KEY, DEFAULT_AGENT_SORT));
@@ -2213,6 +2246,7 @@ async function refresh(options = {}) {
         preservePollContent: !options.force && !options.forceAttachment,
       });
     }
+    dismissBootShell();
     await requestAllServerResourceRefreshes();
   } catch (error) {
     state.failureCount += 1;
@@ -2228,6 +2262,8 @@ async function refresh(options = {}) {
         preservePollContent: !options.force && !options.forceAttachment,
       });
     }
+    if (error.status === 401) dismissBootShell();
+    else failBootShell(error);
   } finally {
     if (!state.timer) schedule();
   }
@@ -16876,6 +16912,18 @@ window.visualViewport?.addEventListener("scroll", syncFullScreenComposerViewport
 
 els.tokenInput.value = token();
 render();
+bootTimeout = window.setTimeout(() => {
+  failBootShell(new Error("The server is taking longer than expected."));
+}, BOOT_TIMEOUT_MS);
+els.bootRetry?.addEventListener("click", () => {
+  setBootShell("loading", "Trying to connect to Remote UI…");
+  els.app?.setAttribute("aria-busy", "true");
+  refresh({ force: true });
+});
+window.addEventListener("offline", () => failBootShell(new Error("Network unavailable")));
+window.addEventListener("online", () => {
+  if (els.bootShell && !els.bootShell.hidden) refresh({ force: true });
+});
 refresh({ force: true });
 pollAgentActivity();
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -846,6 +846,12 @@ const els = {
 const BOOT_TIMEOUT_MS = 15_000;
 let bootTimeout = null;
 
+function bootError(message, kind = "failed") {
+  const error = new Error(message);
+  error.bootFailureKind = kind;
+  return error;
+}
+
 function setBootShell(stateName, message) {
   if (!els.bootShell || els.bootShell.hidden) return;
   els.bootShell.dataset.state = stateName;
@@ -863,13 +869,27 @@ function dismissBootShell() {
   }, 180);
 }
 
+function bootNetworkFailure(error) {
+  if (navigator.onLine === false || error?.bootFailureKind === "offline") return true;
+  if (error?.status !== undefined) return false;
+
+  return error instanceof TypeError && /failed to fetch|networkerror|network request failed|load failed/i.test(error.message || "");
+}
+
 function failBootShell(error) {
   const message = String(error?.message || "Remote UI is unavailable.");
-  const offline = navigator.onLine === false || error?.status === undefined;
+  const offline = bootNetworkFailure(error);
   setBootShell(offline ? "offline" : "failed", offline
     ? "You appear to be offline. Check your connection, then try again."
     : `Tycho could not finish loading: ${message}`);
   els.app?.setAttribute("aria-busy", "false");
+}
+
+function scheduleBootTimeout() {
+  window.clearTimeout(bootTimeout);
+  bootTimeout = window.setTimeout(() => {
+    failBootShell(bootError("The server is taking longer than expected.", "timeout"));
+  }, BOOT_TIMEOUT_MS);
 }
 
 function initialAgentSort() {
@@ -16912,15 +16932,14 @@ window.visualViewport?.addEventListener("scroll", syncFullScreenComposerViewport
 
 els.tokenInput.value = token();
 render();
-bootTimeout = window.setTimeout(() => {
-  failBootShell(new Error("The server is taking longer than expected."));
-}, BOOT_TIMEOUT_MS);
+scheduleBootTimeout();
 els.bootRetry?.addEventListener("click", () => {
   setBootShell("loading", "Trying to connect to Remote UI…");
   els.app?.setAttribute("aria-busy", "true");
+  scheduleBootTimeout();
   refresh({ force: true });
 });
-window.addEventListener("offline", () => failBootShell(new Error("Network unavailable")));
+window.addEventListener("offline", () => failBootShell(bootError("Network unavailable", "offline")));
 window.addEventListener("online", () => {
   if (els.bootShell && !els.bootShell.hidden) refresh({ force: true });
 });

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -13,8 +13,41 @@
     <link rel="icon" href="/favicon.png?v=<%= HQ::RemoteUI.asset_version %>" type="image/png">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=<%= HQ::RemoteUI.asset_version %>">
     <link rel="stylesheet" href="/ui.css?v=<%= HQ::RemoteUI.asset_version %>">
+    <style>
+      :root { background: #282a36; color-scheme: dark; }
+      body { margin: 0; min-height: 100vh; background: #282a36; color: #f8f8f2; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .tycho-boot-shell { position: fixed; z-index: 100; inset: 0; display: grid; place-items: center; min-height: 100vh; min-height: 100dvh; padding: max(24px, env(safe-area-inset-top, 0px)) 24px max(24px, env(safe-area-inset-bottom, 0px)); background: #282a36; text-align: center; transition: opacity 160ms ease, visibility 160ms ease; }
+      .tycho-boot-shell[hidden] { display: none; }
+      .tycho-boot-shell.is-leaving { opacity: 0; visibility: hidden; pointer-events: none; }
+      .tycho-boot-card { display: grid; justify-items: center; gap: 14px; width: min(100%, 320px); }
+      .tycho-boot-mark { width: 72px; height: 72px; color: #ff8a00; filter: drop-shadow(0 0 15px rgba(255, 138, 0, .3)); animation: tycho-boot-orbit 1.5s ease-in-out infinite; }
+      .tycho-boot-mark path { fill: none; stroke: currentColor; stroke-width: 5; stroke-linecap: butt; }
+      .tycho-boot-mark .tycho-boot-light { stroke: #f3f1ea; }
+      .tycho-boot-mark .tycho-boot-muted { stroke: #9c9c9c; }
+      .tycho-boot-mark rect { fill: #f3f1ea; }
+      .tycho-boot-title { margin: 0; font-size: 22px; line-height: 1.15; letter-spacing: -.02em; }
+      .tycho-boot-message { margin: 0; color: #b8b8c8; font-size: 15px; line-height: 1.45; }
+      .tycho-boot-action { display: none; min-height: 42px; border: 1px solid #ff8a00; border-radius: 8px; background: #ff8a00; color: #282a36; padding: 0 14px; font: inherit; font-weight: 700; cursor: pointer; }
+      .tycho-boot-shell[data-state="offline"] .tycho-boot-action, .tycho-boot-shell[data-state="failed"] .tycho-boot-action { display: inline-flex; align-items: center; justify-content: center; }
+      @keyframes tycho-boot-orbit { 0%, 100% { opacity: .62; transform: scale(.94) rotate(0deg); } 50% { opacity: 1; transform: scale(1.04) rotate(10deg); } }
+      @media (prefers-reduced-motion: reduce) { .tycho-boot-shell { transition: none; } .tycho-boot-mark { animation: none; } }
+    </style>
   </head>
   <body>
+    <section id="tycho-boot-shell" class="tycho-boot-shell" data-state="loading" role="status" aria-live="polite" aria-atomic="true" aria-label="Tycho is loading">
+      <div class="tycho-boot-card">
+        <svg class="tycho-boot-mark" aria-hidden="true" viewBox="0 0 64 64">
+          <path d="M7 27a25 25 0 0 1 20-20"></path>
+          <path class="tycho-boot-light" d="M37 7a25 25 0 0 1 20 20"></path>
+          <path class="tycho-boot-light" d="M57 37a25 25 0 0 1-20 20"></path>
+          <path class="tycho-boot-muted" d="M27 57A25 25 0 0 1 7 37"></path>
+          <rect x="30" y="24" width="4" height="4"></rect><rect x="30" y="30" width="4" height="4"></rect><rect x="30" y="38" width="4" height="4"></rect>
+        </svg>
+        <h1 class="tycho-boot-title">Tycho</h1>
+        <p id="tycho-boot-message" class="tycho-boot-message">Connecting to Remote UI&hellip;</p>
+        <button id="tycho-boot-retry" class="tycho-boot-action" type="button">Try again</button>
+      </div>
+    </section>
     <div id="pull-refresh" class="pull-refresh" aria-hidden="true">
       <svg class="pull-refresh-spinner ui-icon" aria-hidden="true" viewBox="0 0 24 24">
         <path d="M5 22h14"></path>
@@ -23,7 +56,7 @@
         <path d="M7 2v4.172a2 2 0 0 0 .586 1.414L12 12l4.414-4.414A2 2 0 0 0 17 6.172V2"></path>
       </svg>
     </div>
-    <div id="app" class="app-shell">
+    <div id="app" class="app-shell" aria-busy="true">
       <header class="app-header">
         <div class="header-row">
           <button id="back-button" class="icon-button ui-button ui-icon-button ui-detail-header__back hidden" type="button" aria-label="Back" title="Back">

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -3954,6 +3954,16 @@ module RemoteServerTest
     assert(legacy_response[:content_type].include?("text/html"), "expected /ui compatibility route to return HTML")
     assert(response[:body].include?('name="theme-color" content="#282a36"'),
            "expected root shell to expose a PWA theme color")
+    assert(response[:body].include?('id="tycho-boot-shell"') &&
+           response[:body].include?('data-state="loading"') &&
+           response[:body].include?('role="status" aria-live="polite" aria-atomic="true"'),
+           "expected root shell to provide an accessible server-rendered loading surface")
+    assert(response[:body].include?('id="tycho-boot-retry"') &&
+           response[:body].include?('class="tycho-boot-mark"'),
+           "expected root shell to expose branded loading and recovery controls before application JavaScript")
+    assert(response[:body].include?('@media (prefers-reduced-motion: reduce)') &&
+           response[:body].include?('animation: none;'),
+           "expected root shell to provide a static reduced-motion loading state")
     assert(response[:body].include?('content="width=device-width, initial-scale=1, viewport-fit=cover"'),
            "expected root shell viewport to expose iOS safe-area insets")
     assert(response[:body].match?(%r{href="/manifest\.webmanifest\?v=[0-9a-f]{12}"}),

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -41,11 +41,17 @@ module RemoteUIAssetSnapshotTest
 
     required_javascript = [
       "const BOOT_TIMEOUT_MS = 15_000;",
+      "function bootNetworkFailure(error)",
+      "error?.bootFailureKind === \"offline\"",
+      "error instanceof TypeError",
+      "function scheduleBootTimeout()",
+      "bootError(\"The server is taking longer than expected.\", \"timeout\")",
       "function dismissBootShell()",
       "function failBootShell(error)",
       "if (error.status === 401) dismissBootShell();",
       "else failBootShell(error);",
       "els.bootRetry?.addEventListener(\"click\"",
+      "scheduleBootTimeout();",
       "window.addEventListener(\"offline\"",
       "window.addEventListener(\"online\""
     ]

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -11,6 +11,7 @@ module RemoteUIAssetSnapshotTest
   ROOT = File.expand_path("..", __dir__)
 
   def run!
+    assert_initial_loading_shell_contract
     assert_loaded_daemon_keeps_one_asset_build
     assert_handoff_retry_key_is_cleared_after_success
     assert_delegation_ui_uses_typed_safe_references
@@ -18,6 +19,38 @@ module RemoteUIAssetSnapshotTest
     assert_archived_agents_are_reference_only_and_read_only
     assert_agent_status_icons_use_lucide_without_badges
     puts "remote_ui_asset_snapshot_test: ok"
+  end
+
+  def assert_initial_loading_shell_contract
+    template = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "templates", "index.html.erb"))
+    javascript = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.js"))
+
+    required_template = [
+      'id="tycho-boot-shell"',
+      'data-state="loading"',
+      'role="status"',
+      'aria-live="polite"',
+      'id="tycho-boot-retry"',
+      'class="tycho-boot-mark"',
+      '@media (prefers-reduced-motion: reduce)',
+      'id="app" class="app-shell" aria-busy="true"',
+      'href="/manifest.webmanifest?v=<%= HQ::RemoteUI.asset_version %>"'
+    ]
+    missing_template = required_template.reject { |fragment| template.include?(fragment) }
+    raise "missing initial loading shell contract: #{missing_template.join(", ")}" unless missing_template.empty?
+
+    required_javascript = [
+      "const BOOT_TIMEOUT_MS = 15_000;",
+      "function dismissBootShell()",
+      "function failBootShell(error)",
+      "if (error.status === 401) dismissBootShell();",
+      "else failBootShell(error);",
+      "els.bootRetry?.addEventListener(\"click\"",
+      "window.addEventListener(\"offline\"",
+      "window.addEventListener(\"online\""
+    ]
+    missing_javascript = required_javascript.reject { |fragment| javascript.include?(fragment) }
+    raise "missing loading shell lifecycle contract: #{missing_javascript.join(", ")}" unless missing_javascript.empty?
   end
 
   def assert_agent_status_icons_use_lucide_without_badges


### PR DESCRIPTION
## Summary
- render a branded, server-rendered loading shell before Remote UI JavaScript, authentication, and API work complete
- move the shell cleanly to the loaded app, token prompt, or retryable offline/failure state
- distinguish network loss from timeouts and other load errors; retry starts a fresh startup deadline
- cover delayed-JavaScript desktop/mobile/PWA loading, reduced motion, and offline/non-offline retry recovery

## Verification
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/service_worker_test.rb`
- `bin/remote-ui-smoke`
- `bin/test`
- `ruby -c lib/hq/remote_ui.rb`
- `node --check lib/hq/remote_ui/assets/app.js`
- `ruby -c bin/remote-ui-smoke`

Visual evidence: delayed-JavaScript desktop, mobile reduced-motion, and standalone-PWA captures were checked locally.