### PR TITLE
Refine splash and silence queued-run pushes

### DIFF
--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -498,6 +498,8 @@ module HQ
         return true
       end
 
+      agent.mark_last_run_prompt_queue_claim!(claim["id"]) if agent.run_count > baseline
+
       if accepted && agent.run_count > baseline
         agent.complete_prompt_queue_claim!
       else

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -488,6 +488,18 @@ module HQ
       @prompt_queue_dispatch_error = nil
     end
 
+    def mark_last_run_prompt_queue_claim!(claim_id)
+      return false unless last_run
+
+      last_run.metadata = {} unless last_run.metadata.is_a?(Hash)
+      last_run.metadata["prompt_queue_claim_id"] = claim_id.to_s
+      true
+    end
+
+    def last_run_from_prompt_queue?
+      !last_run&.metadata&.fetch("prompt_queue_claim_id", nil).to_s.empty?
+    end
+
     def fail_prompt_queue_dispatch!(message, failed_at: Time.now)
       @prompt_queue_dispatch_error = {
         "message" => message.to_s.strip,

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -3806,6 +3806,7 @@ module HQ
 
     def agent_push_payload(agent, unread_count:)
       return nil if agent.respond_to?(:no_action_needed?) && agent.no_action_needed?
+      return nil if agent.last_run_from_prompt_queue?
 
       status = agent.status
       if status == "awaiting-input"

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -816,8 +816,7 @@ let confirmationFocusOrigin = null;
 
 const els = {
   bootShell: document.getElementById("tycho-boot-shell"),
-  bootMessage: document.getElementById("tycho-boot-message"),
-  bootRetry: document.getElementById("tycho-boot-retry"),
+  bootParticles: document.getElementById("tycho-boot-particles"),
   app: document.getElementById("app"),
   header: document.querySelector(".app-header"),
   summaryAttachmentOverlay: document.getElementById("summary-attachment-overlay-root"),
@@ -846,6 +845,38 @@ const els = {
 
 const BOOT_TIMEOUT_MS = 15_000;
 let bootTimeout = null;
+let bootParticleTimer = null;
+
+function randomBootParticleValue(minimum, maximum) {
+  return minimum + (Math.random() * (maximum - minimum));
+}
+
+function emitBootParticles() {
+  if (!els.bootParticles || els.bootShell?.hidden || window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+  const count = 3 + Math.floor(Math.random() * 3);
+  const fragment = document.createDocumentFragment();
+  for (let index = 0; index < count; index += 1) {
+    const particle = document.createElement("span");
+    const angle = randomBootParticleValue(0, Math.PI * 2);
+    const distance = randomBootParticleValue(104, 184);
+    particle.className = "tycho-boot-particle";
+    particle.style.setProperty("--tycho-particle-size", `${randomBootParticleValue(4.5, 10.5).toFixed(1)}px`);
+    particle.style.setProperty("--tycho-particle-duration", `${Math.round(randomBootParticleValue(600, 900))}ms`);
+    particle.style.setProperty("--tycho-particle-x", `${(Math.cos(angle) * distance).toFixed(1)}px`);
+    particle.style.setProperty("--tycho-particle-y", `${(Math.sin(angle) * distance).toFixed(1)}px`);
+    particle.addEventListener("animationend", () => particle.remove(), { once: true });
+    fragment.appendChild(particle);
+  }
+  els.bootParticles.appendChild(fragment);
+  bootParticleTimer = window.setTimeout(emitBootParticles, Math.round(randomBootParticleValue(100, 200)));
+}
+
+function stopBootParticles() {
+  window.clearTimeout(bootParticleTimer);
+  bootParticleTimer = null;
+  els.bootParticles?.replaceChildren();
+}
 
 function bootError(message, kind = "failed") {
   const error = new Error(message);
@@ -857,12 +888,12 @@ function setBootShell(stateName, message) {
   if (!els.bootShell || els.bootShell.hidden) return;
   els.bootShell.dataset.state = stateName;
   els.bootShell.setAttribute("aria-label", message);
-  if (els.bootMessage) els.bootMessage.textContent = message;
 }
 
 function dismissBootShell() {
   if (!els.bootShell || els.bootShell.hidden) return;
   window.clearTimeout(bootTimeout);
+  stopBootParticles();
   els.app?.setAttribute("aria-busy", "false");
   els.bootShell.classList.add("is-leaving");
   window.setTimeout(() => {
@@ -17075,12 +17106,7 @@ window.visualViewport?.addEventListener("scroll", syncFullScreenComposerViewport
 els.tokenInput.value = token();
 render();
 scheduleBootTimeout();
-els.bootRetry?.addEventListener("click", () => {
-  setBootShell("loading", "Trying to connect to Remote UI…");
-  els.app?.setAttribute("aria-busy", "true");
-  scheduleBootTimeout();
-  refresh({ force: true });
-});
+emitBootParticles();
 window.addEventListener("offline", () => failBootShell(bootError("Network unavailable", "offline")));
 window.addEventListener("online", () => {
   if (els.bootShell && !els.bootShell.hidden) refresh({ force: true });

--- a/lib/hq/remote_ui/templates/index.html.erb
+++ b/lib/hq/remote_ui/templates/index.html.erb
@@ -19,23 +19,23 @@
       .tycho-boot-shell { position: fixed; z-index: 100; inset: 0; display: grid; place-items: center; min-height: 100vh; min-height: 100dvh; padding: max(24px, env(safe-area-inset-top, 0px)) 24px max(24px, env(safe-area-inset-bottom, 0px)); background: #282a36; text-align: center; transition: opacity 160ms ease, visibility 160ms ease; }
       .tycho-boot-shell[hidden] { display: none; }
       .tycho-boot-shell.is-leaving { opacity: 0; visibility: hidden; pointer-events: none; }
-      .tycho-boot-card { display: grid; justify-items: center; gap: 14px; width: min(100%, 320px); }
-      .tycho-boot-mark { width: 72px; height: 72px; color: #ff8a00; filter: drop-shadow(0 0 15px rgba(255, 138, 0, .3)); animation: tycho-boot-orbit 1.5s ease-in-out infinite; }
+      .tycho-boot-card { position: relative; display: grid; place-items: center; }
+      .tycho-boot-particles { position: absolute; z-index: 0; inset: -160px; overflow: visible; pointer-events: none; -webkit-mask-image: radial-gradient(circle, transparent 0 34px, #000 36px); mask-image: radial-gradient(circle, transparent 0 34px, #000 36px); }
+      .tycho-boot-particle { position: absolute; top: 50%; left: 50%; width: var(--tycho-particle-size); height: var(--tycho-particle-size); border-radius: 50%; background: #fff; box-shadow: 0 0 5px rgba(255, 255, 255, .55); opacity: 0; animation: tycho-boot-particle var(--tycho-particle-duration) ease-out forwards; }
+      .tycho-boot-mark { position: relative; z-index: 1; width: 72px; height: 72px; color: #ff8a00; filter: drop-shadow(0 0 15px rgba(255, 138, 0, .3)); animation: tycho-boot-orbit 2s ease-in-out infinite; }
       .tycho-boot-mark path { fill: none; stroke: currentColor; stroke-width: 5; stroke-linecap: butt; }
       .tycho-boot-mark .tycho-boot-light { stroke: #f3f1ea; }
       .tycho-boot-mark .tycho-boot-muted { stroke: #9c9c9c; }
       .tycho-boot-mark rect { fill: #f3f1ea; }
-      .tycho-boot-title { margin: 0; font-size: 22px; line-height: 1.15; letter-spacing: -.02em; }
-      .tycho-boot-message { margin: 0; color: #b8b8c8; font-size: 15px; line-height: 1.45; }
-      .tycho-boot-action { display: none; min-height: 42px; border: 1px solid #ff8a00; border-radius: 8px; background: #ff8a00; color: #282a36; padding: 0 14px; font: inherit; font-weight: 700; cursor: pointer; }
-      .tycho-boot-shell[data-state="offline"] .tycho-boot-action, .tycho-boot-shell[data-state="failed"] .tycho-boot-action { display: inline-flex; align-items: center; justify-content: center; }
-      @keyframes tycho-boot-orbit { 0%, 100% { opacity: .62; transform: scale(.94) rotate(0deg); } 50% { opacity: 1; transform: scale(1.04) rotate(10deg); } }
-      @media (prefers-reduced-motion: reduce) { .tycho-boot-shell { transition: none; } .tycho-boot-mark { animation: none; } }
+      @keyframes tycho-boot-orbit { 0%, 25% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+      @keyframes tycho-boot-particle { from { opacity: .95; transform: translate(-50%, -50%) scale(.7); } 55% { opacity: .95; } to { opacity: 0; transform: translate(calc(-50% + var(--tycho-particle-x)), calc(-50% + var(--tycho-particle-y))) scale(.2); } }
+      @media (prefers-reduced-motion: reduce) { .tycho-boot-shell { transition: none; } .tycho-boot-mark { animation: none; } .tycho-boot-particles { display: none; } }
     </style>
   </head>
   <body>
     <section id="tycho-boot-shell" class="tycho-boot-shell" data-state="loading" role="status" aria-live="polite" aria-atomic="true" aria-label="Tycho is loading">
       <div class="tycho-boot-card">
+        <div id="tycho-boot-particles" class="tycho-boot-particles" aria-hidden="true"></div>
         <svg class="tycho-boot-mark" aria-hidden="true" viewBox="0 0 64 64">
           <path d="M7 27a25 25 0 0 1 20-20"></path>
           <path class="tycho-boot-light" d="M37 7a25 25 0 0 1 20 20"></path>
@@ -43,9 +43,6 @@
           <path class="tycho-boot-muted" d="M27 57A25 25 0 0 1 7 37"></path>
           <rect x="30" y="24" width="4" height="4"></rect><rect x="30" y="30" width="4" height="4"></rect><rect x="30" y="38" width="4" height="4"></rect>
         </svg>
-        <h1 class="tycho-boot-title">Tycho</h1>
-        <p id="tycho-boot-message" class="tycho-boot-message">Connecting to Remote UI&hellip;</p>
-        <button id="tycho-boot-retry" class="tycho-boot-action" type="button">Try again</button>
       </div>
     </section>
     <div id="pull-refresh" class="pull-refresh" aria-hidden="true">

--- a/test/prompt_queue_test.rb
+++ b/test/prompt_queue_test.rb
@@ -83,6 +83,8 @@ module PromptQueueTest
       persisted = store.load.find { |candidate| candidate.key == agent.key }
       assert(persisted.run_count == 2, "expected a multi-client claim race to start exactly one follow-up run")
       assert(persisted.queued_prompts.empty?, "expected an accepted claim to be removed")
+      assert(persisted.last_run_from_prompt_queue?,
+             "expected a queue-dispatched run to retain its queue provenance")
       queued_message = HQ::AgentMemory.new(persisted).events.find do |event|
         event.dig("metadata", "prompt_queue_claim_id")
       end

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4014,6 +4014,36 @@ module RemoteServerTest
       no_action_result = service.send(:dispatch_agent_push_events, [forged_no_action_event], agents: HQ::AgentStore.new([]).load)
       assert(no_action_result[:events].zero?, "expected no-action events to be ignored by push dispatch")
       assert(notifier.payloads.length == 2, "expected forged no-action event not to send a push payload")
+      queued_at = Time.now
+      queued_agent = HQ::ManagedAgent.new(
+        key: "web-agent-4",
+        name: "Queue agent",
+        project_key: "web",
+        template_key: "default",
+        workspace: workspace,
+        prompt: "Queued follow-up",
+        started_at: queued_at,
+        finished_at: queued_at,
+        last_exit_code: 0,
+        summary: "Run finished",
+        unread: true,
+        runs: [HQ::ManagedAgent::AgentRun.new(
+          started_at: queued_at,
+          finished_at: queued_at,
+          exit_code: 0,
+          status: "succeeded",
+          metadata: { "prompt_queue_claim_id" => "claim-1" }
+        )]
+      )
+      queued_event = HQ::AgentStore::PollEvent.new(
+        agent_key: queued_agent.key,
+        from_status: "running",
+        to_status: "succeeded",
+        run_count: 1
+      )
+      queued_result = service.send(:dispatch_agent_push_events, [queued_event], agents: [queued_agent])
+      assert(queued_result[:events].zero?, "expected queue-dispatched runs to skip push notifications")
+      assert(notifier.payloads.length == 2, "expected queued completion not to send a push payload")
       read_payload = service.mark_agent_read("web-agent-2")
       assert(!read_payload[:unread], "expected explicit reading mutation to clear unread state")
       read_agent = service.agents.find { |agent| agent[:key] == "web-agent-2" }
@@ -4125,9 +4155,16 @@ module RemoteServerTest
            response[:body].include?('data-state="loading"') &&
            response[:body].include?('role="status" aria-live="polite" aria-atomic="true"'),
            "expected root shell to provide an accessible server-rendered loading surface")
-    assert(response[:body].include?('id="tycho-boot-retry"') &&
-           response[:body].include?('class="tycho-boot-mark"'),
-           "expected root shell to expose branded loading and recovery controls before application JavaScript")
+    assert(response[:body].include?('class="tycho-boot-mark"') &&
+           response[:body].include?('id="tycho-boot-particles"') &&
+           response[:body].include?('@keyframes tycho-boot-particle') &&
+           response[:body].include?('inset: -160px') &&
+           response[:body].include?('rotate(360deg)') &&
+           response[:body].include?('animation: tycho-boot-orbit 2s ease-in-out infinite') &&
+           response[:body].include?('0%, 25% { transform: rotate(0deg); }') &&
+           !response[:body].include?('id="tycho-boot-message"') &&
+           !response[:body].include?('id="tycho-boot-retry"'),
+           "expected root shell to expose a text-free branded loading animation before application JavaScript")
     assert(response[:body].include?('@media (prefers-reduced-motion: reduce)') &&
            response[:body].include?('animation: none;'),
            "expected root shell to provide a static reduced-motion loading state")

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -30,17 +30,38 @@ module RemoteUIAssetSnapshotTest
       'data-state="loading"',
       'role="status"',
       'aria-live="polite"',
-      'id="tycho-boot-retry"',
       'class="tycho-boot-mark"',
+      'id="tycho-boot-particles"',
+      '.tycho-boot-particle',
+      '@keyframes tycho-boot-particle',
+      'rotate(360deg)',
+      'animation: tycho-boot-orbit 2s ease-in-out infinite',
+      '0%, 25% { transform: rotate(0deg); }',
       '@media (prefers-reduced-motion: reduce)',
       'id="app" class="app-shell" aria-busy="true"',
       'href="/manifest.webmanifest?v=<%= HQ::RemoteUI.asset_version %>"'
     ]
     missing_template = required_template.reject { |fragment| template.include?(fragment) }
     raise "missing initial loading shell contract: #{missing_template.join(", ")}" unless missing_template.empty?
+    forbidden_template = [
+      'class="tycho-boot-title"',
+      'id="tycho-boot-message"',
+      'id="tycho-boot-retry"'
+    ]
+    present_template = forbidden_template.select { |fragment| template.include?(fragment) }
+    raise "text remains in initial loading shell: #{present_template.join(", ")}" unless present_template.empty?
 
     required_javascript = [
       "const BOOT_TIMEOUT_MS = 15_000;",
+      "const count = 3 + Math.floor(Math.random() * 3);",
+      "randomBootParticleValue(104, 184)",
+      "randomBootParticleValue(4.5, 10.5)",
+      "randomBootParticleValue(100, 200)",
+      "function emitBootParticles()",
+      "function stopBootParticles()",
+      "particle.addEventListener(\"animationend\"",
+      "stopBootParticles();",
+      "emitBootParticles();",
       "function bootNetworkFailure(error)",
       "error?.bootFailureKind === \"offline\"",
       "error instanceof TypeError",
@@ -50,7 +71,6 @@ module RemoteUIAssetSnapshotTest
       "function failBootShell(error)",
       "if (error.status === 401) dismissBootShell();",
       "else failBootShell(error);",
-      "els.bootRetry?.addEventListener(\"click\"",
       "scheduleBootTimeout();",
       "window.addEventListener(\"offline\"",
       "window.addEventListener(\"online\""


### PR DESCRIPTION
## Summary
- simplify the Remote UI splash to a text-free Tycho mark with a paused, eased single rotation and randomized outward particles
- preserve reduced-motion behavior and stop particle work immediately when the splash dismisses
- stamp prompt-queue runs with durable provenance and suppress their push notifications while preserving in-app unread state

## Verification
- `bin/test`
- Chrome at 390x844 against a throwaway Remote UI server
