### PR TITLE
Tidy Remote UI settings

### DIFF
--- a/lib/hq/registry.rb
+++ b/lib/hq/registry.rb
@@ -371,6 +371,22 @@ module HQ
       @session_loop_settings
     end
 
+    def update_session_loop_defaults!(attrs)
+      update_session_loop_settings!(
+        "interval_minutes" => attrs["interval_minutes"] || attrs[:interval_minutes],
+        "end_time" => attrs["end_time"] || attrs[:end_time],
+        "prompt_templates" => @session_loop_settings.fetch(:prompt_templates)
+      )
+    end
+
+    def update_session_loop_prompt_templates!(attrs)
+      update_session_loop_settings!(
+        "interval_minutes" => @session_loop_settings.fetch(:interval_minutes),
+        "end_time" => @session_loop_settings.fetch(:end_time),
+        "prompt_templates" => attrs["prompt_templates"] || attrs[:prompt_templates]
+      )
+    end
+
     def archive_project!(project_key, archived_path: nil)
       data = load_yaml(@path)
       projects = Array(data["projects"])

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -361,6 +361,12 @@ module HQ
       if %w[PATCH PUT].include?(method) && parts == ["settings", "session-loops"]
         return ok(session_loops: service.update_session_loop_settings(body))
       end
+      if %w[PATCH PUT].include?(method) && parts == ["settings", "session-loops", "defaults"]
+        return ok(session_loops: service.update_session_loop_defaults(body))
+      end
+      if %w[PATCH PUT].include?(method) && parts == ["settings", "session-loops", "prompt-templates"]
+        return ok(session_loops: service.update_session_loop_prompt_templates(body))
+      end
       return ok(response_style: service.response_style) if method == "GET" && parts == ["settings", "response-style"]
       if %w[PATCH PUT].include?(method) && parts == ["settings", "response-style"]
         return ok(response_style: service.update_response_style(body))
@@ -2499,6 +2505,18 @@ module HQ
 
     def update_session_loop_settings(attrs)
       @registry.update_session_loop_settings!(attrs)
+    rescue ConfigError => e
+      raise Error.new(e.message, status: 400)
+    end
+
+    def update_session_loop_defaults(attrs)
+      @registry.update_session_loop_defaults!(attrs)
+    rescue ConfigError => e
+      raise Error.new(e.message, status: 400)
+    end
+
+    def update_session_loop_prompt_templates(attrs)
+      @registry.update_session_loop_prompt_templates!(attrs)
     rescue ConfigError => e
       raise Error.new(e.message, status: 400)
     end

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -7827,8 +7827,8 @@ body:has(.inquiry-form-full-screen) {
     grid-template-columns: 1fr;
   }
 
