### PR TITLE
Add on-demand Mermaid preview controls

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -957,21 +957,108 @@ def write_smoke_script(path)
 
         await page.evaluate(async () => {
           await ensureMarkdownParserLoaded();
-          replaceView(renderMarkdown([
+          const content = [
+            "```mermaid",
+            "flowchart LR",
+            "  A[First chart] --> B[Previewed alone]",
+            "```",
+            "```mermaid",
+            "flowchart LR",
+            "  C[Second chart] --> D[Still code]",
+            "```",
+          ].join("\\n");
+          window.__smokeMermaidRender = render;
+          render = () => replaceView(renderMessageContent({
+            kind: "message",
+            role: "assistant",
+            content,
+            metadata: {},
+          }, { markdownMenuScope: "smoke-conversation-mermaid" }));
+          render();
+        });
+        const conversationMermaidContract = await page.evaluate(() => ({
+          diagrams: document.querySelectorAll(".mermaid").length,
+          codeBlocks: document.querySelectorAll("code.language-mermaid").length,
+          scripts: document.querySelectorAll('script[src*="/mermaid@"]').length,
+        }));
+        if (conversationMermaidContract.diagrams !== 0 || conversationMermaidContract.codeBlocks !== 2 ||
+            conversationMermaidContract.scripts !== 0) {
+          throw new Error(`Mermaid must remain code without loading Mermaid: ${JSON.stringify(conversationMermaidContract)}`);
+        }
+        await page.click('[data-toggle-markdown-code-menu="markdown-code:smoke-conversation-mermaid:0"]');
+        const mermaidPreviewLabel = await page.locator(".markdown-code-menu-popover:not([hidden]) [data-preview-mermaid-code] strong").textContent();
+        if (mermaidPreviewLabel?.trim() !== "Preview chart") {
+          throw new Error(`Mermaid code menu did not offer Preview chart: ${JSON.stringify(mermaidPreviewLabel)}`);
+        }
+        await page.click(".markdown-code-menu-popover:not([hidden]) [data-preview-mermaid-code]");
+        await page.waitForSelector(".mermaid svg", { state: "visible", timeout: 20_000 });
+        const mermaidContract = await page.evaluate(() => ({
+          diagrams: document.querySelectorAll(".mermaid").length,
+          codeBlocks: document.querySelectorAll("pre:not([hidden]) > code.language-mermaid").length,
+          scripts: document.querySelectorAll('script[src*="/mermaid@"]').length,
+          processed: document.querySelector(".mermaid")?.dataset.processed,
+          svg: document.querySelectorAll(".mermaid svg").length,
+        }));
+        if (mermaidContract.diagrams !== 1 || mermaidContract.codeBlocks !== 1 || mermaidContract.scripts !== 1 ||
+            mermaidContract.processed !== "true" || mermaidContract.svg !== 1) {
+          throw new Error(`Mermaid preview did not render exactly one chart: ${JSON.stringify(mermaidContract)}`);
+        }
+        await page.click('[data-toggle-markdown-code-menu="markdown-code:smoke-conversation-mermaid:0"]');
+        const showCodeLabel = await page.locator(".markdown-code-menu-popover:not([hidden]) [data-show-mermaid-code] strong").textContent();
+        if (showCodeLabel?.trim() !== "Show code") {
+          throw new Error(`Mermaid preview menu did not offer Show code: ${JSON.stringify(showCodeLabel)}`);
+        }
+        await page.click(".markdown-code-menu-popover:not([hidden]) [data-show-mermaid-code]");
+        const restoredMermaidContract = await page.evaluate(() => ({
+          diagrams: document.querySelectorAll(".mermaid").length,
+          codeBlocks: document.querySelectorAll("code.language-mermaid").length,
+        }));
+        if (restoredMermaidContract.diagrams !== 0 || restoredMermaidContract.codeBlocks !== 2) {
+          throw new Error(`Show code did not restore the Mermaid source: ${JSON.stringify(restoredMermaidContract)}`);
+        }
+        await page.evaluate(() => {
+          render = window.__smokeMermaidRender;
+          state.renderedViewHtml = "";
+        });
+
+        await page.evaluate(() => {
+          replaceView(renderAgentSummaryContent([
             "```mermaid",
             "flowchart LR",
             "  A[HTML attachment] --> B[Visible lesson]",
             "```",
-          ].join("\\n")));
+          ].join("\\n"), "smoke-summary-mermaid"));
         });
