### PR TITLE
Clarify structured summary guidance

### DIFF
--- a/config/schemas/agent_result.json
+++ b/config/schemas/agent_result.json
@@ -13,7 +13,7 @@
     },
     "summary_sections": {
       "type": ["array", "null"],
-      "description": "Optional ordered rich blocks used instead of summary on the full Summary page. When provided, make them a standalone expanded account of the run; summary remains the concise preview shown in compact surfaces. Use text blocks for Markdown prose, link blocks for inline links, and attachment blocks for durable artifacts. Keep the array in reading order.",
+      "description": "Always provide a non-empty summary as the concise preview. Set summary_sections to null for simple runs. For substantive runs such as investigations, reviews, builds, or plans with multiple findings, decisions, or verification results, provide ordered rich blocks as a standalone expanded account used instead of summary on the full Summary page. Put headings, bullets, numbered lists, tables, and prose in Markdown text blocks; use link and attachment blocks for their respective targets. Set every unused block field to null. Keep the array in reading order. Example Markdown list block: {\"type\":\"text\",\"text\":\"## Findings\\n- First\\n- Second\",\"url\":null,\"attachment\":null}.",
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/lib/hq/domain/managed_agent.rb
+++ b/lib/hq/domain/managed_agent.rb
@@ -120,8 +120,18 @@ module HQ
       TYCHO_GITHUB_TOKEN
       TYCHO_REMOTE_TOKEN
     ].freeze
+    SUMMARY_SECTIONS_EXAMPLE = '{"type":"text","text":"## Findings\\n- First\\n- Second","url":null,"attachment":null}'
+    SUMMARY_SECTIONS_GUIDANCE = "Always provide a non-empty `summary` as the concise preview. " \
+                                "Set `summary_sections` to `null` for simple runs. For substantive runs such as " \
+                                "investigations, reviews, builds, or plans with multiple findings, decisions, or " \
+                                "verification results, provide ordered rich blocks as a standalone expanded " \
+                                "account. Put headings, bullets, numbered lists, tables, and prose in Markdown " \
+                                "`text` blocks; use `link` and `attachment` blocks for their respective targets. " \
+                                "Set every unused block field to `null`. Example Markdown list block: " \
+                                "`#{SUMMARY_SECTIONS_EXAMPLE}`"
     FINAL_OUTPUT_CHECKLIST = "For `summary`, write a concise operator-facing Markdown summary of the outcome, " \
                              "key changes or findings, blockers, and next steps in 1-3 short paragraphs or bullets. " \
+                             "#{SUMMARY_SECTIONS_GUIDANCE} " \
                              "#{NO_ACTION_STATUS_GUIDANCE} " \
                              "Before final structured output, check whether this run created or referenced a PR, " \
                              "plan, review, report, markdown file, image, or other durable artifact. " \

--- a/test/managed_agent_test.rb
+++ b/test/managed_agent_test.rb
@@ -35,6 +35,7 @@ module ManagedAgentTest
     assert_memory_rebuild_prices_codex_token_deltas
     assert_memory_rebuild_uses_each_runs_recorded_model
     assert_final_output_checklist_is_ephemeral_execution_context
+    assert_summary_sections_guidance_reaches_every_harness_run
     assert_response_style_applies_to_cold_and_resumed_runs
     assert_native_resume_includes_same_second_follow_up
     assert_response_style_can_be_disabled_and_run_session_is_recorded
@@ -1339,6 +1340,10 @@ module ManagedAgentTest
              "final output guidance should distinguish no-op checks from completed work")
       assert(checklist.include?("quiet outcome that suppresses operator unread and push notifications"),
              "final output guidance should disclose the quiet no-action consequence")