-  .session-loop-settings,
-  .session-loop-templates {
+  .session-loop-settings:last-child,
+  .session-loop-templates:last-child {
     margin-bottom: calc(var(--mobile-nav-height, 70px) + 24px + env(safe-area-inset-bottom, 0px));
   }
 

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1246,7 +1246,7 @@ textarea {
 
 .server-section-label {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
 }
@@ -1366,9 +1366,9 @@ textarea {
   width: var(--touch-target);
   height: var(--touch-target);
   min-height: var(--touch-target);
-  border: 1px solid var(--border);
+  border: 0;
   border-radius: 8px;
-  background: var(--panel);
+  background: transparent;
   color: var(--muted);
   cursor: pointer;
   list-style: none;
@@ -1382,7 +1382,7 @@ textarea {
 .server-action-menu[open] > summary,
 .server-action-menu > summary:hover,
 .server-action-menu > summary:focus-visible {
-  background: var(--panel-soft);
+  background: color-mix(in srgb, var(--panel-soft) 72%, transparent);
   color: var(--text);
 }
 
@@ -7699,18 +7699,53 @@ body:has(.inquiry-form-full-screen) {
   font-size: 13px;
 }
 
-.session-loop-settings-form {
-  display: grid;
-  gap: 10px;
+.copy-url-button {
+  justify-self: end;
+}
+
+.session-loop-settings,
+.session-loop-templates {
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 10px;
-  padding: 12px;
   background: color-mix(in srgb, var(--panel) 78%, transparent);
 }
 
-.session-loop-settings-form .form-section-heading {
-  padding-right: 0;
-  padding-left: 0;
+.session-loop-settings > summary,
+.session-loop-templates > summary {
+  display: flex;
+  min-height: var(--touch-target);
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.session-loop-settings > summary::-webkit-details-marker,
+.session-loop-templates > summary::-webkit-details-marker {
+  display: none;
+}
+
+.session-loop-settings > summary > div,
+.session-loop-templates > summary > div {
+  display: grid;
+  gap: 2px;
+}
+
+.session-loop-settings > summary span,
+.session-loop-templates > summary span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.session-loop-settings-form,
+.session-loop-templates-form {
+  display: grid;
+  gap: 10px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  padding: 12px;
 }
 
 .session-loop-field {
@@ -7754,6 +7789,23 @@ body:has(.inquiry-form-full-screen) {
   gap: 12px;
 }
 
+.session-loop-template-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.session-loop-template-preview {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.session-loop-template-editor {
+  display: grid;
+  gap: 8px;
+}
+
 .session-loop-template-heading .icon-button {
   width: var(--touch-target);
   min-width: var(--touch-target);
@@ -7775,7 +7827,8 @@ body:has(.inquiry-form-full-screen) {
     grid-template-columns: 1fr;
   }
 
-  .session-loop-settings-form {
+  .session-loop-settings,
+  .session-loop-templates {
     margin-bottom: calc(var(--mobile-nav-height, 70px) + 24px + env(safe-area-inset-bottom, 0px));
   }
 
@@ -7783,6 +7836,40 @@ body:has(.inquiry-form-full-screen) {
     width: 100%;
     justify-content: center;
   }
+}
+
+.push-notification-card .detail-card-body {
+  display: grid;
+  gap: 12px;
+  padding-top: 12px;
+}
+
+.push-notification-heading,
+.push-notification-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.push-notification-heading {
+  justify-content: space-between;
+}
+
+.push-notification-heading span,
+.push-notification-status > div > span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.push-notification-status > .status-mark {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+}
+
+.push-notification-status > div {
+  display: grid;
+  gap: 2px;
 }
 
 .visibility-legend {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -4648,9 +4648,9 @@ function renderSetup() {
         ${metadataBadge(setup.tailscale?.magic_dns ? "MagicDNS" : "Direct URL", "chip")}
         ${setup.auth?.warning ? statusBadge("Token recommended", "need", "chip") : ""}
       </div>
-      <div class="button-row">
-        <button type="button" data-copy="${escapeAttr(displayUrl || "")}">Copy URL</button>
-      </div>
+      <button class="copy-url-button inline-icon-button ui-button" type="button" data-copy="${escapeAttr(displayUrl || "")}">
+        ${iconSvg("copy")}<span>Copy URL</span>
+      </button>
     </section>`)}
     ${settingsPanel("servers", renderServerSwitcher())}
     ${settingsPanel("notifications", renderPushSetup(setup))}
@@ -4734,7 +4734,7 @@ function renderSkillInstallation(installation) {
       <div class="kv-grid skill-installation-source">
         ${copyableKv("Source", first.source || "unavailable")}
         ${copyableKv("Source version", first.version || "unavailable")}
-        ${copyableKv("Verify", first.verification || "Open the harness skill picker and invoke tycho.")}
+        ${kv("Verify", first.verification || "Open the harness skill picker and invoke tycho.")}
       </div>
     </div>
   </section>`;
@@ -4773,38 +4773,52 @@ function renderSessionLoopSettings(configured) {
   const settings = configured || sessionLoopSettings();
   const templates = Array.isArray(settings.prompt_templates) ? settings.prompt_templates : [];
   return `
-    <form id="session-loop-settings-form" class="session-loop-settings-form">
-      <div class="response-style-form-heading">
+    <details class="session-loop-settings" id="session-loop-settings">
+      <summary>
         <div>
           <strong>Session loop defaults</strong>
-          <span>Quick schedule presets and reusable prompts.</span>
+          <span>Quick schedule presets.</span>
         </div>
+      </summary>
+      <form id="session-loop-settings-form" class="session-loop-settings-form ui-form-layout">
+        <div class="session-loop-default-grid">
+          <div class="session-loop-field ui-field">
+            <label class="field-label ui-field__label" for="session-loop-default-interval">Default interval</label>
+            <input class="ui-input" id="session-loop-default-interval" name="interval_minutes" type="number" min="1" max="59" step="1" value="${escapeAttr(String(settings.interval_minutes || 10))}" required aria-describedby="session-loop-default-interval-help">
+            <span class="field-hint ui-field__description" id="session-loop-default-interval-help">Minutes between loop runs.</span>
+          </div>
+          <div class="session-loop-field ui-field">
+            <label class="field-label ui-field__label" for="session-loop-default-end-time">Default stop time</label>
+            <input class="ui-input" id="session-loop-default-end-time" name="end_time" type="time" value="${escapeAttr(settings.end_time || "23:59")}" required aria-describedby="session-loop-default-end-time-help">
+            <span class="field-hint ui-field__description" id="session-loop-default-end-time-help">Local time on the Tycho server.</span>
+          </div>
+        </div>
+        <div class="session-loop-settings-actions ui-form-actions">
+          <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Save defaults</span></button>
+        </div>
+      </form>
+    </details>
+    ${renderSessionLoopTemplates(templates)}
+  `;
+}
+
+function renderSessionLoopTemplates(templates) {
+  return `
+    <details class="session-loop-templates" id="session-loop-templates">
+      <summary>
+        <div><strong>Prompt templates</strong><span>Reusable starting points.</span></div>
         ${metadataBadge(`${templates.length} ${templates.length === 1 ? "template" : "templates"}`)}
-      </div>
-      <div class="session-loop-default-grid">
-        <div class="session-loop-field ui-field">
-          <label class="field-label ui-field__label" for="session-loop-default-interval">Default interval</label>
-          <input class="ui-input" id="session-loop-default-interval" name="interval_minutes" type="number" min="1" max="59" step="1" value="${escapeAttr(String(settings.interval_minutes || 10))}" required aria-describedby="session-loop-default-interval-help">
-          <span class="field-hint ui-field__description" id="session-loop-default-interval-help">Minutes between loop runs.</span>
+      </summary>
+      <form id="session-loop-templates-form" class="session-loop-templates-form ui-form-layout">
+        <div class="session-loop-template-list" data-session-loop-template-list>
+          ${templates.map(sessionLoopTemplateRow).join("")}
         </div>
-        <div class="session-loop-field ui-field">
-          <label class="field-label ui-field__label" for="session-loop-default-end-time">Default stop time</label>
-          <input class="ui-input" id="session-loop-default-end-time" name="end_time" type="time" value="${escapeAttr(settings.end_time || "23:59")}" required aria-describedby="session-loop-default-end-time-help">
-          <span class="field-hint ui-field__description" id="session-loop-default-end-time-help">Local time on the Tycho server.</span>
+        <button class="inline-icon-button ui-button" type="button" data-add-session-loop-template>${iconSvg("plus")}<span>Add prompt template</span></button>
+        <div class="session-loop-settings-actions ui-form-actions">
+          <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Save templates</span></button>
         </div>
-      </div>
-      <div class="form-section-heading ui-form-section-heading"><strong>Prompt templates</strong><span>Optional starting points</span></div>
-      <div class="session-loop-template-list" data-session-loop-template-list>
-        ${templates.map(sessionLoopTemplateRow).join("")}
-      </div>
-      <button class="inline-icon-button ui-button" type="button" data-add-session-loop-template>${iconSvg("plus")}<span>Add prompt template</span></button>
-      <div class="response-style-form-footer session-loop-settings-footer">
-        <span>Stored in ~/.tycho/config/hq.yml</span>
-        <div class="response-style-form-actions ui-form-actions session-loop-settings-actions">
-          <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Save loop settings</span></button>
-        </div>
-      </div>
-    </form>
+      </form>
+    </details>
   `;
 }
 
@@ -4815,12 +4829,19 @@ function sessionLoopTemplateRow(template = {}, index = 0) {
     <section class="session-loop-template-row" data-session-loop-template-row>
       <input name="template_key" type="hidden" value="${escapeAttr(templateKey)}">
       <div class="session-loop-template-heading">
-        <label class="field-label" for="session-loop-template-name-${index}">Template name</label>
-        <button type="button" class="icon-button ui-button ui-icon-button" data-remove-session-loop-template aria-label="Remove prompt template" title="Remove prompt template">${iconSvg("trash2")}</button>
+        <strong>${escapeHtml(template.name || "New prompt template")}</strong>
+        <div class="session-loop-template-actions">
+          <button type="button" class="ui-button" data-edit-session-loop-template>Edit</button>
+          <button type="button" class="danger icon-button ui-button ui-icon-button" data-variant="danger" data-remove-session-loop-template aria-label="Delete prompt template" title="Delete prompt template">${iconSvg("trash2")}</button>
+        </div>
       </div>
-      <input class="ui-input" id="session-loop-template-name-${index}" name="template_name" data-state-key="session-loop-template:${escapeAttr(stateKey)}:name" type="text" value="${escapeAttr(template.name || "")}" placeholder="Wait for PR review" required>
-      <label class="field-label ui-field__label" for="session-loop-template-prompt-${index}">Prompt</label>
-      <textarea class="ui-input" id="session-loop-template-prompt-${index}" name="template_prompt" data-state-key="session-loop-template:${escapeAttr(stateKey)}:prompt" rows="5" required>${escapeHtml(template.prompt || "")}</textarea>
+      <p class="session-loop-template-preview">${escapeHtml(truncate(template.prompt || "Add a reusable starting prompt.", 140))}</p>
+      <div class="session-loop-template-editor" hidden>
+        <label class="field-label ui-field__label" for="session-loop-template-name-${index}">Template name</label>
+        <input class="ui-input" id="session-loop-template-name-${index}" name="template_name" data-state-key="session-loop-template:${escapeAttr(stateKey)}:name" type="text" value="${escapeAttr(template.name || "")}" placeholder="Wait for PR review" required>
+        <label class="field-label ui-field__label" for="session-loop-template-prompt-${index}">Prompt</label>
+        <textarea class="ui-input" id="session-loop-template-prompt-${index}" name="template_prompt" data-state-key="session-loop-template:${escapeAttr(stateKey)}:prompt" rows="5" required>${escapeHtml(template.prompt || "")}</textarea>
+      </div>
     </section>
   `;
 }
@@ -4991,19 +5012,26 @@ function renderServerSwitcher() {
       <div class="detail-card-body" style="padding-top: 12px;">
         <div class="section-label server-section-label">
           <div><strong>Servers</strong><span>${servers.length} connected</span></div>
-          <button class="inline-icon-button ui-button" type="button" data-refresh-all-servers>
-            ${iconSvg("rotateCcw")}
-            <span>Refresh all</span>
-          </button>
-          <button class="inline-icon-button ui-button" type="button" data-toggle-server-form aria-expanded="${state.serverFormOpen ? "true" : "false"}">
-            ${iconSvg(state.serverFormOpen ? "x" : "plus")}
-            <span>${state.serverFormOpen ? "Cancel" : "Add server"}</span>
-          </button>
+          ${renderServersActionsMenu()}
         </div>
         ${renderServerList(servers)}
         ${state.serverFormOpen ? renderAddServerForm() : ""}
       </div>
     </section>
+  `;
+}
+
+function renderServersActionsMenu() {
+  return `
+    <details class="server-action-menu servers-action-menu" data-overlay-menu data-overlay-key="servers-actions">
+      <summary aria-label="Server actions" title="Server actions" aria-haspopup="menu">${iconSvg("ellipsis")}</summary>
+      <div class="server-action-popover ui-overlay-surface" data-overlay-kind="menu">
+        ${moreMenuHtml([
+          moreMenuButton({ label: "Refresh all", icon: "rotateCcw", attrs: "data-refresh-all-servers" }),
+          moreMenuButton({ label: state.serverFormOpen ? "Cancel adding server" : "Add server", icon: state.serverFormOpen ? "x" : "plus", attrs: "data-toggle-server-form" }),
+        ])}
+      </div>
+    </details>
   `;
 }
 
@@ -5039,6 +5067,7 @@ function renderServerRow(server) {
           ${server.activity_error ? `<span class="server-activity-error" role="status">${escapeHtml(server.activity_error)}.</span>` : ""}
         </div>
         <div class="server-row-actions">
+          <button class="icon-button ui-button ui-icon-button" type="button" data-copy="${escapeAttr(server.url || "")}" aria-label="Copy ${escapeAttr(serverDisplayName(server))} URL" title="Copy URL" ${server.url ? "" : "disabled"}>${iconSvg("copy")}</button>
           ${actions}
         </div>
       </div>
@@ -5294,19 +5323,18 @@ function renderPushSetup(setup) {
       : "VAPID keys are unavailable";
   const pushActions = subscribed
     ? `
-      <button type="button" data-test-push ${canEnable ? "" : "disabled"}>Send test</button>
-      <button class="danger ui-button" data-variant="danger" type="button" data-disable-push ${support.supported ? "" : "disabled"}>Disable notifications</button>
+      <button type="button" data-test-push ${canEnable ? "" : "disabled"}>Test</button>
+      <button class="danger ui-button" data-variant="danger" type="button" data-disable-push ${support.supported ? "" : "disabled"}>Disable</button>
     `
     : `<button class="primary inline-icon-button ui-button" data-variant="brand" type="button" data-enable-push ${canEnable ? "" : "disabled"}>${iconSvg("check")}<span>Enable notifications</span></button>`;
 
   return `
-    <section class="detail-card" id="settings-push-notifications">
-      <div class="detail-card-body" style="padding-top: 12px;">
-        <div class="section-label"><strong>Push notifications</strong><span>browser alerts</span></div>
-        <div class="detail-row">
+    <section class="detail-card push-notification-card" id="settings-push-notifications">
+      <div class="detail-card-body">
+        <div class="push-notification-heading"><strong>Push notifications</strong><span>Browser alerts</span></div>
+        <div class="push-notification-status">
           <span class="status-mark ${statusClassName}" ${statusMarkAttributes(statusClassName)} aria-hidden="true">${statusIcon(subscribed || canEnable)}</span>
           <div><strong>${escapeHtml(status)}</strong><span>${escapeHtml(detail)}</span></div>
-          ${statusBadge(titleFromKey(notificationPermissionLabel()), statusClassName)}
         </div>
         <div class="button-row form-actions ui-form-actions">
           ${pushActions}
@@ -13925,7 +13953,23 @@ function handleViewClick(event) {
     if (list) {
       const index = list.querySelectorAll("[data-session-loop-template-row]").length;
       list.insertAdjacentHTML("beforeend", sessionLoopTemplateRow({}, index));
-      list.querySelectorAll("[data-session-loop-template-row]")[index]?.querySelector("[name='template_name']")?.focus();
+      const row = list.querySelectorAll("[data-session-loop-template-row]")[index];
+      const editor = row?.querySelector(".session-loop-template-editor");
+      if (editor) editor.hidden = false;
+      const editButton = row?.querySelector("[data-edit-session-loop-template]");
+      if (editButton) editButton.textContent = "Close";
+      row?.querySelector("[name='template_name']")?.focus();
+    }
+    return;
+  }
+  const editLoopTemplate = event.target.closest("[data-edit-session-loop-template]");
+  if (editLoopTemplate) {
+    const row = editLoopTemplate.closest("[data-session-loop-template-row]");
+    const editor = row?.querySelector(".session-loop-template-editor");
+    if (editor) {
+      editor.hidden = !editor.hidden;
+      editLoopTemplate.textContent = editor.hidden ? "Edit" : "Close";
+      if (!editor.hidden) editor.querySelector("[name='template_name']")?.focus();
     }
     return;
   }
@@ -14995,20 +15039,29 @@ els.view.addEventListener("submit", (event) => {
 
   if (event.target.id === "session-loop-settings-form") {
     const form = event.target;
+    const formData = new FormData(form);
+    mutate(async () => {
+      const data = await apiPatch("/settings/session-loops/defaults", {
+        interval_minutes: Number.parseInt(String(formData.get("interval_minutes") || ""), 10),
+        end_time: String(formData.get("end_time") || "").trim(),
+      });
+      if (state.setup?.config) state.setup.config.session_loop_settings = data.session_loops;
+      showGrowl("Session loop defaults saved", "done");
+    }, { form });
+    return;
+  }
+
+  if (event.target.id === "session-loop-templates-form") {
+    const form = event.target;
     const templates = Array.from(form.querySelectorAll("[data-session-loop-template-row]")).map((row) => ({
       key: String(row.querySelector("[name='template_key']")?.value || "").trim(),
       name: String(row.querySelector("[name='template_name']")?.value || "").trim(),
       prompt: String(row.querySelector("[name='template_prompt']")?.value || "").trim(),
     }));
-    const formData = new FormData(form);
     mutate(async () => {
-      const data = await apiPatch("/settings/session-loops", {
-        interval_minutes: Number.parseInt(String(formData.get("interval_minutes") || ""), 10),
-        end_time: String(formData.get("end_time") || "").trim(),
-        prompt_templates: templates,
-      });
+      const data = await apiPatch("/settings/session-loops/prompt-templates", { prompt_templates: templates });
       if (state.setup?.config) state.setup.config.session_loop_settings = data.session_loops;
-      showGrowl("Session loop settings saved", "done");
+      showGrowl("Prompt templates saved", "done");
     }, { form });
     return;
   }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -4794,7 +4794,7 @@ function renderSessionLoopSettings(configured) {
           </div>
         </div>
         <div class="session-loop-settings-actions ui-form-actions">
-          <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Save defaults</span></button>
+          <button class="primary inline-icon-button ui-button" data-variant="brand" type="submit">${iconSvg("check")}<span>Save</span></button>
         </div>
       </form>
     </details>

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -391,6 +391,21 @@ module RemoteServerTest
       assert(persisted.dig("session_loops", "prompt_templates", 1, "prompt") ==
              "Check release readiness.\nReport blockers only.",
              "expected session loop settings to persist each template prompt independently")
+
+      defaults_updated = server.send(:route, service, "PATCH", "/settings/session-loops/defaults", {
+                                       "interval_minutes" => 20,
+                                       "end_time" => "20:00"
+                                     }, nil)
+      assert(defaults_updated.dig(:body, :session_loops, :prompt_templates, 0, :key) == "review-watch",
+             "expected loop defaults to preserve prompt templates")
+
+      templates_updated = server.send(:route, service, "PATCH", "/settings/session-loops/prompt-templates", {
+                                        "prompt_templates" => [
+                                          { "name" => "Check deploy", "prompt" => "Check deploy readiness." }
+                                        ]
+                                      }, nil)
+      assert(templates_updated.dig(:body, :session_loops, :interval_minutes) == 20,
+             "expected prompt template updates to preserve loop defaults")
     end
   end
 
@@ -5406,11 +5421,29 @@ module RemoteServerTest
            js[:body].include?('apiPost(`/agents/${encodeURIComponent(agentKey)}/loop-schedule`, payload)'),
            "expected conversation context menus to create quick session loops")
     assert(js[:body].include?('id="session-loop-settings-form"') &&
-           js[:body].include?('apiPatch("/settings/session-loops"') &&
+           js[:body].include?('id="session-loop-templates-form"') &&
+           js[:body].include?('apiPatch("/settings/session-loops/defaults"') &&
+           js[:body].include?('apiPatch("/settings/session-loops/prompt-templates"') &&
            js[:body].include?("data-session-loop-template-row") &&
            js[:body].include?("session-loop-settings-actions") &&
+           js[:body].include?("data-edit-session-loop-template") &&
+           js[:body].include?("Save defaults") &&
+           js[:body].include?("Save templates") &&
            js[:body].include?('data-state-key="session-loop-template:${escapeAttr(stateKey)}:prompt"'),
-           "expected General Settings to configure loop defaults and prompt templates")
+           "expected General Settings to configure loop defaults and prompt templates independently")
+    assert(js[:body].include?('>Test</button>') &&
+           js[:body].include?('>Disable</button>') &&
+           !js[:body].include?(">Send test</button>") &&
+           !js[:body].include?(">Disable notifications</button>") &&
+           js[:body].include?("push-notification-card"),
+           "expected Push notification controls and status treatment to use the compact Settings card")
+    assert(js[:body].include?("function renderServersActionsMenu") &&
+           js[:body].include?("data-refresh-all-servers") &&
+           js[:body].include?("data-toggle-server-form") &&
+           js[:body].include?('iconSvg("copy")') &&
+           css[:body].include?(".server-action-menu > summary") &&
+           css[:body].include?("border: 0;"),
+           "expected server actions to move into borderless context menus with copy controls")
     assert(css[:body].include?(".session-loop-settings-actions") &&
            css[:body].include?("var(--mobile-nav-height, 70px) + 24px"),
            "expected session loop settings save actions to remain reachable on mobile")

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5427,7 +5427,8 @@ module RemoteServerTest
            js[:body].include?("data-session-loop-template-row") &&
            js[:body].include?("session-loop-settings-actions") &&
            js[:body].include?("data-edit-session-loop-template") &&
-           js[:body].include?("Save defaults") &&
+           js[:body].include?("<span>Save</span>") &&
+           !js[:body].include?("Save defaults") &&
            js[:body].include?("Save templates") &&
            js[:body].include?('data-state-key="session-loop-template:${escapeAttr(stateKey)}:prompt"'),
            "expected General Settings to configure loop defaults and prompt templates independently")


### PR DESCRIPTION
## Summary
- simplify Settings server, push-notification, and verification surfaces
- split session-loop defaults from prompt-template editing and persistence
- add focused server and session-loop regression coverage

## Fizzy
https://fizzy.startkit.tech/1/cards/166

## Validation
- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/registry_test.rb`
- `bin/remote-ui-smoke`
- `bin/test`