### PR TITLE
Prepare v0.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+## 0.10.2 - 2026-08-30
+
+### Highlights
+
+- Persist validated Second Brain memory handoffs on successful runs and expose
+  them through the local or remote `tycho memory handoffs` command and Remote
+  Sessions API.
+- Add Pi as a first-class harness across managed execution, native session
+  resume, structured result correction, setup, usage metrics, skills, TUI, and
+  Remote UI.
+- Add ordered rich summary sections for prose, links, and attachments while
+  preserving the existing concise run summary.
+- Let operators dismiss and restore inquiries without rewriting conversation
+  history, with guarded actions in both Remote UI and TUI workflows.
+- Show a branded, retryable loading shell while the Remote UI or installed PWA
+  starts, including clear offline and timeout states.
+
+### Fixes
+
+- Finalize managed runs correctly when their exit-status file arrives before
+  the wrapper process exits, preserving successful status and memory handoffs.
+- Distinguish a running agent without a completed summary from an agent that has
+  never run.
+- Suppress push notifications for prompt-queue continuation runs while keeping
+  their in-app unread state.
+
+### Other changes
+
+- Test CI on Ruby 4.0 while retaining Ruby 3.2+ as the documented runtime
+  requirement.
+- Refine the Remote UI startup animation and reduced-motion behavior.
+
 ## 0.10.1 - 2026-08-27
 
 ### Highlights

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-08-29
+2026-08-30
 
 ## Strategic Direction
 
@@ -95,28 +95,17 @@ Key references:
 
 ## Current Focus
 
-**v0.10.1 release**: remote CLI control, server-owned credentials, structured
-output correction, auditable usage metrics, project workspace browsing, Tycho
-skill installation, pull-request context, and durable agent delegation are
-complete. Ownership-aware takeover/report routing now includes edge-local
-generations, run stamps, stale-report suppression, parent-reclaim inquiry
-cancellation, explicit trusted parent declarations, and ancestor-operation rejection.
-Remote UI now keeps compact agent activity live independently from
-page polling, preserves focused work, and adds direct navigation across run
-summaries, attachments, and linked agents from both the composer and quick
-agent switcher. Running agents now accept ordinary Remote UI prompts into a
-synchronized, editable server-side queue. The composer switches immediately
-into queue mode without blocking on submission, shows locally persisted
-optimistic entries until the server accepts their stable client IDs, and keeps
-Stop in the shared top action row across conversation and attachment layouts.
-Terminal runs claim pending entries as one ordered follow-up prompt, while
-inquiries and retryable start failures retain the queue without silently
-advancing the conversation. The release also keeps live agent conversations in
-a durable incremental journal, makes delegation takeover and parent reclaim
-explicit, surfaces linked-agent navigation, improves Remote UI lifecycle and
-reliability visibility, and ranks agent search results with matched-text
-highlights. Schedule-management work remains on `wip/tui-schedule-management`
-for a later release.
+**v0.10.2 release**: successful managed runs can now persist validated Second
+Brain memory handoffs and expose them through local or remote CLI and API
+feeds. Pi is a first-class managed harness with native session resume,
+structured result correction, setup discovery, usage metrics, skills, and UI
+support. Structured results can also render ordered prose, links, and
+attachments beneath the concise run summary. Operators can dismiss and restore
+inquiries without rewriting conversation history, while the Remote UI adds a
+branded, retryable startup shell for browser and installed-PWA launches. The
+release also corrects run finalization races, running-agent empty summaries,
+and queued-run push notification behavior. Schedule-management work remains on
+`wip/tui-schedule-management` for a later release.
 
 ## Roadmap
 

--- a/lib/hq/version.rb
+++ b/lib/hq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HQ
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end


### PR DESCRIPTION
## Summary
- bump Tycho to v0.10.2
- document the nine user-visible changes since v0.10.1, including Second Brain memory handoffs, Pi harness support, rich summary sections, inquiry suspension, and the PWA loading shell
- update the current release milestone and retain schedule-management work for a later release

## Validation
- bin/test
- bundle exec gem build hq.gemspec --output /tmp/tycho-0.10.2.gem
- git diff --check

## Compatibility
- additive local and remote memory-handoff command/API contract
- additive structured-result summary sections and Pi harness support
- no breaking config migration