+      assert(checklist.include?(HQ::ManagedAgent::SUMMARY_SECTIONS_GUIDANCE),
+             "final output guidance should include the shared summary sections decision rule")
+      assert(checklist.include?(HQ::ManagedAgent::SUMMARY_SECTIONS_EXAMPLE),
+             "final output guidance should include a strict Markdown list block example")
       log_path = File.join(dir, "checklist.raw.log")
 
       agent = HQ::ManagedAgent.new(
@@ -1401,6 +1406,55 @@ module ManagedAgentTest
     end
   end
 
+  def assert_summary_sections_guidance_reaches_every_harness_run
+    %w[codex claude opencode pi].each do |harness|
+      cold = HQ::ManagedAgent.new(
+        key: "#{harness}-summary-guidance-cold",
+        name: "#{harness.capitalize} Summary Guidance Cold",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: Dir.tmpdir,
+        prompt: "Complete a substantive review.",
+        agent: harness
+      )
+      assert_summary_sections_guidance(cold.send(:build_command).fetch(:command).last, harness, "cold")
+
+      resumed = HQ::ManagedAgent.new(
+        key: "#{harness}-summary-guidance-resumed",
+        name: "#{harness.capitalize} Summary Guidance Resumed",
+        project_key: "demo",
+        template_key: "custom",
+        workspace: Dir.tmpdir,
+        prompt: "Original prompt.",
+        agent: harness,
+        session_id: "#{harness}-summary-guidance-session",
+        session_bootstrapped: true,
+        runs: [
+          HQ::ManagedAgent::AgentRun.new(
+            started_at: Time.now - 60,
+            finished_at: Time.now - 30,
+            exit_code: 0,
+            status: "success"
+          )
+        ]
+      )
+      resumed.add_user_message!("Continue the substantive review.")
+      assert_summary_sections_guidance(resumed.send(:build_command).fetch(:command).last, harness, "resumed")
+    end
+  end
+
+  def assert_summary_sections_guidance(prompt, harness, phase)
+    assert(prompt.include?("Always provide a non-empty `summary`"),
+           "expected #{phase} #{harness} prompt to require the compact summary")
+    assert(prompt.include?("Set `summary_sections` to `null` for simple runs"),
+           "expected #{phase} #{harness} prompt to define the null case")
+    assert(prompt.include?("For substantive runs such as investigations, reviews, builds, or plans"),
+           "expected #{phase} #{harness} prompt to define when rich sections are useful")
+    assert(prompt.include?("Markdown `text` blocks") &&
+           prompt.include?(HQ::ManagedAgent::SUMMARY_SECTIONS_EXAMPLE),
+           "expected #{phase} #{harness} prompt to include Markdown list encoding guidance")
+  end
+
   def assert_agent_result_schema_describes_summary
     schema_path = File.expand_path("../config/schemas/agent_result.json", __dir__)
     schema = JSON.parse(File.read(schema_path))
@@ -1421,6 +1475,11 @@ module ManagedAgentTest
     assert(sections.dig("items", "required") == %w[type text url attachment] &&
            sections.dig("items", "properties", "type", "enum") == %w[text link attachment],
            "agent result schema should require ordered rich summary blocks")
+    sections_description = sections.fetch("description")
+    assert(sections_description.include?("Set summary_sections to null for simple runs") &&
+           sections_description.include?("For substantive runs such as investigations, reviews, builds, or plans") &&
+           sections_description.include?("Example Markdown list block"),
+           "agent result schema should explain when and how to produce rich summary blocks")
 
     old_schema_path = replace_constant(HQ, :AGENT_RESULT_SCHEMA, schema_path)
     agent = HQ::ManagedAgent.new(

--- a/test/memory_handoff_test.rb
+++ b/test/memory_handoff_test.rb
@@ -90,6 +90,9 @@ module MemoryHandoffTest
       assert(migrated.fetch("required").include?("summary_sections"), "expected required root summary sections migration")
       assert(migrated.dig("properties", "summary_sections", "type") == %w[array null],
              "expected summary sections schema migration")
+      assert(migrated.dig("properties", "summary_sections", "description").to_s
+                     .include?("Set summary_sections to null for simple runs"),
+             "expected schema migration to install the summary sections production guidance")
       assert(migrated.dig("properties", "memory_handoff", "required") ==
              %w[outcome decisions continuing_context references lessons promotion_candidates],
              "expected strict handoff schema migration")


### PR DESCRIPTION
## Summary
- teach every managed harness when to return `summary_sections: null` and when to provide an expanded rich summary
- show the strict Markdown `text` block shape for headings and semantic lists while keeping `summary` mandatory
- update the canonical schema description, including migration into existing user-owned schemas
- cover Codex, Claude, OpenCode, and Pi on both cold and resumed runs

## Verification
- `bundle exec ruby test/managed_agent_test.rb`
- `bundle exec ruby test/memory_handoff_test.rb`
- `bundle exec ruby test/structured_output_validation_test.rb`
- `bundle exec ruby test/rendering_test.rb`
- `bin/test`
- `git diff --check`

Context: [Fizzy card 143](https://fizzy.startkit.tech/0000001/cards/143) and the rich-block implementation in #94.