### PR TITLE
Trim README to an operator quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ The complete annotated configuration is in
 hooks, and response style use separate files under `~/.tycho/config`.
 
 Tycho launches agent CLIs with access to the selected project. Review project
-paths, prompts, and sandbox settings before starting an agent. Do not commit
-your Tycho config, `.env`, logs, transcripts, or generated agent artifacts;
-they may contain local paths, source context, or credentials. See the
-[security policy](SECURITY.md).
+paths, prompts, and sandbox settings before starting an agent. Pi has
+[no native sandbox equivalent](docs/PI_CODING_AGENT.md#sandbox-behavior).
+Do not commit your Tycho config, `.env`, logs, transcripts, or generated agent
+artifacts; they may contain local paths, source context, or credentials. See
+the [security policy](SECURITY.md).
 
 ## Run
 
@@ -76,6 +77,13 @@ Open the TUI:
 ```bash
 tycho
 ```
+
+To run your first agent:
+
+1. Press `2` and select the project with `j`/`k`.
+2. Press `n`, enter a name and prompt, then choose **Create and Run Agent**.
+3. Continue in the open chat. Type a follow-up and press Enter; reopen the chat
+   later with `c` or Enter on the selected agent.
 
 Start the browser-based Remote UI:
 

--- a/README.md
+++ b/README.md
@@ -1,86 +1,23 @@
-
-
 # Tycho
 
-Tycho - Factorio for Agents.
+Tycho is a local-first control center for supervising coding-agent sessions
+across projects. It gives a solo developer or technical lead one place to
+start agents, answer follow-up questions, inspect logs and results, and run
+recurring work. Use it in the terminal or through its optional Remote UI.
 
-Tycho is a local-first control center for supervising managed coding agents
-across many projects. It keeps project context, agent sessions, schedules,
-logs, attachments, and follow-up questions in one operator workflow, with both
-a terminal UI and an optional lightweight Remote UI for checking agent state
-from a browser on your local network or tailnet.
+![Tycho terminal dashboard and remote agent control interface](docs/assets/tycho-hero.jpg)
 
-## Screenshots
+Tycho currently supports Codex, Claude, OpenCode, Pi, and custom
+Claude-compatible harnesses. It keeps each agent's conversation, status, and
+artifacts under your local `~/.tycho` directory.
 
-<p align="center">
-  <img src="docs/assets/tycho-hero.jpg" alt="Tycho terminal dashboard and remote agent control interface" width="100%">
-</p>
+Tycho is early, single-operator software. Homebrew installs target macOS;
+source installs also work in Linux-style environments and Windows 11 through
+WSL when Ruby and the selected agent CLIs are available.
 
-### TUI
+## Install
 
-| Agents dashboard | New project |
-|------------------|-------------|
-| <img src="docs/assets/readme/tui-agents-list.png" alt="Tycho TUI agents dashboard with selected agent details" width="420"> | <img src="docs/assets/readme/tui-new-project.png" alt="Tycho TUI new project form with project metadata and agent selection" width="420"> |
-
-| Chat composer | Attachment picker |
-|---------------|-------------------|
-| <img src="docs/assets/readme/tui-chat-compose.png" alt="Tycho TUI agent chat composer with conversation history" width="420"> | <img src="docs/assets/readme/tui-chat-attachments.png" alt="Tycho TUI attachment picker inside an agent conversation" width="420"> |
-
-### Remote UI
-
-| Needs attention | Agents |
-|-----------------|--------|
-| <img src="docs/assets/readme/web-now.png" alt="Tycho Remote UI Now view showing schedules and unread agent attention" width="420"> | <img src="docs/assets/readme/web-agents-list.png" alt="Tycho Remote UI agents list grouped by project" width="420"> |
-
-| Chat composer | Attachment preview |
-|---------------|--------------------|
-| <img src="docs/assets/readme/web-chat-compose.png" alt="Tycho Remote UI agent chat composer with a selected agent conversation" width="420"> | <img src="docs/assets/readme/web-chat-attachment.png" alt="Tycho Remote UI Markdown attachment preview with copy and delete actions" width="420"> |
-
-| Remote connection switcher | Agent switcher |
-|----------------------------|----------------|
-| <img src="docs/assets/readme/web-remote-connection-switcher.png" alt="Tycho Remote UI menu showing multiple Remote servers with Local, VPS, and ATASGG options" width="420"> | <img src="docs/assets/readme/web-agent-switcher.png" alt="Tycho Remote UI agent switcher showing recent managed agents and status badges" width="420"> |
-
-## Status
-
-Tycho is early open-source software. It is designed around a single-operator
-workflow and is currently macOS-first for packaged installs. Source installs
-also work on Linux-style environments where Ruby and the optional agent CLIs
-are available, and Tycho has been tested on Windows 11 through WSL.
-
-## Features
-
-- Project registry from `~/.tycho/config/hq.yml`.
-- Managed Codex, Claude, OpenCode, Pi, and custom Claude-compatible agents with
-  persistent chat memory.
-- Scheduled managed-agent runs from cron-style local config.
-- In-app log views, agent detail views, project detail views, and omnisearch.
-- Local JSON API and mobile Remote UI through `tycho serve`.
-- Combined Remote UI agents and projects across multiple Tycho servers through
-  a local broker.
-- Optional Tailscale MagicDNS URL and terminal QR code for Remote UI access.
-- Optional browser push notifications for agent completions and inquiries.
-- Agent-scoped pull request diff inspection with GitHub App login and `gh`
-  compatibility.
-
-## Requirements
-
-- Homebrew for the packaged macOS install.
-- Ruby 3.2 or newer for source installs.
-- Bundler for source installs.
-- Go, when Charm Ruby native gems need to be compiled during install.
-- Windows 11 users should run Tycho inside WSL.
-
-Tycho can run without every optional tool, but features backed by missing tools
-will show as unavailable.
-
-See [docs/SETUP_REQUIREMENTS.md](docs/SETUP_REQUIREMENTS.md) for the
-dependency checklist and hard/soft failure policy used by `bin/setup`.
-
-## Installation
-
-### Homebrew
-
-Homebrew is the primary install path for users:
+Homebrew is the primary install path:
 
 ```bash
 brew tap firewalker06/tycho
@@ -88,39 +25,8 @@ brew install tycho
 tycho
 ```
 
-The formula installs one executable, `tycho`. Remote Sessions and scheduled
-agents run through subcommands:
-
-```bash
-tycho serve
-tycho schedule daemon
-```
-
-Optional integrations are intentionally not installed by the formula. Install
-Claude-compatible harnesses only for the features you use.
-
-### Source Checkout
-
-Use a source checkout when contributing or when Homebrew is not suitable.
-
-One-line setup:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/firewalker06/tycho/main/setup.sh | bash
-cd tycho
-bin/tycho
-```
-
-Pass setup options after `bash -s --`:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/firewalker06/tycho/main/setup.sh | bash -s -- --profile codex
-```
-
-Set `TYCHO_DIR` to clone into a different directory, or `TYCHO_REPO_URL` to use
-another Git remote.
-
-Manual source setup:
+To run from source, install Ruby 3.2+, Bundler, Go, and native build tools,
+then run:
 
 ```bash
 git clone https://github.com/firewalker06/tycho.git tycho
@@ -129,29 +35,14 @@ bin/setup
 bin/tycho
 ```
 
-`bin/setup` installs gems, creates missing user config files from examples
-under `~/.tycho`, and prints hard failures plus soft feature warnings for
-optional tools. Use `bin/setup --check` to inspect readiness without changing
-files, or pass feature profiles such as `bin/setup --profile codex` or
-`bin/setup --profile claude` to make those optional tools mandatory.
+`bin/setup --check` reports missing requirements without changing files. See
+[setup requirements](docs/SETUP_REQUIREMENTS.md) for dependency profiles,
+optional integrations, and environment overrides.
 
-Run through Bundler if your shell has conflicting gem versions:
+## Configure
 
-```bash
-bundle exec bin/tycho
-```
-
-Command mapping for source users:
-
-| Homebrew command | Source checkout command |
-|------------------|-------------------------|
-| `tycho` | `bin/tycho` |
-| `tycho serve` | `bin/tycho serve` |
-| `tycho schedule daemon` | `bin/tycho schedule daemon` |
-
-## Configuration
-
-Project definitions live in `~/.tycho/config/hq.yml` by default.
+Tycho stores project definitions in `~/.tycho/config/hq.yml`. A minimal project
+looks like this:
 
 ```yaml
 projects:
@@ -162,114 +53,23 @@ projects:
     agent: codex
 ```
 
-System prompt templates live beside the project registry as
-`system_prompts.yml`.
+You can also create projects from the TUI or the command line:
 
-Tycho also appends a cross-harness writing policy from `response_style.md` to
-every cold and resumed execution. Set `response_style` on a project or
-structured prompt template to replace the global text, or set it to `false` to
-disable the policy for that scope. Explicit output formats, schemas, code,
-quotations, and user-requested genres take precedence over this default.
-The global file can be edited from **Settings → Configuration** in Remote UI;
-Tycho saves it atomically to `~/.tycho/config/response_style.md` by default.
-
-Real config files, `.env`, runtime logs, and generated agent artifacts are
-gitignored. Keep secrets and machine-specific paths out of committed files.
-Runtime state and logs default to `~/.tycho/logs`.
-
-### Where Tycho Writes Files
-
-Homebrew and source installs use the same user-scoped defaults:
-
-| Purpose | Default |
-|---------|---------|
-| Project registry | `~/.tycho/config/hq.yml` |
-| System prompts | `~/.tycho/config/system_prompts.yml` |
-| Response style policy | `~/.tycho/config/response_style.md` |
-| Schedules | `~/.tycho/config/schedules.yml` |
-| Schedule prompt files | `~/.tycho/schedules/` |
-| Hooks | `~/.tycho/config/hooks.yml` |
-| Remote server peers | `remote_servers` in `~/.tycho/config/hq.yml` |
-| Runtime state and logs | `~/.tycho/logs/` |
-| Project logs | `~/.tycho/logs/projects/` |
-| Agent logs and artifacts | `~/.tycho/logs/agents/` |
-| Normalized usage metrics | `~/.tycho/logs/usage_metrics.json` |
-| Browser push state | `~/.tycho/logs/push_*.json` and `~/.tycho/logs/web_push_vapid.json` |
-| GitHub App session | `~/.tycho/config/github_auth.json` with mode `0600` |
-
-Tycho does not write runtime files under the Homebrew Cellar. Set the
-`TYCHO_*` environment variables below to move config or state for tests,
-temporary runs, or multi-profile setups.
-
-### Environment Variables
-
-Use the `TYCHO_` prefix for runtime overrides.
-
-| Variable | Purpose |
-|----------|---------|
-| `TYCHO_HOME` | Override the default `~/.tycho` root. |
-| `TYCHO_CONFIG_DIR` | Override the default user config directory. |
-| `TYCHO_CONFIG_PATH` | Override the project registry path. |
-| `TYCHO_SYSTEM_PROMPTS_PATH` | Override the system prompt template path. |
-| `TYCHO_RESPONSE_STYLE_PATH` | Override the global response style policy path. |
-| `TYCHO_SCHEDULES_PATH` | Override scheduled-agent config path. |
-| `TYCHO_SCHEDULES_ROOT` | Override schedule message file root. |
-| `TYCHO_HOOKS_PATH` | Override global hooks config path. |
-| `TYCHO_LOGS_ROOT` | Override runtime state and logs root. |
-| `TYCHO_SKILLS_HOME` | Override the home prefix used for harness skill installation, primarily for isolated tests or profiles. |
-| `TYCHO_SCHEDULES_STATE_PATH` | Override scheduler runtime state path. |
-| `TYCHO_SCHEDULER_DAEMON_PATH` | Override scheduler daemon heartbeat path. |
-| `TYCHO_CODEX_BIN` | Override Codex executable lookup. |
-| `TYCHO_CLAUDE_BIN` | Override Claude executable lookup. |
-| `TYCHO_OPENCODE_BIN` | Override OpenCode executable lookup. |
-| `TYCHO_PI_BIN` | Override Pi Coding Agent executable lookup. |
-| `TYCHO_STRUCTURED_OUTPUT_CORRECTION_LIMIT` | Set schema-correction attempts for Codex, Claude-compatible, and Pi managed agents. Defaults to `2`; Tycho clamps values to `0..5`. |
-| `TYCHO_TAILSCALE_BIN` | Override Tailscale executable lookup. |
-| `TYCHO_GH_BIN` | Override the compatibility GitHub CLI lookup. |
-| `TYCHO_GITHUB_APP_CLIENT_ID` | Public Client ID for the Tycho GitHub App device flow. |
-| `TYCHO_GITHUB_APP_SLUG` | App slug used to build the organization installation URL. |
-| `TYCHO_GITHUB_APP_INSTALL_URL` | Override the GitHub App installation URL. |
-| `TYCHO_GITHUB_AUTH_PATH` | Override the local App session file path. |
-| `TYCHO_GITHUB_WRITE_ENABLED` | Allow separately confirmed review posting when the App has write permission. |
-| `TYCHO_REMOTE_TOKEN` | Require bearer auth for non-local Remote UI/API access. |
-| `TYCHO_LOG_LEVEL` | Set Tycho's log level, such as `DEBUG` or `INFO`. |
-| `TYCHO_LIPGLOSS_BACKEND` | Force the Lipgloss backend; `compat`, `pure`, and `ruby` select the pure-Ruby loader, while `native` and `go` force the native gem. |
-
-Web Push can also use `TYCHO_WEB_PUSH_VAPID_PUBLIC_KEY`,
-`TYCHO_WEB_PUSH_VAPID_PRIVATE_KEY`, and `TYCHO_WEB_PUSH_VAPID_SUBJECT`.
-
-### GitHub App
-
-Register a GitHub App for Tycho and enable **Device Flow**. A callback URL,
-client secret, webhook, and private key are not required for user-to-server
-device authentication. Configure these repository permissions:
-
-- **Contents: read**
-- **Issues: read**
-- **Pull requests: read**
-- **Checks: read**
-- **Commit statuses: read**
-
-Use **Pull requests: write** only if review posting is required. Set the App's
-public Client ID and slug in `.env`, restart Tycho, then connect from
-**Settings → GitHub** or **Reviews**:
-
-```dotenv
-TYCHO_GITHUB_APP_CLIENT_ID=Iv1.example
-TYCHO_GITHUB_APP_SLUG=tycho-example
+```bash
+tycho project my-workspace --path ~/Code/my-workspace --harness codex
 ```
 
-Authorizing the user and installing the App are separate. Install the App on
-each personal account or organization whose repositories Tycho should review,
-then select the smallest useful repository set. Tycho stores refreshable App
-credentials locally and never sends them to the Remote UI. When no App session
-exists, an authenticated `gh` session remains available for backward
-compatibility.
+The complete annotated configuration is in
+[`config/hq.yml.example`](config/hq.yml.example). Schedules, prompt templates,
+hooks, and response style use separate files under `~/.tycho/config`.
 
-## Commands
+Tycho launches agent CLIs with access to the selected project. Review project
+paths, prompts, and sandbox settings before starting an agent. Do not commit
+your Tycho config, `.env`, logs, transcripts, or generated agent artifacts;
+they may contain local paths, source context, or credentials. See the
+[security policy](SECURITY.md).
 
-Homebrew users run `tycho`. Source checkout users can replace `tycho` with
-`bin/tycho` in the examples below.
+## Run
 
 Open the TUI:
 
@@ -277,418 +77,57 @@ Open the TUI:
 tycho
 ```
 
-Start the Remote Sessions server:
+Start the browser-based Remote UI:
 
 ```bash
 tycho serve
 ```
 
-Connect and inspect the Tycho GitHub App session:
+Without `TYCHO_REMOTE_TOKEN`, the Remote UI and API are safe only on localhost.
+Set a token before binding to Tailscale or any other non-loopback address:
 
 ```bash
-tycho github login
-tycho github status
-tycho github logout
+TYCHO_REMOTE_TOKEN="$(ruby -rsecurerandom -e 'puts SecureRandom.hex(24)')" \
+  tycho serve
 ```
 
-Bind explicitly to localhost:
-
-```bash
-tycho serve --host 127.0.0.1 --port 7373
-```
-
-Manage projects without opening the TUI:
-
-```bash
-# Quick creation uses the current directory and derives the display name.
-tycho project my-workspace
-
-# The explicit form accepts the same options.
-tycho project create my-workspace \
-  --path ~/Code/my-workspace \
-  --name "My Workspace" \
-  --group Personal \
-  --harness codex \
-  --model gpt-5.5 \
-  --reasoning-effort medium
-
-tycho project show my-workspace
-tycho project list
-tycho project update my-workspace --group Work --model=""
-tycho project archive my-workspace
-```
-
-Create and update also accept `--response-style`, `--pr-url`, and a
-`--hidden=true|false|inherit` visibility override. Add `--json` to any project
-command for script-friendly output. Archive rejects projects with running
-agents; otherwise it moves the project configuration and logs to their normal
-archive locations and archives all managed agents owned by the project.
-
-Connect one Remote UI to multiple Tycho servers by adding `remote_servers` to
-`~/.tycho/config/hq.yml`:
-
-```yaml
-remote_servers:
-  - key: vps
-    name: VPS
-    icon: server
-    url: http://vps-cd946cb7.tail952bf7.ts.net:7373
-    token_env: TYCHO_VPS_REMOTE_TOKEN
-```
-
-Target a configured peer directly from the CLI with `--server`. Project reads
-and the full managed-agent lifecycle use the peer's Remote JSON API; commands
-without `--server` keep using local state.
-
-```bash
-tycho project list --server vps
-tycho project show my-workspace --server vps --json
-
-tycho agent list my-workspace --server vps
-tycho agent status <agent-key> --server vps --json
-tycho agent create my-workspace "Inspect the failing build" --server vps
-tycho agent run <agent-key> --server vps
-tycho agent send <agent-key> "Try the smaller reproduction" --server vps
-tycho agent stop <agent-key> --server vps
-tycho agent archive <agent-key> --server vps
-```
-
-Remote CLI commands resolve the server only from `remote_servers` in
-`hq.yml`. Each server key owns its credential. Tycho-managed tokens live in
-`~/.tycho/config/remote_credentials.json`, which Tycho writes atomically with
-`0600` permissions. An explicit `token_env` on that server entry takes
-precedence; if the variable is missing, the request fails instead of silently
-using another source.
-
-```bash
-tycho server login vps                 # hidden prompt; verify before saving
-tycho server login vps --no-verify     # save for an offline server
-tycho server status [vps] [--json]     # metadata only; never the token
-tycho server verify vps
-tycho server logout vps
-tycho server migrate vps               # move an inline hq.yml token
-tycho server migrate --all
-```
-
-Credentials bind to the stable server key and, after verification, to the
-server's scheme, normalized host, and effective port. Changing that origin
-requires login or verification. Authentication rejection marks a credential
-rejected and stops automatic reuse until explicit recovery. Inline `token`
-entries remain a warned migration fallback through v0.10.x and will be removed
-in v0.11.0. `--json` is supported by project list/show and every agent command
-above. Errors distinguish unknown server keys, missing external sources,
-origin changes, unreachable servers, timeouts, rejected credentials,
-unsupported endpoints, and other Remote API responses without printing tokens.
-
-Query normalized run, native-session, token, and estimated-cost metrics without
-scanning raw logs:
-
-```bash
-tycho metrics backfill --timezone Asia/Jakarta
-tycho metrics query --from 2026-07-06 --to 2026-08-07 --timezone Asia/Jakarta
-tycho metrics query --server vps --from 2026-07-06 --to 2026-08-07 --timezone UTC --json
-```
-
-Ranges are start-inclusive and end-exclusive. Unknown telemetry and prices stay
-unknown rather than becoming zero. See [Usage metrics](docs/USAGE_METRICS.md).
-
-The Remote UI always includes the local server and combines agents and projects
-from every configured peer into the same Agents list. Use the server filter to
-narrow the list. Local resources use a home icon; peer resources use their
-configured `server` or `computer` icon and name. Each agent, project, or
-attachment request goes only to its owner. Settings manages peer connections
-and identity; schedules, setup, GitHub, push notifications, restart, and other
-server-level controls remain local to the server serving the UI.
+See [Remote Sessions](docs/REMOTE_SERVER.md) for binding, Tailscale, daemon,
+multiserver, authentication, and API details.
 
 Run scheduled agents:
 
 ```bash
 tycho schedule list
-tycho schedule daemon --once --dry-run
 tycho schedule daemon
 ```
 
-Manage schedules without opening the TUI:
+See [Scheduled Runs](docs/SCHEDULED_RUNS.md) for schedule configuration and
+runtime policies. Run `tycho --help` for the full command list.
 
-```bash
-tycho schedule validate
-tycho schedule list
-tycho schedule run <schedule-key>
-tycho schedule pause <schedule-key>
-tycho schedule resume <schedule-key>
-tycho schedule reload
-```
-
-Run a non-interactive runtime smoke check:
-
-```bash
-tycho doctor
-```
-
-The TUI includes a Schedules screen, and the Remote UI `Now` view shows
-scheduler daemon freshness plus schedule state. Schedule rows use three
-operator-facing statuses: `scheduled`, `paused`, and `stopped`. Last outcome
-details such as failed runs or interactive protection are shown separately. The
-Remote UI keeps the schedule card compact by showing daemon status, PID, and
-last tick in the header, while schedule rows show project, next run, and a
-humanized cron cadence such as `every 15 minutes`.
-
-## Scheduled Agents
-
-Schedules create fresh managed agents for projects. They do not run shell
-commands directly and do not resume old agent sessions. This keeps recurring
-work reviewable and prevents stale context from accumulating across runs.
-
-Definitions live in `~/.tycho/config/schedules.yml`, which is local and gitignored.
-Long prompts should live as Markdown files under `~/.tycho/schedules/`.
-
-```yaml
-schedules:
-  - key: pull-request-review
-    name: Pull request review
-    enabled: true
-    cron: "*/15 * * * *"
-    timezone: local
-    target:
-      type: agent
-      project_key: my-workspace
-      name: Pull request review
-      message_source: file
-      message_file: schedules/pull-request-review.md
-    policy:
-      overlap: skip
-      missed: run_once_on_start
-      archive_previous_agent: true
-```
-
-Use `message_source: inline` with `message: "..."` for short prompts. Use
-`message_source: file` and `message_file: schedules/<name>.md` for anything
-longer than a few lines. Tycho validates cron syntax, project references, and
-that prompt files stay inside `~/.tycho/schedules/`.
-
-Each run automatically appends Tycho's final-output attachment checklist to the
-scheduled prompt, so reports, Markdown files, PRs, reviews, images, and other
-durable artifacts should be returned in `attachments`.
-`no_action_needed` is reserved for successful observational checks where no new
-condition required action; completed changes, answers, commits, reviews, and
-deliverables use `success` even when no next step remains.
-
-Prompt tips for reliable schedules:
-
-- Make the task idempotent. Tell the agent to check current state first and
-  skip work that is already done.
-- Give the agent stable dedupe keys, such as PR URL, issue number, date bucket,
-  or output path.
-- Prefer deterministic output locations like `tmp/<schedule-key>/...`, and say
-  whether files should be overwritten, updated in place, or left untouched.
-- Require explicit skip conditions. For example: skip a PR that was already
-  reviewed after its latest commit, or skip a report that already exists for
-  the current date.
-- Separate review from mutation. For risky workflows, ask the agent to write a
-  review file or plan first and wait for human approval before posting,
-  deleting, merging, or sending messages.
-- Keep prompts narrow. A scheduled agent should have one recurring job, one
-  project, and a clear completion condition.
-- Include a no-op result. Tell the agent what to output when there is no work,
-  such as `No new PRs to review.`
-- Mention artifact expectations. If the run creates or references durable
-  output, name the expected files or links so they appear in `attachments`.
-
-If you converse with a scheduled agent, Tycho protects that session. A later
-due run stops the schedule with reason `interactive` instead of archiving the
-user-touched agent. Resume the stopped schedule when you want Tycho to archive
-the active scheduled session and wait for the next scheduled run with fresh
-context.
-
-`tycho schedule daemon` writes daemon heartbeat state to `~/.tycho/logs/scheduler_daemon.json`.
-The schedule UI treats a missing or stale heartbeat as daemon attention. If it
-finds a running scheduler process without heartbeat state, it reports the
-daemon as `untracked`; restart `tycho schedule daemon` to restore tick freshness.
-
-## TUI Tutorial
-
-Start the TUI:
-
-```bash
-tycho
-```
-
-### Create A Project
-
-1. Press `2` to switch to the Projects screen.
-2. Press `N` to open the New Project form.
-3. Enter the local project path first. Tycho will offer path suggestions and can
-   prefill the project key/name as you tab through the form.
-4. Fill in the project key, name, and group.
-5. Use left/right arrows on the Agent field to choose the default harness
-   (`codex`, `claude`, or a configured custom harness).
-6. Tab to `Create Project` and press Enter.
-
-Tycho writes the project entry to `~/.tycho/config/hq.yml`, selects the new
-project, and starts a metadata refresh.
-
-### Create A Project Agent
-
-1. Stay on the Projects screen and select the project with `j`/`k`.
-2. Press `n` to open the Create Agent form for that project.
-3. Use left/right arrows to choose the prompt template and harness.
-4. Fill in the agent name and prompt. Use Shift+Enter, Alt+Enter, or `ctrl+j`
-   for new lines inside the prompt.
-5. Choose `Create Agent` to save the agent without starting it, or choose
-   `Create and Run Agent` to start it immediately.
-
-After creation, Tycho switches to the Agents screen, selects the new agent, and
-opens its chat panel.
-
-### Converse With An Agent
-
-1. Press `1` to switch to the Agents screen.
-2. Select an agent with `j`/`k`.
-3. Press `c` or Enter to open the agent chat panel.
-4. Type your message. Use Shift+Enter, Alt+Enter, or `ctrl+j` for multiline
-   prompts.
-5. Press Enter or `ctrl+s` to send. If the agent is idle, Tycho starts it
-   automatically.
-
-While in chat, use Tab/Shift+Tab to move between the prompt, conversation, and
-summary areas. `L` opens the selected agent's raw log from the Agents screen,
-and `ctrl+t` opens an interactive terminal session for the selected agent.
-
-## Remote UI Security
-
-`tycho serve` is local-first. If `TYCHO_REMOTE_TOKEN` is unset, API requests are
-accepted without authentication. This is intended only for localhost.
-
-Set a token before binding to Tailscale or any non-loopback address:
-
-```bash
-TYCHO_REMOTE_TOKEN="$(ruby -rsecurerandom -e 'puts SecureRandom.hex(24)')" tycho serve
-```
-
-When Tailscale HTTPS Serve is available, Tycho can print an HTTPS MagicDNS
-Remote UI URL and QR code. Public screenshots should redact MagicDNS URLs,
-Tailscale IPs, and QR codes.
-
-For multiple Remote servers, the browser still talks only to the Tycho server
-that served the UI. That local server returns a cached combined resource
-catalog and brokers each detail or mutation request to the resource's owner,
-using each peer's selected external or Tycho-stored credential. Saving a token
-in Settings verifies it, writes it to the host's private
-`remote_credentials.json`, and only then removes the browser-local copy.
-
-## Custom Claude Harnesses
-
-Tycho has built-in `codex`, `claude`, `opencode`, and `pi` harnesses. To run Claude
-through a wrapper, define a custom harness in `~/.tycho/config/hq.yml` and use
-its key as a project or template agent:
-
-```yaml
-custom_harnesses:
-  - key: claude-wrapper
-    adapter: claude
-    execution_command: /Users/you/bin/claude-wrapper
-
-projects:
-  - key: my-workspace
-    name: My Workspace
-    group: Personal
-    path: /Users/you/Code/my-workspace
-    agent: claude-wrapper
-```
-
-`execution_command` may be a shell string or an argv list. The command must be
-Claude-compatible because Tycho appends Claude CLI flags for stream-json output,
-structured result schemas, and native session resume.
-
-## Structured Output Correction
-
-Tycho validates each final managed-agent response against
-`~/.tycho/config/schemas/agent_result.json` before accepting it as successful.
-When JSON is malformed or violates the schema, Tycho sends concise JSON feedback
-to the same native Codex, Claude-compatible, or Pi session and asks for one complete
-corrected payload. The feedback reports only error codes, schema paths, expected
-types, and allowed enum values; it does not copy response values.
-
-The default limit is two correction attempts (three total responses). Set
-`TYCHO_STRUCTURED_OUTPUT_CORRECTION_LIMIT=0` to disable correction while keeping
-validation, or choose up to `5`. If the limit is exhausted, the run fails with
-an actionable summary and keeps the final invalid response in the agent's
-owner-readable `*.invalid_structured_output.json` diagnostic file. Raw and
-system logs record validation events, and the Remote UI shows the failed status
-and summary without treating the invalid payload as a successful result.
-
-Each validation failure also appears in the conversation as a collapsed
-**system event block** branded **TYCHO**, between the rejected response and the
-next response. The compact row shows whether Tycho is retrying or has exhausted
-the limit. Expanding it shows schema paths and safe error details, but never
-copies rejected field values into the conversation.
-
-Use `TYCHO_CODEX_BIN`, `TYCHO_CLAUDE_BIN`, `TYCHO_OPENCODE_BIN`, `TYCHO_PI_BIN`, or another documented environment
-override when a harness executable is not on `PATH`.
-
-## Pi Coding Agent
-
-Tycho supports the `pi` executable from `@mariozechner/pi-coding-agent` 0.73.1,
-the latest release under Mario Zechner's package name when this integration was
-implemented. It relies on the documented `--mode json`, `--session`, `--model`,
-`--thinking`, `--tools`, and `--list-models` contracts. Install it with
-`npm install -g --ignore-scripts @mariozechner/pi-coding-agent@0.73.1`, then run
-`pi` and use `/login`, or configure a provider API key as documented by Pi.
-`pi --list-models` must show at least one model before Tycho reports authentication
-ready.
-
-Pi has no native JSON Schema output flag, so Tycho adds the canonical result
-schema to cold execution context, validates the final assistant JSON, and uses
-the native Pi session for bounded correction attempts. Pi also has no sandbox
-equivalent to Tycho's restricted modes. `danger-full-access` keeps Pi's native
-tool set; other Tycho modes conservatively allow only `read,grep,find,ls` and
-report the capability gap in Settings. Usage and cost come only from Pi's
-assistant-message telemetry; missing counters or prices remain unknown.
-
-## Tests
-
-Run the main test suite:
-
-```bash
-bin/test
-```
-
-Run an individual test:
-
-```bash
-bundle exec ruby test/rendering_test.rb
-```
-
-## Known Limitations
-
-- Tycho is macOS-first for the initial Homebrew release.
-- Linux and Windows 11 through WSL are source-install targets where Ruby,
-  native build tools, and optional CLIs are available, but they are not the
-  primary packaged target yet.
-- Remote UI is local-first. Set `TYCHO_REMOTE_TOKEN` before binding to a
-  non-loopback interface.
-- Custom harness dependencies remain the operator's responsibility.
-- Managed agents can run powerful local tools. Review prompts, project paths,
-  and sandbox settings before starting agents.
+Source-checkout users can replace `tycho` with `bin/tycho` in these examples.
 
 ## Documentation
 
-- `docs/PROJECT_STATUS.md`: current roadmap and architectural decisions.
-- `docs/SYSTEM_PROMPT_AUDIT.md`: when Tycho introduces system and automatic prompt context, the exact content, purpose, and known contract gaps.
-- `docs/REMOTE_SERVER.md`: Remote Sessions API and Remote UI behavior.
-- `docs/TYCHO_SKILLS.md`: Tycho skill source, install/update paths, ownership safety, and verification.
-- `docs/SCHEDULED_RUNS.md`: scheduled-agent design, policies, and runtime state.
-- `docs/GOTCHAS.md`: operational pitfalls.
-- `docs/OPEN_SOURCE_PLAN.md`: open-source readiness plan and launch criteria.
+- [Setup requirements](docs/SETUP_REQUIREMENTS.md) — dependencies, setup
+  profiles, paths, and environment overrides.
+- [Remote Sessions](docs/REMOTE_SERVER.md) — Remote UI, API, authentication,
+  Tailscale, and multiserver operation.
+- [Scheduled Runs](docs/SCHEDULED_RUNS.md) — recurring agent configuration and
+  policies.
+- [Agent memory](docs/AGENT_MEMORY.md) and
+  [delegation](docs/AGENT_DELEGATION.md) — session persistence and managed-agent
+  ownership.
+- [Hooks](docs/HOOKS.md), [skills](docs/TYCHO_SKILLS.md), and
+  [usage metrics](docs/USAGE_METRICS.md) — optional operator workflows.
+- [Pull request diffs](docs/PULL_REQUEST_DIFFS.md) — review workflow and GitHub
+  integration boundaries.
+- [Gotchas](docs/GOTCHAS.md) — known operational pitfalls.
+- [Project status](docs/PROJECT_STATUS.md) — roadmap and architectural
+  decisions.
 
 ## Contributing
 
-See `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
+See [CONTRIBUTING.md](CONTRIBUTING.md). Run `bin/test` before opening a pull
+request.
 
-## Security
-
-See `SECURITY.md`.
-
-## License
-
-Tycho is released under the MIT License. See `LICENSE`.
+Tycho is released under the [MIT License](LICENSE).

--- a/docs/PI_CODING_AGENT.md
+++ b/docs/PI_CODING_AGENT.md
@@ -2,8 +2,29 @@
 
 Tycho's built-in Pi harness targets the documented
 `@mariozechner/pi-coding-agent` 0.73.1 command and event contract. See
-[setup requirements](SETUP_REQUIREMENTS.md) for installation and readiness
-checks.
+[setup requirements](SETUP_REQUIREMENTS.md) for dependency profiles and
+readiness checks.
+
+## Install and Authenticate
+
+Install Tycho's supported Pi version:
+
+```bash
+npm install -g --ignore-scripts @mariozechner/pi-coding-agent@0.73.1
+```
+
+Run `pi`, enter `/login`, and authenticate a supported provider. You can
+instead configure a provider API-key environment variable documented by Pi.
+Keep provider credentials out of Tycho.
+
+Verify that Pi can load at least one authenticated model:
+
+```bash
+pi --list-models
+```
+
+Tycho reports Pi authentication as ready only when `pi --list-models` returns
+at least one model.
 
 ## Sandbox Behavior
 

--- a/docs/PI_CODING_AGENT.md
+++ b/docs/PI_CODING_AGENT.md
@@ -1,0 +1,18 @@
+# Pi Coding Agent
+
+Tycho's built-in Pi harness targets the documented
+`@mariozechner/pi-coding-agent` 0.73.1 command and event contract. See
+[setup requirements](SETUP_REQUIREMENTS.md) for installation and readiness
+checks.
+
+## Sandbox Behavior
+
+Pi has tool allowlists but no native equivalent to Tycho's workspace-write or
+read-only filesystem sandboxes. For `danger-full-access`, Tycho does not pass a
+`--tools` restriction, so Pi keeps its native configured tool set. For every
+other Tycho sandbox mode, Tycho passes `--tools read,grep,find,ls`, removing
+write, edit, and shell tools.
+
+That restricted tool list reduces capabilities, but it does not create a
+filesystem boundary or distinguish workspace-write from read-only. Treat Pi's
+restricted modes as a conservative tool allowlist, not as a sandbox.


### PR DESCRIPTION
## Summary

- reduce the README to the product, supported harnesses, install paths, minimal project configuration, first-agent workflow, first-run commands, and a task-oriented documentation index
- keep the local-agent and Remote UI authentication warnings at the point of use
- document Pi's pinned installation, authentication, readiness, and sandbox limitations in a focused harness guide linked from the README safety surface
- route setup, Remote Sessions, schedules, memory, delegation, hooks, skills, metrics, PR review, and operational details to focused docs

## Evidence for the reduction

The current READMEs for [uv](https://github.com/astral-sh/uv), [Aider](https://github.com/Aider-AI/aider), and [OpenCode](https://github.com/anomalyco/opencode) use the repository front page for product orientation, a primary install path, a first run, and links to deeper documentation. Tycho's 3,814-word README instead carried command reference, runtime internals, advanced integration setup, and repeated focused-doc content.

| Measure | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Lines | 694 | 141 | 79.7% |
| Words | 3,814 | 545 | 85.7% |
| Bytes | 27,870 | 4,433 | 84.1% |

Fizzy: [#153 — Tycho README diet](https://fizzy.startkit.tech/1/cards/153)

## Verification

- `npx --yes markdownlint-cli2 README.md docs/PI_CODING_AGENT.md`
- `npx --yes markdown-link-check README.md` — 17 links checked
- `npx --yes markdown-link-check docs/PI_CODING_AGENT.md` — 1 link checked
- local changed-document target check — 21 Markdown link references checked
- `bundle exec bin/tycho --help`
- `bundle exec bin/tycho project --help`
- `bundle exec bin/tycho serve --help`
- `bundle exec bin/tycho schedule --help`
- `bin/setup --help`
- repository remote, example config keys, and token generator checked directly
- first-agent labels/paths checked against TUI source and rendering coverage
- Pi install/auth commands checked against current onboarding code; npm confirms package version `0.73.1`
- Pi tool handling checked against the command builder and managed-agent regression coverage
- `bin/test`
- `git diff --check`

Documentation only. No config, schema, dependency, TUI input, Remote UI behavior, or harness command contract changes.