-        await page.waitForSelector(".mermaid svg", { state: "visible", timeout: 20_000 });
-        const mermaidContract = await page.evaluate(() => ({
-          scripts: document.querySelectorAll('script[src*="/mermaid@"]').length,
-          processed: document.querySelector(".mermaid")?.dataset.processed,
-          svg: Boolean(document.querySelector(".mermaid svg")),
+        const summaryMermaidContract = await page.evaluate(() => ({
+          diagrams: document.querySelectorAll(".mermaid").length,
+          codeBlocks: document.querySelectorAll("code.language-mermaid").length,
         }));
-        if (mermaidContract.scripts !== 1 || mermaidContract.processed !== "true" || !mermaidContract.svg) {
-          throw new Error(`Mermaid rendering contract failed: ${JSON.stringify(mermaidContract)}`);
+        if (summaryMermaidContract.diagrams !== 0 || summaryMermaidContract.codeBlocks !== 1) {
+          throw new Error(`Summary Mermaid rendered without a preview action: ${JSON.stringify(summaryMermaidContract)}`);
+        }
+
+        await page.evaluate(() => {
+          state.attachmentDetails["smoke-mermaid-markdown"] = {
+            id: "smoke-mermaid-markdown",
+            type: "file",
+            format: "markdown",
+            title: "Mermaid Markdown attachment",
+            path: "/tmp/mermaid-smoke.md",
+            content: [
+              "```mermaid",
+              "flowchart LR",
+              "  A[Attachment] --> B[Rendered]",
+              "```",
+            ].join("\\n"),
+          };
+          replaceView(attachmentViewerHtml("smoke-mermaid-markdown"));
+        });
+        const attachmentMermaidContract = await page.evaluate(() => ({
+          diagrams: document.querySelectorAll(".attachment-viewer .mermaid").length,
+          codeBlocks: document.querySelectorAll(".attachment-viewer code.language-mermaid").length,
+        }));
+        if (attachmentMermaidContract.diagrams !== 0 || attachmentMermaidContract.codeBlocks !== 1) {
+          throw new Error(`Attachment Mermaid rendered without a preview action: ${JSON.stringify(attachmentMermaidContract)}`);
         }
 
         await page.evaluate(async () => {
@@ -996,23 +1083,25 @@ def write_smoke_script(path)
             "```",
           ].join("\\n");
           window.__smokeMarkdownRender = render;
-          render = () => replaceView(renderMarkdown(window.__smokeMarkdownCodeSource, { menuScope: "smoke-markdown-code" }));
+          render = () => replaceView(renderMarkdown(window.__smokeMarkdownCodeSource, {
+            menuScope: "smoke-markdown-code",
+          }));
           render();
         });
-        await page.waitForSelector(".mermaid svg", { state: "visible", timeout: 20_000 });
         const markdownCodeMenus = await page.locator("[data-toggle-markdown-code-menu]").count();
         if (markdownCodeMenus !== 3) {
           throw new Error(`Markdown code blocks did not get independent menus: ${markdownCodeMenus}`);
         }
         await page.click('[data-toggle-markdown-code-menu="markdown-code:smoke-markdown-code:1"]');
         const codeMenuContract = await page.evaluate(() => ({
-          openMenus: document.querySelectorAll(".markdown-code-menu-popover").length,
-          copyLabel: document.querySelector(".markdown-code-menu-popover [role='menuitem'] strong")?.textContent?.trim(),
+          openMenus: document.querySelectorAll(".markdown-code-menu-popover:not([hidden])").length,
+          copyLabel: document.querySelector(".markdown-code-menu-popover:not([hidden]) [role='menuitem'] strong")?.textContent?.trim(),
+          previewButtons: document.querySelectorAll(".markdown-code-menu-popover:not([hidden]) [data-preview-mermaid-code]").length,
         }));
-        if (codeMenuContract.openMenus !== 1 || codeMenuContract.copyLabel !== "Copy code") {
+        if (codeMenuContract.openMenus !== 1 || codeMenuContract.copyLabel !== "Copy code" || codeMenuContract.previewButtons !== 0) {
           throw new Error(`Markdown code menu did not open independently: ${JSON.stringify(codeMenuContract)}`);
         }
-        await page.click("[data-close-markdown-code-menu]");
+        await page.click(".markdown-code-menu-popover:not([hidden]) [data-close-markdown-code-menu]");
         const copiedMarkdownCode = await page.evaluate(() => window.__smokeCopiedMarkdownCode);
         if (copiedMarkdownCode !== "const same = true;\\n") {
           throw new Error(`Markdown code copy lost raw source: ${JSON.stringify(copiedMarkdownCode)}`);
@@ -1021,7 +1110,7 @@ def write_smoke_script(path)
           navigator.clipboard.writeText = async () => { throw new Error("clipboard blocked"); };
         });
         await page.click('[data-toggle-markdown-code-menu="markdown-code:smoke-markdown-code:2"]');
-        await page.click("[data-close-markdown-code-menu]");
+        await page.click(".markdown-code-menu-popover:not([hidden]) [data-close-markdown-code-menu]");
         await page.waitForSelector(".growl.fail", { state: "visible", timeout: 10_000 });
         const failedCodeCopy = await page.locator(".growl.fail").textContent();
         if (failedCodeCopy !== "Copy failed") {

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ type: project
 
 ## Last Updated
 
-2026-08-30
+2026-09-02
 
 ## Strategic Direction
 
@@ -58,7 +58,7 @@ Key references:
 | Chat viewport rendering | Project complete harness events into `memory.jsonl` while the run is live and render by durable sequence; retain `raw.log` parsing only as legacy/recovery fallback | Assistant, delegation, callback, user, tool, and summary events share one cross-process order instead of batching assistant turns at finalization |
 | Agent chat conversation blocks | Conversation renders selectable blocks for user messages, agent messages, system events, and collapsed tool-call groups; Enter opens the selected block in a floating scrollable detail layer | Keeps normal chat scanning compact while preserving full tool/message detail on demand |
 | Agent attachments | Structured agent results can include PR/document/image attachments, persisted in `.attachments.json` and mirrored into `memory.jsonl`, surfaced from chat with a `ctrl+a` navigable list | Durable links to artifacts survive later runs and memory rebuilds instead of living only in a single assistant message |
-| Remote artifact rendering | Render attached HTML in an origin-isolated iframe with a restrictive content policy and package explicitly referenced, allowlisted workspace web assets; render sanitized Markdown Mermaid fences with a pinned, conditional CDN loader in strict mode | Interactive lessons and shared course assets remain usable without granting generated HTML access to Tycho or browser storage, and ordinary Markdown does not pay the Mermaid download cost |
+| Remote artifact rendering | Render attached HTML in an origin-isolated iframe with a restrictive content policy and package explicitly referenced, allowlisted workspace web assets; keep sanitized Mermaid fences as code on every Markdown surface and toggle each block between `Preview chart` and `Show code` through a DOM-local action menu, using a pinned, conditional CDN loader in strict mode to render only that block | Interactive lessons and shared course assets remain usable without granting generated HTML access to Tycho or browser storage, while Mermaid work happens only for the chart the operator chooses and preview state remains reversible |
 | Pull request diffs | Agent-scoped PR diff inspection remains available through an authenticated `gh` CLI | Keep PR diff fetching agent-scoped and read-only. |
 | Agent pull request catalog | Persist canonical PR references and origin title/status metadata in an agent-owned `<agent-stem>.pull_request_catalog.json` sidecar; keep ordinary agent PR listing network-free | Opening one agent reads only that agent's catalog; displayed titles and Open/Draft/Closed/Merged state come from cached GitHub metadata, refreshes remain explicit, and archiving moves the catalog with the agent |
 | Agent pull request switching | Paint the route shell before asynchronously attaching its diff, give foreground navigation a reserved request slot, cancel stale background work outside the open PR route, preload at most six saved snapshots, retain at most twelve payloads plus six visited viewers and per-PR scroll positions, and render lines in 100-line containment chunks | Persistent snapshots remain authoritative; navigation never shares a frame with diff layout, while immutable parsed-store reuse and bounded browser caches preserve each PR's form, selection, and desktop/mobile scroll state |

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -5552,7 +5552,7 @@ select {
   position: absolute;
   top: 7px;
   right: 7px;
-  z-index: 3;
+  z-index: 20;
 }
 
 .markdown-code-menu-trigger {
@@ -5584,13 +5584,17 @@ select {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  z-index: 4;
+  z-index: 21;
   min-width: 150px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: color-mix(in srgb, var(--panel) 98%, transparent);
   box-shadow: var(--shadow);
   padding: 6px;
+}
+
+.markdown-code-menu-popover [hidden] {
+  display: none;
 }
 
 .markdown-viewer table {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3057,7 +3057,6 @@ function replaceView(html) {
     syncViewControls();
     syncFullScreenComposerModal();
     syncAgentDockLayout();
-    queueMermaidRendering();
     return;
   }
 
@@ -3087,7 +3086,6 @@ function replaceView(html) {
   syncFullScreenComposerModal();
   syncAgentDockLayout();
   restoreVisiblePullRequestDiffScroll();
-  queueMermaidRendering();
 }
 
 function replaceViewContent(html) {
@@ -10427,7 +10425,6 @@ function renderMarkdownRoute() {
     state.markdownFallbacks.delete(fallbackKey);
   });
   state.markdownFallbacks.clear();
-  queueMermaidRendering();
 }
 
 function renderParsedMarkdown(text, options = {}) {
@@ -10440,80 +10437,113 @@ function renderParsedMarkdown(text, options = {}) {
     FORBID_TAGS: ["embed", "iframe", "img", "object", "script", "style"],
     FORBID_ATTR: ["style", "srcset"],
   });
-  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${prepareMarkdownCodeBlocks(safe, options.menuScope)}</div>`;
+  return `<div class="${escapeAttr(markdownViewerClassName(options))}">${prepareMarkdownCodeBlocks(safe, options)}</div>`;
 }
 
-function prepareMarkdownCodeBlocks(html, menuScope = "markdown") {
+function prepareMarkdownCodeBlocks(html, options = {}) {
+  const menuScope = options.menuScope || "markdown";
   const template = document.createElement("template");
   template.innerHTML = html;
   template.content.querySelectorAll("pre > code").forEach((code, index) => {
     const source = code.textContent || "";
     const pre = code.parentElement;
     const menuId = `markdown-code:${menuScope}:${index}`;
+    const isMermaid = code.classList.contains("language-mermaid");
     const block = document.createElement("div");
     block.className = "markdown-code-block";
-    block.innerHTML = renderMarkdownCodeMenu(menuId, source);
+    block.dataset.markdownCodeBlock = menuId;
+    block.innerHTML = renderMarkdownCodeMenu(menuId, source, { isMermaid });
 
     pre?.replaceWith(block);
-
-    if (code.classList.contains("language-mermaid")) {
-      const diagram = document.createElement("div");
-      diagram.className = "mermaid";
-      diagram.textContent = source;
-      block.appendChild(diagram);
-    } else {
-      block.appendChild(pre);
-    }
+    block.appendChild(pre);
   });
   return template.innerHTML;
 }
 
-function renderMarkdownCodeMenu(menuId, source) {
-  const isOpen = state.openMarkdownCodeMenu === menuId;
-  const menuHtml = isOpen
-    ? `<div class="markdown-code-menu-popover" role="menu">
-        ${moreMenuButton({ label: "Copy code", icon: "copy", attrs: `data-copy="${escapeAttr(source)}" data-close-markdown-code-menu` })}
-      </div>`
+function renderMarkdownCodeMenu(menuId, source, options = {}) {
+  const previewButton = options.isMermaid
+    ? moreMenuButton({ label: "Preview chart", icon: "eye", attrs: "data-preview-mermaid-code" })
     : "";
+  const showCodeButton = options.isMermaid
+    ? moreMenuButton({ label: "Show code", icon: "code", attrs: "data-show-mermaid-code hidden" })
+    : "";
+  const menuHtml = `<div class="markdown-code-menu-popover" role="menu" hidden>
+        ${previewButton}
+        ${showCodeButton}
+        ${moreMenuButton({ label: "Copy code", icon: "copy", attrs: `data-copy="${escapeAttr(source)}" data-close-markdown-code-menu` })}
+      </div>`;
   return `
     <div class="markdown-code-menu" data-markdown-code-menu="${escapeAttr(menuId)}">
-      <button class="markdown-code-menu-trigger${isOpen ? " active" : ""}" type="button"
-        aria-label="Code block actions" aria-expanded="${isOpen}"
+      <button class="markdown-code-menu-trigger" type="button"
+        aria-label="Code block actions" aria-expanded="false"
         data-toggle-markdown-code-menu="${escapeAttr(menuId)}">${iconSvg("ellipsis")}</button>
       ${menuHtml}
     </div>
   `;
 }
 
-function queueMermaidRendering() {
-  if (!els.view.querySelector(".mermaid:not([data-processed]):not([data-mermaid-pending])")) return;
-  window.requestAnimationFrame(syncMermaidDiagrams);
-}
+async function previewMermaidCodeBlock(block) {
+  const code = block?.querySelector("pre > code.language-mermaid");
+  if (!code) return;
 
-async function syncMermaidDiagrams() {
-  const nodes = Array.from(els.view.querySelectorAll(".mermaid:not([data-processed]):not([data-mermaid-pending])"));
-  if (!nodes.length) return;
+  const source = code.textContent || "";
+  const diagram = document.createElement("div");
+  diagram.className = "mermaid";
+  diagram.dataset.mermaidPending = "true";
+  diagram.textContent = source;
+  const pre = code.parentElement;
+  pre.hidden = true;
+  pre.insertAdjacentElement("afterend", diagram);
+  setMermaidCodeBlockPreview(block, true);
+  closeMarkdownCodeMenu();
 
-  const sources = new Map(nodes.map((node) => [node, node.textContent || ""]));
-  nodes.forEach((node) => {
-    node.dataset.mermaidPending = "true";
-  });
   const ready = await ensureMermaidLoaded();
   if (!ready) {
-    nodes.filter((node) => node.isConnected).forEach((node) => markMermaidError(node, sources.get(node)));
+    if (diagram.isConnected) markMermaidError(diagram, source);
     return;
   }
 
-  for (const node of nodes) {
-    if (!node.isConnected) continue;
-    try {
-      await window.mermaid.run({ nodes: [node] });
-      delete node.dataset.mermaidPending;
-    } catch (error) {
-      console.warn("Mermaid rendering failed", error);
-      markMermaidError(node, sources.get(node));
-    }
+  if (!diagram.isConnected) return;
+  try {
+    await window.mermaid.run({ nodes: [diagram] });
+    delete diagram.dataset.mermaidPending;
+  } catch (error) {
+    console.warn("Mermaid rendering failed", error);
+    markMermaidError(diagram, source);
   }
+}
+
+function showMermaidCodeBlock(block) {
+  const pre = block?.querySelector("pre > code.language-mermaid")?.parentElement;
+  if (!pre) return;
+
+  block.querySelector(":scope > .mermaid")?.remove();
+  pre.hidden = false;
+  setMermaidCodeBlockPreview(block, false);
+  closeMarkdownCodeMenu();
+}
+
+function setMermaidCodeBlockPreview(block, previewing) {
+  block?.toggleAttribute("data-mermaid-previewing", previewing);
+  const previewButton = block?.querySelector("[data-preview-mermaid-code]");
+  const showCodeButton = block?.querySelector("[data-show-mermaid-code]");
+  if (previewButton) previewButton.hidden = previewing;
+  if (showCodeButton) showCodeButton.hidden = !previewing;
+}
+
+function toggleMarkdownCodeMenu(menu) {
+  const popover = menu?.querySelector(".markdown-code-menu-popover");
+  const trigger = menu?.querySelector("[data-toggle-markdown-code-menu]");
+  if (!popover || !trigger) return;
+
+  const opening = popover.hidden;
+  closeMarkdownCodeMenu();
+  if (!opening) return;
+
+  popover.hidden = false;
+  trigger.classList.add("active");
+  trigger.setAttribute("aria-expanded", "true");
+  state.openMarkdownCodeMenu = menu.dataset.markdownCodeMenu || null;
 }
 
 function ensureMermaidLoaded() {
@@ -14076,19 +14106,30 @@ function handleViewClick(event) {
 
   const markdownCodeMenuToggle = event.target.closest("[data-toggle-markdown-code-menu]");
   if (markdownCodeMenuToggle) {
-    const menuId = markdownCodeMenuToggle.dataset.toggleMarkdownCodeMenu;
-    state.openMarkdownCodeMenu = state.openMarkdownCodeMenu === menuId ? null : menuId;
-    render();
+    toggleMarkdownCodeMenu(markdownCodeMenuToggle.closest("[data-markdown-code-menu]"));
     return;
   }
 
   const closeMarkdownCodeMenuButton = event.target.closest("[data-close-markdown-code-menu]");
   if (closeMarkdownCodeMenuButton) {
     const copyValue = closeMarkdownCodeMenuButton.dataset.copy;
-    state.openMarkdownCodeMenu = null;
-    event.stopPropagation(); // prevent document copy handler from firing on detached element
-    render();
+    closeMarkdownCodeMenu();
+    event.stopPropagation();
     if (copyValue !== undefined) copyToClipboard(copyValue);
+    return;
+  }
+
+  const previewMermaidCodeButton = event.target.closest("[data-preview-mermaid-code]");
+  if (previewMermaidCodeButton) {
+    event.stopPropagation();
+    previewMermaidCodeBlock(previewMermaidCodeButton.closest(".markdown-code-block"));
+    return;
+  }
+
+  const showMermaidCodeButton = event.target.closest("[data-show-mermaid-code]");
+  if (showMermaidCodeButton) {
+    event.stopPropagation();
+    showMermaidCodeBlock(showMermaidCodeButton.closest(".markdown-code-block"));
     return;
   }
 
@@ -16220,9 +16261,14 @@ function closeBlockMenu() {
 }
 
 function closeMarkdownCodeMenu() {
-  if (state.openMarkdownCodeMenu === null) return;
   state.openMarkdownCodeMenu = null;
-  render();
+  document.querySelectorAll("[data-markdown-code-menu]").forEach((menu) => {
+    const popover = menu.querySelector(".markdown-code-menu-popover");
+    const trigger = menu.querySelector("[data-toggle-markdown-code-menu]");
+    if (popover) popover.hidden = true;
+    trigger?.classList.remove("active");
+    trigger?.setAttribute("aria-expanded", "false");
+  });
 }
 
 function setSkillFlyoutOpen(open) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -6110,8 +6110,11 @@ module RemoteServerTest
            "expected markdown rendering to sanitize parsed HTML with DOMPurify")
     assert(js[:body].include?("https://cdn.jsdelivr.net/npm/mermaid@11.15.0/") &&
            js[:body].include?("function prepareMarkdownCodeBlocks") &&
-           js[:body].include?("function queueMermaidRendering"),
-           "expected Mermaid code fences to lazy-load and render through a pinned CDN build")
+           js[:body].include?("function previewMermaidCodeBlock") &&
+           js[:body].include?("function showMermaidCodeBlock") &&
+           js[:body].include?("data-preview-mermaid-code") &&
+           js[:body].include?("data-show-mermaid-code"),
+           "expected Mermaid code fences to toggle individual previews through a pinned lazy CDN build")
     assert(js[:body].include?('securityLevel: "strict"'),
            "expected Mermaid rendering to use strict security mode")
     assert(js[:body].include?("function renderPlainTextMarkdown"),

--- a/test/remote_ui_mermaid_scope_test.rb
+++ b/test/remote_ui_mermaid_scope_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module RemoteUIMermaidScopeTest
+  module_function
+
+  APP_PATH = File.expand_path("../lib/hq/remote_ui/assets/app.js", __dir__)
+
+  def run!
+    javascript = File.read(APP_PATH)
+    assert_mermaid_stays_code_until_preview(javascript)
+    assert_mermaid_menu_offers_preview(javascript)
+    assert_preview_targets_one_code_block(javascript)
+    assert_preview_can_restore_code(javascript)
+    puts "remote_ui_mermaid_scope_test: ok"
+  end
+
+  def assert_mermaid_stays_code_until_preview(javascript)
+    renderer = function_source(javascript, "prepareMarkdownCodeBlocks")
+    assert(!renderer.include?("allowMermaid"),
+           "expected Mermaid fences to stay code on every Markdown surface")
+    assert(renderer.include?("code.classList.contains(\"language-mermaid\")"),
+           "expected Mermaid fences to be identified for code-block actions")
+    assert(!renderer.include?("diagram.className = \"mermaid\""),
+           "expected Markdown preparation not to render Mermaid automatically")
+  end
+
+  def assert_mermaid_menu_offers_preview(javascript)
+    menu = function_source(javascript, "renderMarkdownCodeMenu")
+    assert(menu.include?("Preview chart"), "expected Mermaid code menus to offer Preview chart")
+    assert(menu.include?("data-preview-mermaid-code"), "expected a dedicated Mermaid preview action")
+  end
+
+  def assert_preview_targets_one_code_block(javascript)
+    preview = function_source(javascript, "previewMermaidCodeBlock")
+    assert(preview.include?("window.mermaid.run({ nodes: [diagram] })"),
+           "expected Mermaid preview to render only the selected diagram")
+    assert(!javascript.include?("queueMermaidRendering();"),
+           "expected no global Mermaid rendering queue")
+  end
+
+  def assert_preview_can_restore_code(javascript)
+    menu = function_source(javascript, "renderMarkdownCodeMenu")
+    restore = function_source(javascript, "showMermaidCodeBlock")
+    toggle = function_source(javascript, "toggleMarkdownCodeMenu")
+
+    assert(menu.include?("Show code"), "expected previewed Mermaid menus to offer Show code")
+    assert(restore.include?("pre.hidden = false"), "expected Show code to restore the source fence")
+    assert(toggle.include?("popover.hidden = false"), "expected code menus to open without a full view render")
+  end
+
+  def function_source(javascript, name)
+    source = javascript[/function #{Regexp.escape(name)}\b.*?^}/m]
+    raise "missing #{name}" unless source
+
+    source
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+end
+
+RemoteUIMermaidScopeTest.run! if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary
- keep Mermaid fences as code until the operator selects Preview chart
- render only the selected diagram and expose Show code to restore its source
- keep preview menus local and above preserved chart content

## Verification
- full Ruby test suite
- `TYCHO_REMOTE_UI_SMOKE_RENDERING_ONLY=1 bin/remote-ui-smoke`
- `bundle exec ruby -c bin/tycho`
- `bundle exec ruby -c bin/schedule`
- `ruby bin/tycho doctor`
- `git diff --check`