### PR TITLE
Reflect schedule status in agent icons

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -4333,14 +4333,24 @@ def write_smoke_script(path)
         const stoppedAgentListIcon = await page.evaluate((key) => {
           const row = Array.from(document.querySelectorAll(".agent-row[data-open-agent]")).find((item) => item.dataset.openAgent === key);
           const icon = row?.querySelector(":scope > .agent-status-icon");
+          const scheduleIcon = row?.querySelector('[data-agent-role="scheduled"]');
+          const comparison = document.createElement("span");
+          comparison.className = "pill fail";
+          document.body.append(comparison);
+          const stoppedColor = getComputedStyle(comparison).color;
+          comparison.remove();
           return {
             found: Boolean(icon),
             checkIcon: Boolean(icon?.querySelector('path[d="M20 6 9 17l-5-5"]')),
             label: icon?.getAttribute("aria-label"),
+            scheduleFailClass: scheduleIcon?.classList.contains("fail"),
+            scheduleIconColor: scheduleIcon ? getComputedStyle(scheduleIcon).color : "",
+            stoppedColor,
           };
         }, agentKey);
-        if (!stoppedAgentListIcon.found || !stoppedAgentListIcon.checkIcon || stoppedAgentListIcon.label !== "Idle") {
-          throw new Error(`Idle agent-list icon did not retain the rebased status contract: ${JSON.stringify(stoppedAgentListIcon)}`);
+        if (!stoppedAgentListIcon.found || !stoppedAgentListIcon.checkIcon || stoppedAgentListIcon.label !== "Idle" ||
+            !stoppedAgentListIcon.scheduleFailClass || stoppedAgentListIcon.scheduleIconColor !== stoppedAgentListIcon.stoppedColor) {
+          throw new Error(`Stopped schedule agent row did not preserve agent status and render a red calendar: ${JSON.stringify(stoppedAgentListIcon)}`);
         }
         await page.evaluate((key) => {
           scheduleForAgent(findAgent(key)).status = "scheduled";

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -446,6 +446,22 @@ h3 {
   color: var(--warning);
 }
 
+.agent-name-role-icon.need {
+  color: var(--warning);
+}
+
+.agent-name-role-icon.done {
+  color: var(--ok);
+}
+
+.agent-name-role-icon.fail {
+  color: var(--danger);
+}
+
+.agent-name-role-icon.info {
+  color: var(--info);
+}
+
 .agent-name-label {
   min-width: 0;
   overflow: hidden;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -11560,7 +11560,8 @@ function agentRoleIcons(agent) {
   const delegation = agent?.delegation || {};
   const roles = [];
   if (agent?.scheduled || agent?.schedule_key) {
-    roles.push({ className: "scheduled", icon: "calendarCheck2", label: "Scheduled agent", role: "scheduled" });
+    const scheduleClass = REMOTE_HELPERS.agentScheduleStatusClass(agent, state.schedules);
+    roles.push({ className: `scheduled ${scheduleClass}`, icon: "calendarCheck2", label: "Scheduled agent", role: "scheduled" });
   }
   if (Array.isArray(delegation.children) && delegation.children.length) {
     roles.push({ className: "orchestrator", icon: "hardHat", label: "Orchestrator", role: "orchestrator" });

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -60,6 +60,19 @@
       String(agent?.status || "").toLowerCase() === "no_action_needed";
   }
 
+  function agentScheduleStatusClass(agent, schedules = []) {
+    const scheduleKey = String(agent?.schedule_key || "").trim();
+    const schedule = (Array.isArray(schedules) ? schedules : [])
+      .find((candidate) => String(candidate?.key || "") === scheduleKey);
+    if (!schedule) return "info";
+
+    const status = String(schedule.status || "scheduled").toLowerCase();
+    if (status === "stopped") return "fail";
+    if (status === "paused" || schedule.paused || schedule.enabled === false) return "need";
+    if (status === "scheduled") return "done";
+    return "info";
+  }
+
   function compareQuickSwitchAgents(a, b) {
     if (noActionNeeded(a) !== noActionNeeded(b)) return noActionNeeded(a) ? 1 : -1;
     return compareAgentsByUpdatedAt(a, b, "desc");
@@ -608,6 +621,7 @@
   global.TychoRemoteHelpers = Object.freeze({
     agentComposerState,
     agentActivityTimestamp,
+    agentScheduleStatusClass,
     agentSearchMatch,
     activityFetchFailure,
     agentSortUsesProjectGroups,

--- a/test/remote_ui_schedule_status_test.rb
+++ b/test/remote_ui_schedule_status_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RemoteUIScheduleStatusTest
+  module_function
+
+  ROOT = File.expand_path("..", __dir__)
+  HELPERS_PATH = File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app_helpers.js")
+  APP_PATH = File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.js")
+
+  def run!
+    assert_schedule_role_status_classes
+    assert_agent_role_renderer_uses_schedule_status
+    assert_schedule_role_status_colors
+    puts "remote_ui_schedule_status_test: ok"
+  end
+
+  def assert_schedule_role_status_classes
+    script = <<~'JAVASCRIPT'
+      const fs = require("fs");
+      const vm = require("vm");
+      const context = { window: {}, URL, URLSearchParams };
+      vm.createContext(context);
+      vm.runInContext(fs.readFileSync(process.argv[1], "utf8"), context);
+
+      const statusClass = context.window.TychoRemoteHelpers.agentScheduleStatusClass;
+      const agent = { schedule_key: "daily" };
+      const cases = [
+        [{ key: "daily", status: "scheduled" }, "done"],
+        [{ key: "daily", status: "paused" }, "need"],
+        [{ key: "daily", status: "stopped" }, "fail"],
+        [{ key: "daily", status: "unknown" }, "info"],
+      ];
+
+      for (const [schedule, expected] of cases) {
+        const actual = statusClass(agent, [schedule]);
+        if (actual !== expected) {
+          throw new Error(`${schedule.status} schedule rendered as ${actual}, expected ${expected}`);
+        }
+      }
+      if (statusClass(agent, []) !== "info") {
+        throw new Error("a missing schedule must render with a neutral informational color");
+      }
+    JAVASCRIPT
+
+    _stdout, stderr, status = Open3.capture3("node", "-e", script, HELPERS_PATH, chdir: ROOT)
+    raise "Remote UI schedule status regression failed: #{stderr.strip}" unless status.success?
+  end
+
+  def assert_agent_role_renderer_uses_schedule_status
+    javascript = File.read(APP_PATH)
+    renderer = javascript[/function agentRoleIcons\(agent\).*?^}/m]
+    raise "missing agent role icon renderer" unless renderer
+    return if renderer.include?("REMOTE_HELPERS.agentScheduleStatusClass(agent, state.schedules)")
+
+    raise "scheduled agent role icon does not use its schedule status"
+  end
+
+  def assert_schedule_role_status_colors
+    css = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.css"))
+    %w[need done fail info].each do |status|
+      next if css.include?(".agent-name-role-icon.#{status}")
+
+      raise "missing #{status} color for scheduled agent role icons"
+    end
+  end
+end
+
+RemoteUIScheduleStatusTest.run! if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary
- color scheduled-agent calendar icons from the linked schedule status
- keep agent run status independent
- add unit and browser regression coverage

## Verification
- bundle exec ruby test/remote_ui_schedule_status_test.rb
- bundle exec ruby test/remote_server_test.rb
- TYCHO_REMOTE_UI_SMOKE_RENDERING_ONLY=1 bin/remote-ui-smoke