### PR TITLE
Allow dismissing and restoring inquiries

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -4608,6 +4608,33 @@ def write_smoke_script(path)
         }
         await page.click(".mobile-inquiry > summary");
         await page.waitForSelector("#inquiry-form", { state: "visible", timeout: 10_000 });
+        await page.click("#inquiry-form .composer-action-menu > summary");
+        await page.waitForSelector('[data-inquiry-lifecycle-action="dismiss"]', { state: "visible", timeout: 10_000 });
+        const dismissActionContract = await page.evaluate(() => ({
+          menuLabel: document.querySelector("#inquiry-form .composer-action-menu > summary")?.getAttribute("aria-label"),
+          actionLabel: document.querySelector('[data-inquiry-lifecycle-action="dismiss"]')?.getAttribute("aria-label"),
+        }));
+        if (dismissActionContract.menuLabel !== "Inquiry actions" || dismissActionContract.actionLabel !== "Dismiss inquiry") {
+          throw new Error(`Inquiry dismiss context menu is not accessible: ${JSON.stringify(dismissActionContract)}`);
+        }
+        await page.evaluate((key) => {
+          state.pendingInquiryActions.set(key, "dismiss");
+          state.renderedViewHtml = "";
+          render();
+        }, agentKey);
+        const dismissPendingContract = await page.evaluate(() => ({
+          label: document.querySelector("#inquiry-form .composer-action-menu > summary")?.getAttribute("aria-label"),
+          busy: document.querySelector("#inquiry-form .composer-action-menu > summary")?.getAttribute("aria-busy"),
+          disabled: document.querySelector('[data-inquiry-lifecycle-action="dismiss"]')?.disabled,
+        }));
+        if (dismissPendingContract.label !== "Dismissing inquiry" || dismissPendingContract.busy !== "true" || !dismissPendingContract.disabled) {
+          throw new Error(`Inquiry dismiss pending state is not accessible: ${JSON.stringify(dismissPendingContract)}`);
+        }
+        await page.evaluate((key) => {
+          state.pendingInquiryActions.delete(key);
+          state.renderedViewHtml = "";
+          render();
+        }, agentKey);
         const expandedInquiryHeader = await page.evaluate(() => ({
           banners: document.querySelectorAll(".mobile-inquiry > #inquiry-form .inquiry-banner").length,
           fullScreenInHeader: Boolean(document.querySelector(".mobile-inquiry > summary [data-toggle-inquiry-full-screen]")),
@@ -4750,6 +4777,7 @@ def write_smoke_script(path)
         await page.evaluate((key) => {
           clearFormDraft(document.querySelector("#inquiry-form"));
           const agent = findAgent(key);
+          agent.suspended_inquiry = agent.latest_inquiry;
           agent.latest_inquiry = null;
           state.fullScreenInquiryKeys.delete(key);
           state.conversations[key].blocks.push({
@@ -4763,6 +4791,17 @@ def write_smoke_script(path)
           render();
         }, agentKey);
         await page.waitForSelector("#prompt-input", { state: "visible", timeout: 10_000 });
+        await page.click("#composer .composer-action-menu > summary");
+        await page.waitForSelector('[data-inquiry-lifecycle-action="restore"]', { state: "visible", timeout: 10_000 });
+        const restoreActionLabel = await page.locator('[data-inquiry-lifecycle-action="restore"]').getAttribute("aria-label");
+        if (restoreActionLabel !== "Restore inquiry") {
+          throw new Error(`Composer restore context menu is not accessible: ${JSON.stringify(restoreActionLabel)}`);
+        }
+        await page.evaluate((key) => {
+          findAgent(key).suspended_inquiry = null;
+          state.renderedViewHtml = "";
+          render();
+        }, agentKey);
         const inquiryResponseFields = await page.evaluate(() => {
           const replies = Array.from(document.querySelectorAll(".message.inquiry-response"));
           const reply = replies.at(-1);

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-08-27
+2026-08-29
 
 ## Strategic Direction
 
@@ -66,6 +66,7 @@ Key references:
 | Conversation block scrolling | Initial chat load bottom-aligns the latest block when it fits, oversized blocks start at row 1, and navigation scrolls only enough to reveal the selected block | The selected label/cursor must remain visible and predictable while keeping surrounding recent context on first open |
 | Conversation viewport offsets | Block `line_offset` / `line_height` are derived from the final rendered rows; long unbroken preview tokens are hard-wrapped before entering the viewport, and footer debug is computed after viewport sync | Bubbles `Viewport` counts newline-separated lines, while terminals visually wrap long tokens; stale or mismatched offsets cause misleading `visible 0/0` debug and cropped selected blocks |
 | Inquiry submission | Gated review step inside a rounded box | Prevents accidental structured submissions |
+| Inquiry suspension | Record dismiss, restore, and ordinary-prompt retirement as inquiry-ID-scoped events in the canonical agent journal; keep active and restorable inquiries as prompt-queue blockers | Dismissal remains durable across clients without rewriting conversation history, stale clients cannot transition a different inquiry, and only the ordinary composer that rendered the suspended inquiry may retire it |
 | Input handling | `BubbleteaInput` patches `Bubbletea::Program#poll_event` with a Ruby-side queue | Fixes multi-byte / bracketed paste truncation in Bubbles `TextInput`/`TextArea` |
 | Logging | Centralized `HQ.logger` (stdlib `Logger`), daily rotation, 7-day retention | Single sink for lifecycle, config, process, and silently-rescued errors |
 | Skill discovery | Enumerate SKILL.md from `~/.claude/skills` + workspace `.claude/skills` (Claude-compatible harnesses) and `~/.codex/skills` + `~/.agents/skills` + workspace `.agents/skills` (Codex) | Per-agent trigger character (`/` vs `$`) surfaced in the chat composer |

--- a/lib/hq/app.rb
+++ b/lib/hq/app.rb
@@ -2213,8 +2213,29 @@ def selected_screen_items
       return [self, nil] if content.empty?
 
       agent = @agent_chat_form.agent
-      @agent_store.accept_delegation_prompt!(agent, owner: "user")
-      agent.add_user_message!(content)
+      if @agent_chat_form.inquiry_active?
+        @agent_store.accept_delegation_prompt!(agent, owner: "user")
+        agent.add_user_message!(content)
+      else
+        begin
+          agent = @agent_store.accept_ordinary_prompt!(
+            agent.key,
+            text: content,
+            attachments: [],
+            actor: HQ::DelegationActor.user_actor,
+            retire_inquiry_id: agent.suspended_inquiry_id
+          )
+        rescue ArgumentError => e
+          agent = @agent_store.load.find { |item| item.key == agent.key } || agent
+          @agent_chat_form.agent = agent if @agent_chat_form.respond_to?(:agent=)
+          sync_agent_chat_workspace!
+          @agent_chat_form.inquiry_form.error_message = e.message if @agent_chat_form.inquiry_active?
+          return [self, nil]
+        end
+        index = @agents.index { |item| item.key == agent.key }
+        @agents[index] = agent if index
+        @agent_chat_form.agent = agent if @agent_chat_form.respond_to?(:agent=)
+      end
       @agent_chat_form.composer.clear unless @agent_chat_form.inquiry_active?
       save_agents!
       unless agent.running?

--- a/lib/hq/domain/agent_memory.rb
+++ b/lib/hq/domain/agent_memory.rb
@@ -136,12 +136,35 @@ module HQ
     def latest_inquiry_event(fallback: nil)
       events = read_events
       has_request = events.any? { |event| event["type"] == "inquiry_request" }
-      has_resolution = events.any? { |event| %w[inquiry_response inquiry_cancelled].include?(event["type"]) }
-      return fallback unless has_request || has_resolution
+      has_lifecycle = events.any? { |event| inquiry_lifecycle_event?(event) }
+      return fallback unless has_request || has_lifecycle
 
-      unresolved_inquiry_event(events)
+      active_inquiry_event(events)
     rescue StandardError
       fallback
+    end
+
+    def suspended_inquiry
+      event = suspended_inquiry_event
+      return nil unless event
+
+      metadata = event["metadata"]
+      metadata.is_a?(Hash) ? metadata["inquiry"] : nil
+    rescue StandardError
+      nil
+    end
+
+    def suspended_inquiry_event
+      suspended_inquiry_event_from(read_events)
+    rescue StandardError
+      nil
+    end
+
+    def suspended_inquiry_id
+      event = suspended_inquiry_event
+      event ? inquiry_id_for_event(event) : nil
+    rescue StandardError
+      nil
     end
 
     def latest_inquiry_id(fallback: nil)
@@ -432,6 +455,18 @@ module HQ
       )
     end
 
+    def append_inquiry_suspended!(created_at: Time.now, inquiry_id: nil)
+      append_inquiry_lifecycle!("inquiry_suspended", "Inquiry dismissed", created_at:, inquiry_id:)
+    end
+
+    def append_inquiry_restored!(created_at: Time.now, inquiry_id: nil)
+      append_inquiry_lifecycle!("inquiry_restored", "Inquiry restored", created_at:, inquiry_id:)
+    end
+
+    def append_inquiry_retired!(created_at: Time.now, inquiry_id: nil)
+      append_inquiry_lifecycle!("inquiry_retired", "Inquiry retired by an ordinary prompt", created_at:, inquiry_id:)
+    end
+
     def append_attachment!(attachment, created_at: Time.now)
       attachment = normalize_attachments([attachment]).first
       return unless attachment.is_a?(Hash)
@@ -678,29 +713,55 @@ module HQ
     end
 
     def unresolved_inquiry_event(events)
-      inquiry = events.reverse.find { |event| event["type"] == "inquiry_request" }
-      return nil unless inquiry
+      active_inquiry_event(events) || suspended_inquiry_event_from(events)
+    end
 
-      response = events.reverse.find { |event| %w[inquiry_response inquiry_cancelled].include?(event["type"]) }
-      return inquiry unless response
+    def active_inquiry_event(events)
+      inquiry_event_for_state(events, "active")
+    end
 
+    def suspended_inquiry_event_from(events)
+      inquiry_event_for_state(events, "suspended")
+    end
+
+    def inquiry_event_for_state(events, expected_state)
+      inquiry_index = events.rindex { |event| event["type"] == "inquiry_request" }
+      return nil unless inquiry_index
+
+      inquiry = events[inquiry_index]
       inquiry_id = inquiry_id_for_event(inquiry)
-      unless inquiry_id.to_s.empty?
-        matching_response = events.reverse.find do |event|
-          %w[inquiry_response inquiry_cancelled].include?(event["type"]) && inquiry_id_for_event(event) == inquiry_id
-        end
-        if matching_response
-          response = matching_response
-        elsif !inquiry_id_for_event(response).to_s.empty?
-          return inquiry
-        end
+      lifecycle = Array(events[(inquiry_index + 1)..]).reverse.find do |event|
+        next false unless inquiry_lifecycle_event?(event)
+
+        event_id = inquiry_id_for_event(event)
+        inquiry_id.to_s.empty? ? event_id.to_s.empty? : event_id == inquiry_id
       end
+      inquiry_state_for_lifecycle(lifecycle) == expected_state ? inquiry : nil
+    end
 
-      inquiry_time = parse_time(inquiry["created_at"])
-      response_time = parse_time(response["created_at"])
-      return inquiry if inquiry_time && response_time && inquiry_time > response_time
+    def inquiry_lifecycle_event?(event)
+      %w[inquiry_response inquiry_cancelled inquiry_suspended inquiry_restored inquiry_retired].include?(event["type"])
+    end
 
-      nil
+    def inquiry_state_for_lifecycle(event)
+      case event&.fetch("type", nil)
+      when nil, "inquiry_restored" then "active"
+      when "inquiry_suspended" then "suspended"
+      else "retired"
+      end
+    end
+
+    def append_inquiry_lifecycle!(type, content, created_at:, inquiry_id:)
+      id = inquiry_id.to_s.strip
+      return false if id.empty?
+
+      journal.append({
+        "type" => type,
+        "content" => content,
+        "created_at" => created_at.iso8601,
+        "metadata" => { "inquiry_id" => id }
+      })
+      true
     end
 
     def format_inquiry_context(event)

--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -311,10 +311,70 @@ module HQ
         target = agents.find { |agent| agent.key == key.to_s }
         raise ArgumentError, "Unknown agent: #{key}" unless target
         raise ArgumentError, "No queued dispatch is waiting for retry" unless target.prompt_queue_dispatch_error
-        raise ArgumentError, "An inquiry must be answered before retrying queued work" if target.latest_inquiry
+        raise ArgumentError, "An inquiry must be resolved before retrying queued work" if target.inquiry_blocking_prompt_queue?
 
         target.clear_prompt_queue_dispatch_error!
         dispatch_prompt_queue!(target, agents)
+        target
+      end
+    end
+
+    def suspend_inquiry!(key, inquiry_id)
+      mutate do |agents, _events|
+        target = find_agent_in!(agents, key)
+        raise ArgumentError, "Inquiry has changed; refresh and try again" unless target.suspend_inquiry!(inquiry_id)
+
+        target
+      end
+    end
+
+    def restore_inquiry!(key, inquiry_id)
+      mutate do |agents, _events|
+        target = find_agent_in!(agents, key)
+        raise ArgumentError, "Inquiry is no longer restorable; refresh and try again" unless target.restore_inquiry!(inquiry_id)
+
+        target
+      end
+    end
+
+    def accept_ordinary_prompt!(key, text:, attachments:, actor:, retire_inquiry_id: nil)
+      mutate(dispatch_prompt_queues: false) do |agents, _events|
+        target = find_agent_in!(agents, key)
+        active_id = target.latest_inquiry_id.to_s
+        suspended_id = target.suspended_inquiry_id.to_s
+        supplied_id = retire_inquiry_id.to_s
+        unless active_id.empty?
+          raise ArgumentError, "Inquiry has changed; refresh and try again" unless supplied_id.empty?
+
+          target.cancel_pending_inquiry!
+        end
+        if suspended_id.empty?
+          raise ArgumentError, "Inquiry is no longer restorable; refresh and try again" unless supplied_id.empty?
+        elsif supplied_id.empty? || supplied_id != suspended_id
+          raise ArgumentError, "Inquiry has changed; refresh and try again"
+        else
+          target.retire_suspended_inquiry!(suspended_id)
+        end
+
+        accept_prompt_from!(target, actor:, agents:)
+        target.add_user_message!(text, attachments:, metadata: target.message_author_metadata(actor))
+        target
+      end
+    end
+
+    def answer_inquiry!(key, inquiry_id:, answer:, attachments:, feedback: nil, feedback_embedded: false)
+      mutate(dispatch_prompt_queues: false) do |agents, _events|
+        target = find_agent_in!(agents, key)
+        expected_id = target.latest_inquiry_id.to_s
+        if expected_id.empty? || inquiry_id.to_s != expected_id
+          raise ArgumentError, "Inquiry has changed; refresh and try again"
+        end
+
+        accept_delegation_prompt!(target, owner: "user")
+        target.add_user_message!(answer, inquiry_id: expected_id, attachments:)
+        unless feedback_embedded || feedback.to_s.empty?
+          target.add_user_message!(feedback, metadata: { "inquiry_feedback" => true })
+        end
         target
       end
     end
@@ -402,6 +462,10 @@ module HQ
     end
 
     private
+
+    def find_agent_in!(agents, key)
+      agents.find { |agent| agent.key == key.to_s } || raise(ArgumentError, "Unknown agent: #{key}")
+    end
 
     def dispatch_prompt_queues!(agents)
       changed = false

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -508,7 +508,7 @@ module HQ
     end
 
     def prompt_queue_dispatchable?
-      !running? && latest_inquiry.nil? && last_run &&
+      !running? && !inquiry_blocking_prompt_queue? && last_run &&
         ((@prompt_queue_claim && @prompt_queue_dispatch_error.nil?) || (!@prompt_queue.empty? && !@prompt_queue_claim))
     end
 
@@ -961,11 +961,44 @@ module HQ
     end
 
     def cancel_pending_inquiry!(created_at: Time.now)
-      inquiry_id = latest_inquiry_id.to_s
+      inquiry_id = (latest_inquiry_id || suspended_inquiry_id).to_s
       return false if inquiry_id.empty?
 
       memory_store.append_inquiry_cancelled!(created_at:, inquiry_id:)
       true
+    end
+
+    def suspended_inquiry
+      memory_store.suspended_inquiry
+    end
+
+    def suspended_inquiry_id
+      memory_store.suspended_inquiry_id
+    end
+
+    def inquiry_blocking_prompt_queue?
+      !latest_inquiry.nil? || !suspended_inquiry.nil?
+    end
+
+    def suspend_inquiry!(inquiry_id, created_at: Time.now)
+      expected_id = latest_inquiry_id.to_s
+      return false if expected_id.empty? || inquiry_id.to_s != expected_id
+
+      memory_store.append_inquiry_suspended!(created_at:, inquiry_id: expected_id)
+    end
+
+    def restore_inquiry!(inquiry_id, created_at: Time.now)
+      expected_id = suspended_inquiry_id.to_s
+      return false if expected_id.empty? || inquiry_id.to_s != expected_id
+
+      memory_store.append_inquiry_restored!(created_at:, inquiry_id: expected_id)
+    end
+
+    def retire_suspended_inquiry!(inquiry_id, created_at: Time.now)
+      expected_id = suspended_inquiry_id.to_s
+      return false if expected_id.empty? || inquiry_id.to_s != expected_id
+
+      memory_store.append_inquiry_retired!(created_at:, inquiry_id: expected_id)
     end
 
     def add_assistant_message!(content)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -428,6 +428,12 @@ module HQ
         if method == "POST" && tail.length == 3 && tail.first == "inquiries" && tail[2] == "answer"
           return ok(service.answer_inquiry(key, tail[1], body, actor:))
         end
+        if method == "POST" && tail.length == 3 && tail.first == "inquiries" && tail[2] == "dismiss"
+          return ok(service.dismiss_inquiry(key, tail[1], actor:))
+        end
+        if method == "POST" && tail.length == 3 && tail.first == "inquiries" && tail[2] == "restore"
+          return ok(service.restore_inquiry(key, tail[1], actor:))
+        end
         if tail.length == 2 && tail.first == "prompt-queue"
           return ok(service.edit_queued_prompt(key, tail[1], body)) if %w[PATCH PUT].include?(method)
           return ok(service.delete_queued_prompt(key, tail[1])) if method == "DELETE"
@@ -2896,19 +2902,27 @@ module HQ
         end
       end
 
-      @agent_store.accept_prompt_from!(target, actor:)
-      target.cancel_pending_inquiry! if target.latest_inquiry
-      target.add_user_message!(
-        text,
-        attachments:,
-        metadata: target.message_author_metadata(actor)
-      )
-      save_agent(target)
+      if actor.parent?
+        @agent_store.accept_prompt_from!(target, actor:)
+        target.cancel_pending_inquiry! if target.inquiry_blocking_prompt_queue?
+        target.add_user_message!(text, attachments:, metadata: target.message_author_metadata(actor))
+        save_agent(target)
+      else
+        target = @agent_store.accept_ordinary_prompt!(
+          target.key,
+          text:,
+          attachments:,
+          actor:,
+          retire_inquiry_id: attrs["retire_inquiry_id"]
+        )
+      end
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"]) && !target.running?
       @agent_activity_snapshot.upsert!(target)
       { agent: agent_payload(target), conversation: conversation(target.key) }
     rescue DelegationStore::Error => e
       raise Error.new(e.message, status: actor&.parent? ? 403 : 409)
+    rescue ArgumentError => e
+      raise Error.new(e.message, status: e.message.start_with?("Unknown agent") ? 404 : 409)
     end
 
     def edit_queued_prompt(key, entry_id, attrs)
@@ -2943,27 +2957,44 @@ module HQ
       attrs = attribute_keywords.transform_keys(&:to_s).merge(attrs)
       raise Error.new("Parent-declared requests cannot answer user inquiries", status: 403) if actor.parent?
 
-      target = find_agent!(key)
-      inquiry = target.latest_inquiry
-      raise Error.new("No pending inquiry", status: 409) unless inquiry
-
-      expected_id = target.latest_inquiry_id.to_s
-      supplied_id = inquiry_id.to_s
-      if expected_id.empty? || supplied_id != expected_id
-        raise Error.new("Inquiry has changed; refresh and try again", status: 409)
-      end
-
       answer = required_text(attrs, "answer", fallback: "prompt")
       feedback = attrs["feedback"].to_s.strip
       answer, feedback_embedded = inquiry_answer_with_feedback(answer, feedback, supplied: attrs.key?("feedback"))
+      target = find_agent!(key)
       attachments = import_prompt_attachments(target, attrs)
-      @agent_store.accept_delegation_prompt!(target, owner: "user")
-      target.add_user_message!(answer, inquiry_id: expected_id, attachments:)
-      target.add_user_message!(feedback, metadata: { "inquiry_feedback" => true }) unless feedback_embedded || feedback.empty?
-      save_agent(target)
+      target = @agent_store.answer_inquiry!(
+        key,
+        inquiry_id:,
+        answer:,
+        attachments:,
+        feedback:,
+        feedback_embedded:
+      )
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"]) && !target.running?
       @agent_activity_snapshot.upsert!(target)
       { agent: agent_payload(target), conversation: conversation(target.key) }
+    rescue ArgumentError => e
+      raise Error.new(e.message, status: e.message.start_with?("Unknown agent") ? 404 : 409)
+    end
+
+    def dismiss_inquiry(key, inquiry_id, actor: DelegationActor.user_actor)
+      raise Error.new("Parent-declared requests cannot dismiss user inquiries", status: 403) if actor.parent?
+
+      target = @agent_store.suspend_inquiry!(key, inquiry_id)
+      @agent_activity_snapshot.upsert!(target)
+      { agent: agent_payload(target), conversation: conversation(target.key) }
+    rescue ArgumentError => e
+      raise Error.new(e.message, status: e.message.start_with?("Unknown agent") ? 404 : 409)
+    end
+
+    def restore_inquiry(key, inquiry_id, actor: DelegationActor.user_actor)
+      raise Error.new("Parent-declared requests cannot restore user inquiries", status: 403) if actor.parent?
+
+      target = @agent_store.restore_inquiry!(key, inquiry_id)
+      @agent_activity_snapshot.upsert!(target)
+      { agent: agent_payload(target), conversation: conversation(target.key) }
+    rescue ArgumentError => e
+      raise Error.new(e.message, status: e.message.start_with?("Unknown agent") ? 404 : 409)
     end
 
     def update_agent_delegation(key, attrs)
@@ -4251,6 +4282,7 @@ module HQ
         summary: agent.last_summary,
         cost_snapshot: agent.cost_snapshot,
         latest_inquiry: inquiry_payload(agent),
+        suspended_inquiry: suspended_inquiry_payload(agent),
         prompt_queue: prompt_queue_payload(agent),
         attachments: attachment_payloads(agent),
         skills: agent.skills,
@@ -4683,8 +4715,19 @@ module HQ
       inquiry = agent.latest_inquiry
       return nil unless inquiry.is_a?(Hash)
 
+      inquiry_payload_for(agent, inquiry, agent.latest_inquiry_id)
+    end
+
+    def suspended_inquiry_payload(agent)
+      inquiry = agent.suspended_inquiry
+      return nil unless inquiry.is_a?(Hash)
+
+      inquiry_payload_for(agent, inquiry, agent.suspended_inquiry_id)
+    end
+
+    def inquiry_payload_for(agent, inquiry, inquiry_id)
       payload = deep_dup_hash(inquiry)
-      id = agent.latest_inquiry_id.to_s
+      id = inquiry_id.to_s
       payload["id"] = id unless id.empty?
       payload["session_id"] = agent.session_id.to_s unless agent.session_id.to_s.empty?
       payload["run_count"] = agent.run_count
@@ -4697,7 +4740,7 @@ module HQ
       {
         "entries" => agent.queued_prompts.map { |entry| prompt_queue_entry_payload(agent, entry) },
         "dispatch_error" => agent.prompt_queue_dispatch_error,
-        "blocked_by_inquiry" => !agent.latest_inquiry.nil?
+        "blocked_by_inquiry" => agent.inquiry_blocking_prompt_queue?
       }
     end
 

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -6833,6 +6833,32 @@ body:has(.inquiry-form-full-screen) {
   gap: 8px;
 }
 
+.composer-action-menu {
+  position: relative;
+}
+
+.composer-action-menu > summary {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.composer-action-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.composer-action-popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: 12;
+  width: min(250px, calc(100vw - 32px));
+  padding: 6px;
+}
+
 .send-actions {
   display: inline-flex;
   align-items: center;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -685,6 +685,7 @@ const state = {
   loadingConversations: {},
   pendingConversationMessages: {},
   pendingComposerKeys: new Set(),
+  pendingInquiryActions: new Map(),
   composerSubmissionChains: {},
   optimisticPromptQueues: {},
   pendingPullRequestCommentKeys: new Set(),
@@ -6723,6 +6724,7 @@ function renderAgentComposer(agent, skills, options = {}) {
             ${renderLinkedAgentsToggle(agent)}
             ${renderAgentViewToggle(agent, options)}
             <button class="skill-toggle-button" type="button" data-toggle-skills aria-label="Insert skill" title="Insert skill">${iconSvg("squareSlash")}</button>
+            ${renderInquiryLifecycleMenu(agent, "restore")}
           </div>
           <div class="send-actions">
             <span class="agent-live-actions" data-agent-live-actions data-agent-live-action-state="${escapeAttr(agentComposerActionState(agent, sending))}">
@@ -6890,6 +6892,7 @@ function renderInquiryForm(agent, options = {}) {
               ${renderPromptAttachmentButton(agent)}
               ${renderAttachmentToggle(agent)}
               ${renderAgentViewToggle(agent, options)}
+              ${renderInquiryLifecycleMenu(agent, "dismiss")}
             </div>
             <div class="send-actions">
               <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit" data-agent-key="${escapeAttr(agent.key)}" disabled>${iconSvg("check")}<span>Send answer</span></button>
@@ -6951,6 +6954,32 @@ function renderAgentViewToggle(agent, options = {}) {
   if (!options.attachmentMode) return "";
 
   return `<button class="agent-view-toggle-button" type="button" data-open-agent="${escapeAttr(agent.key)}" aria-label="Show conversation" title="Conversation">${iconSvg("botMessageSquare")}</button>`;
+}
+
+function renderInquiryLifecycleMenu(agent, action) {
+  const inquiry = action === "dismiss" ? agent?.latest_inquiry : agent?.suspended_inquiry;
+  const inquiryId = String(inquiry?.id || "").trim();
+  if (!inquiryId) return "";
+
+  const pendingAction = state.pendingInquiryActions.get(agent.key);
+  const pending = pendingAction === action;
+  const label = action === "dismiss" ? "Dismiss inquiry" : "Restore inquiry";
+  const pendingLabel = action === "dismiss" ? "Dismissing inquiry" : "Restoring inquiry";
+  const attrs = [
+    `data-inquiry-lifecycle-action="${action}"`,
+    `data-agent-key="${escapeAttr(agent.key)}"`,
+    `data-inquiry-id="${escapeAttr(inquiryId)}"`,
+    `aria-label="${pending ? pendingLabel : label}"`,
+    pending ? 'aria-busy="true"' : "",
+  ].filter(Boolean).join(" ");
+  return `
+    <details class="composer-action-menu" data-overlay-menu data-overlay-key="inquiry-actions:${escapeAttr(agent.key)}" data-state-key="inquiry-actions:${escapeAttr(agent.key)}:${action}">
+      <summary class="ui-button ui-icon-button" aria-label="${pending ? pendingLabel : "Inquiry actions"}" title="Inquiry actions" aria-haspopup="menu"${pending ? ' aria-busy="true"' : ""}>${iconSvg("ellipsis")}</summary>
+      <div class="composer-action-popover ui-overlay-surface" role="menu" aria-label="Inquiry actions" data-overlay-kind="menu">
+        ${moreMenuButton({ label: pending ? pendingLabel : label, icon: action === "dismiss" ? "x" : "rotateCcw", attrs, disabled: Boolean(pendingAction) })}
+      </div>
+    </details>
+  `;
 }
 
 function renderPromptQueue(agent) {
@@ -9638,6 +9667,7 @@ async function submitComposerPrompt(options) {
     submittedAttachments,
     submittedPullRequestContexts,
     pendingMessageId,
+    retireInquiryId,
   } = options;
 
   try {
@@ -9651,6 +9681,7 @@ async function submitComposerPrompt(options) {
       start: true,
       attachments,
       pull_request_contexts: pullRequestContexts,
+      ...(retireInquiryId ? { retire_inquiry_id: retireInquiryId } : {}),
       ...(optimisticQueueEntry ? { client_request_id: optimisticQueueEntry.id } : {}),
     });
     if (response.agent) upsertAgent(response.agent);
@@ -14066,7 +14097,53 @@ els.authPanel.addEventListener("submit", (event) => {
 
 els.saveToken.addEventListener("click", () => withPendingForm(els.authPanel, saveRemoteToken));
 
+async function runInquiryLifecycleAction(button) {
+  const action = button.dataset.inquiryLifecycleAction;
+  const key = button.dataset.agentKey;
+  const inquiryId = button.dataset.inquiryId;
+  if (!action || !key || !inquiryId || state.pendingInquiryActions.has(key)) return;
+
+  state.pendingInquiryActions.set(key, action);
+  state.renderedViewHtml = "";
+  render();
+  try {
+    setConnection(action === "dismiss" ? "Dismissing inquiry" : "Restoring inquiry");
+    const response = await apiPost(
+      `/agents/${encodeURIComponent(key)}/inquiries/${encodeURIComponent(inquiryId)}/${action}`,
+      {}
+    );
+    if (response.agent) upsertAgent(response.agent);
+    if (Array.isArray(response.conversation)) {
+      state.conversations[key] = {
+        revision: response.agent?.revision,
+        blocks: response.conversation,
+        loaded: true,
+        loading: false,
+      };
+    }
+    showGrowl(action === "dismiss" ? "Inquiry dismissed" : "Inquiry restored", "done");
+    state.failureCount = 0;
+    await refresh({ force: true, forceConversation: true });
+  } catch (error) {
+    state.failureCount += 1;
+    const label = action === "dismiss" ? "dismiss" : "restore";
+    showGrowl(`Could not ${label} inquiry: ${error.message}`, "need");
+    setConnection(error.message);
+  } finally {
+    state.pendingInquiryActions.delete(key);
+    state.renderedViewHtml = "";
+    render();
+    schedule();
+  }
+}
+
 function handleViewClick(event) {
+  const inquiryLifecycleAction = event.target.closest("[data-inquiry-lifecycle-action]");
+  if (inquiryLifecycleAction) {
+    closeDetailsOverlay(inquiryLifecycleAction.closest("[data-overlay-menu]"));
+    runInquiryLifecycleAction(inquiryLifecycleAction);
+    return;
+  }
   const editQueuedPrompt = event.target.closest("[data-edit-queued-prompt]");
   if (editQueuedPrompt) {
     const entry = editQueuedPrompt.closest("[data-prompt-queue-entry]");
@@ -15483,6 +15560,7 @@ els.view.addEventListener("submit", (event) => {
       submittedAttachments: pendingAttachments,
       submittedPullRequestContexts,
       pendingMessageId,
+      retireInquiryId: String(findAgent(key)?.suspended_inquiry?.id || ""),
     });
     return;
   }

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -529,6 +529,7 @@
 
   function agentComposerState(agent) {
     if (agent?.latest_inquiry) return "inquiry";
+    if (agent?.suspended_inquiry) return "composer";
     if (agent?.awaiting_input) return "inquiry-loading";
     return "composer";
   }

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -28,6 +28,7 @@ module RemoteServerTest
     assert_remote_memory_handoffs
     assert_remote_metrics_query_and_backfill_routes
     assert_remote_inquiry_payload_has_stable_id_and_guarded_answer
+    assert_remote_inquiry_dismiss_restore_and_retirement_lifecycle
     assert_remote_agent_payload_includes_attachments
     assert_remote_agent_pull_request_diff_payload
     assert_agent_pull_request_listing_avoids_eager_metadata_requests
@@ -870,6 +871,121 @@ module RemoteServerTest
       response = HQ::AgentMemory.new(agent).events.reverse.find { |event| event["type"] == "inquiry_response" }
       assert(response.dig("metadata", "inquiry_id") == inquiry_id,
              "expected inquiry response memory to retain the answered inquiry id")
+    end
+  end
+
+  def assert_remote_inquiry_dismiss_restore_and_retirement_lifecycle
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace)
+      client_a = HQ::RemoteService.new(registry: registry)
+      client_b = HQ::RemoteService.new(registry: registry)
+      created = client_a.create_agent(
+        "project_key" => "web", "template_key" => "custom", "name" => "Inquiry Agent",
+        "prompt" => "Ask before advancing.", "agent" => "codex"
+      )
+      agent = HQ::AgentStore.new(registry.projects).load.find { |item| item.key == created[:key] }
+      inquiry = {
+        "message" => "Choose the next step",
+        "fields" => [{ "key" => "next_step", "label" => "Next step", "input_type" => "text", "required" => true }]
+      }
+      run = HQ::ManagedAgent::AgentRun.new(
+        started_at: Time.utc(2026, 8, 29, 1), finished_at: Time.utc(2026, 8, 29, 1, 1),
+        status: "input_required", log_path: agent.raw_log_path
+      )
+      agent.runs << run
+      agent.structured_result = { "status" => "input_required", "summary" => "Needs input", "inquiry" => inquiry }
+      inquiry_id = agent.send(:inquiry_identity, inquiry, run: run)
+      memory = HQ::AgentMemory.new(agent)
+      memory.append_assistant_message!("I need one decision before continuing.")
+      memory.append_inquiry_request!(inquiry, created_at: run.finished_at, inquiry_id: inquiry_id)
+      HQ::AgentStore.new(registry.projects).save([agent])
+
+      active = HQ::AgentStore.new(registry.projects).load.find { |item| item.key == created[:key] }
+      active.enqueue_prompt!(prompt: "Queued while inquiry is active")
+      assert(!active.prompt_queue_dispatchable?, "expected an active inquiry to block queued prompt dispatch")
+      history_before = client_a.conversation(created[:key])
+
+      race_results = Queue.new
+      [client_a, client_b].map do |client|
+        Thread.new do
+          begin
+            client.dismiss_inquiry(created[:key], inquiry_id)
+            race_results << :dismissed
+          rescue HQ::RemoteServer::Error => e
+            race_results << [e.status, e.message]
+          end
+        end
+      end.each(&:join)
+      outcomes = 2.times.map { race_results.pop }
+      assert(outcomes.count(:dismissed) == 1 && outcomes.count { |outcome| outcome.is_a?(Array) && outcome.first == 409 } == 1,
+             "expected concurrent dismissals to accept exactly one current-state transition: #{outcomes.inspect}")
+
+      reloaded = client_b.agent(created[:key])
+      assert(reloaded[:latest_inquiry].nil?, "expected dismissal to hide the active inquiry")
+      assert(reloaded.dig(:suspended_inquiry, "id") == inquiry_id,
+             "expected another client to reload the same restorable inquiry")
+      suspended = HQ::AgentStore.new(registry.projects).load.find { |item| item.key == created[:key] }
+      suspended.enqueue_prompt!(prompt: "Queued while inquiry is suspended")
+      assert(!suspended.prompt_queue_dispatchable?, "expected a suspended inquiry to block queued prompt dispatch")
+      assert(client_b.conversation(created[:key]) == history_before,
+             "expected dismissal to preserve conversation history exactly")
+
+      restored_route = HQ::RemoteServer.new.send(
+        :route, client_b, "POST", "/agents/#{created[:key]}/inquiries/#{inquiry_id}/restore", {}, nil
+      )
+      assert(restored_route.dig(:body, :agent, :latest_inquiry, "id") == inquiry_id,
+             "expected the restore API route to reactivate the same inquiry")
+      assert(restored_route.dig(:body, :agent, :suspended_inquiry).nil?,
+             "expected restore to clear the restorable payload")
+
+      dismissed_route = HQ::RemoteServer.new.send(
+        :route, client_a, "POST", "/agents/#{created[:key]}/inquiries/#{inquiry_id}/dismiss", {}, nil
+      )
+      assert(dismissed_route.dig(:body, :agent, :suspended_inquiry, "id") == inquiry_id,
+             "expected the dismiss API route to persist restorable state")
+
+      [nil, "another-inquiry"].each do |retire_id|
+        begin
+          attrs = { "prompt" => "Advance without answering", "start" => false }
+          attrs["retire_inquiry_id"] = retire_id if retire_id
+          client_b.submit_prompt(created[:key], attrs)
+          raise "expected an unintended suspended inquiry retirement to fail"
+        rescue HQ::RemoteServer::Error => e
+          assert(e.status == 409, "expected stale ordinary prompt context to return conflict")
+        end
+      end
+
+      retired = client_b.submit_prompt(
+        created[:key],
+        "prompt" => "Advance with the ordinary prompt",
+        "retire_inquiry_id" => inquiry_id,
+        "start" => false
+      )
+      assert(retired[:agent][:latest_inquiry].nil? && retired[:agent][:suspended_inquiry].nil?,
+             "expected the intended ordinary prompt to retire the suspended inquiry")
+      assert(retired[:conversation].first(history_before.length) == history_before,
+             "expected retirement to preserve existing conversation history")
+      assert(retired[:conversation].last[:content] == "Advance with the ordinary prompt",
+             "expected retirement to append the ordinary prompt normally")
+
+      after_reload = HQ::RemoteService.new(registry: registry).agent(created[:key])
+      assert(after_reload[:latest_inquiry].nil? && after_reload[:suspended_inquiry].nil?,
+             "expected retired inquiry state to remain retired after reload")
+      events = HQ::AgentMemory.new(
+        HQ::AgentStore.new(registry.projects).load.find { |item| item.key == created[:key] }
+      ).events
+      retired_event = events.reverse.find { |event| event["type"] == "inquiry_retired" }
+      assert(retired_event.dig("metadata", "inquiry_id") == inquiry_id,
+             "expected retirement to record only the intended suspended inquiry id")
+
+      begin
+        client_a.restore_inquiry(created[:key], inquiry_id)
+        raise "expected retired inquiry restore to fail"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.status == 409, "expected retired inquiry restore to be rejected")
+      end
     end
   end
 
@@ -4823,6 +4939,22 @@ module RemoteServerTest
            "expected Remote UI to serialize inquiry answers")
     assert(js[:body].include?('/inquiries/${encodeURIComponent(inquiryId)}/answer'),
            "expected Remote UI inquiry answers to use the guarded answer endpoint")
+    assert(js[:body].include?("function renderInquiryLifecycleMenu") &&
+           js[:body].include?('data-inquiry-lifecycle-action="${action}"') &&
+           js[:body].include?('aria-label="Inquiry actions"') &&
+           js[:body].include?('aria-busy="true"'),
+           "expected inquiry and composer context menus to expose accessible pending lifecycle actions")
+    assert(js[:body].include?('action === "dismiss" ? "Dismiss inquiry" : "Restore inquiry"') &&
+           js[:body].include?('action === "dismiss" ? "Dismissing inquiry" : "Restoring inquiry"'),
+           "expected dismiss and restore actions to expose stable accessible names and pending labels")
+    assert(js[:body].include?("function runInquiryLifecycleAction") &&
+           js[:body].include?('showGrowl(`Could not ${label} inquiry: ${error.message}`, "need")'),
+           "expected inquiry lifecycle actions to announce failures")
+    assert(js[:body].include?('retire_inquiry_id: retireInquiryId') &&
+           js[:body].include?('findAgent(key)?.suspended_inquiry?.id'),
+           "expected ordinary prompts to retire only the suspended inquiry rendered by that client")
+    assert(css[:body].include?(".composer-action-menu") && css[:body].include?(".composer-action-popover"),
+           "expected inquiry lifecycle context menus to be positioned in both composers")
     assert(js[:body].include?("normalizeInquiryInputType"),
            "expected Remote UI to normalize inquiry field input types")
     assert(js[:body].include?("function setHeaderMore"), "expected Remote UI to expose reusable header More menus")


### PR DESCRIPTION
## Summary

- persist inquiry dismiss, restore, and retirement transitions in the canonical agent event journal
- expose guarded API actions and ID-scoped ordinary-prompt retirement while keeping queued prompts blocked
- add accessible inquiry/composer context menus with pending and failure feedback
- preserve Remote UI and TUI behavior across reloads, clients, and stale-action races

Fizzy: https://fizzy.startkit.tech/1/cards/135

## Verification

- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/prompt_queue_test.rb`
- `bundle exec ruby test/rendering_test.rb`
- `bundle exec ruby test/app_agent_persistence_test.rb`
- `bundle exec ruby test/delegation_test.rb`
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb`
- `bin/test`
- Ruby and JavaScript syntax checks
- `git diff --check`

### Manual TUI smoke

Ran `bin/tycho` in a PTY. The startup sequence completed into the Agents dashboard with the Agents, Projects, and Schedules tabs plus the selected agent detail visible. Pressed `q`, confirmed `Quit Tycho?` with `y`, and returned cleanly to the terminal.

### Remote UI browser capture

`bin/remote-ui-smoke` ran in headless Chrome at the mobile inquiry viewport and verified these concrete states:

- the active inquiry context menu exposed `Dismiss inquiry` with an `Inquiry actions` accessible name;
- the pending dismiss state exposed `Dismissing inquiry`, `aria-busy="true"`, and a disabled action;
- after switching the fixture to suspended state, the ordinary composer context menu exposed `Restore inquiry`.

Concise terminal capture:

```text
$ bin/remote-ui-smoke
PR rendering (5,000 lines): full 112.7ms sync / selection 21.2ms sync / first poll 67.7ms sync / steady poll 31.2ms sync
remote-ui-smoke: ok
```