### PR TITLE
Align Agents list with quick switcher

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -791,13 +791,20 @@ def write_smoke_script(path)
         await page.click("#header-more-button");
         await page.waitForSelector("#header-more-panel [data-open-project-workspace='web']", { state: "visible", timeout: 10_000 });
         const projectMenu = await page.evaluate(() => {
-          const items = Array.from(document.querySelectorAll("#header-more-panel .more-menu-item strong"), (item) => item.textContent.trim());
-          const separator = document.querySelector("#header-more-panel .more-menu-separator");
+          const menu = document.querySelector("#header-more-panel .more-menu");
+          const items = Array.from(menu?.querySelectorAll(".more-menu-item strong") || [], (item) => item.textContent.trim());
+          const separator = menu?.querySelector(".more-menu-separator");
           const newAgent = document.querySelector("#header-more-panel [data-create-agent='web']");
-          return { items, separated: Boolean(separator && newAgent && separator.compareDocumentPosition(newAgent) & Node.DOCUMENT_POSITION_FOLLOWING) };
+          const actions = Array.from(menu?.querySelectorAll(".more-menu-item") || []);
+          return {
+            items,
+            separated: Boolean(separator?.nextElementSibling === newAgent),
+            newAgentIsLast: actions.at(-1) === newAgent,
+          };
         });
         if (!projectMenu.items.includes("Browse workspace") || !projectMenu.items.includes("See diff") ||
-            !projectMenu.items.includes("New agent") || !projectMenu.separated) {
+            !projectMenu.items.includes("Edit project") || !projectMenu.items.includes("New agent") ||
+            !projectMenu.separated || !projectMenu.newAgentIsLast) {
           throw new Error(`Project action menu is incomplete: ${JSON.stringify(projectMenu)}`);
         }
         await page.click("#header-more-panel [data-open-project-workspace='web']");

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -784,8 +784,23 @@ def write_smoke_script(path)
       async function assertProjectWorkspaceBrowser() {
         const consoleErrorStart = errors.length;
         await page.goto(`${baseUrl}/ui#project/web`, { waitUntil: "networkidle" });
-        await page.waitForSelector("[data-open-project-workspace='web']", { state: "visible", timeout: 10_000 });
-        await page.click(".project-primary-actions [data-open-project-workspace='web']");
+        await page.waitForSelector("#header-more-button", { state: "visible", timeout: 10_000 });
+        if (await page.locator(".project-primary-actions").count() !== 0) {
+          throw new Error("Project detail still renders workspace and diff buttons outside its action menu");
+        }
+        await page.click("#header-more-button");
+        await page.waitForSelector("#header-more-panel [data-open-project-workspace='web']", { state: "visible", timeout: 10_000 });
+        const projectMenu = await page.evaluate(() => {
+          const items = Array.from(document.querySelectorAll("#header-more-panel .more-menu-item strong"), (item) => item.textContent.trim());
+          const separator = document.querySelector("#header-more-panel .more-menu-separator");
+          const newAgent = document.querySelector("#header-more-panel [data-create-agent='web']");
+          return { items, separated: Boolean(separator && newAgent && separator.compareDocumentPosition(newAgent) & Node.DOCUMENT_POSITION_FOLLOWING) };
+        });
+        if (!projectMenu.items.includes("Browse workspace") || !projectMenu.items.includes("See diff") ||
+            !projectMenu.items.includes("New agent") || !projectMenu.separated) {
+          throw new Error(`Project action menu is incomplete: ${JSON.stringify(projectMenu)}`);
+        }
+        await page.click("#header-more-panel [data-open-project-workspace='web']");
         await page.waitForSelector(".workspace-entry-list", { state: "visible", timeout: 10_000 });
 
         const rootContract = await page.evaluate(() => ({
@@ -1461,6 +1476,7 @@ def write_smoke_script(path)
               server_key: "local",
             })),
           ];
+          state.agentSort = "project_asc";
           render();
         });
         await page.waitForSelector("[data-agent-mobile-toolbar-menu] > summary", { state: "visible", timeout: 10_000 });
@@ -2591,14 +2607,27 @@ def write_smoke_script(path)
           }));
           throw new Error(`Unscheduled agent missing from combined list: ${JSON.stringify(agentState)} / ${error.message}`);
         }
+        const relevancyOrder = await agentsRegressionPage.evaluate(() => ({
+          sort: state.agentSort,
+          direct: Boolean(document.querySelector(".agent-flat-list")),
+          visible: Array.from(document.querySelectorAll(".agent-flat-list [data-open-agent]"), (row) => row.dataset.openAgent),
+          expected: currentAgents().sort(compareQuickSwitchAgents).map((agent) => agent.key),
+        }));
+        if (relevancyOrder.sort !== "relevancy" || !relevancyOrder.direct ||
+            relevancyOrder.visible.join("|") !== relevancyOrder.expected.join("|")) {
+          throw new Error(`Agents default no longer matches quick-switch Relevancy: ${JSON.stringify(relevancyOrder)}`);
+        }
         await agentsRegressionPage.fill("#agent-filter", "unscheduled");
         if (await agentsRegressionPage.locator(".agent-row[data-open-agent]").count() !== 1 ||
             await agentsRegressionPage.locator(".agent-name-label .agent-search-match").innerText() !== "Unscheduled") {
           throw new Error("Agents filter did not isolate and highlight an agent-name match");
         }
         await agentsRegressionPage.fill("#agent-filter", "web");
-        if (await agentsRegressionPage.locator(".agent-group-project-title .agent-search-match").count() !== 1 ||
-            await agentsRegressionPage.locator(".agent-group-project-title .agent-search-match").innerText() !== "Web") {
+        const projectMatches = await agentsRegressionPage.evaluate(() => Array.from(
+          document.querySelectorAll(".agent-flat-list .row-title > span .agent-search-match"),
+          (node) => node.textContent
+        ));
+        if (projectMatches.length < 1 || projectMatches.some((match) => match !== "Web")) {
           throw new Error("Agents filter did not highlight a project-name match");
         }
         await agentsRegressionPage.fill("#agent-filter", "personal");
@@ -2670,6 +2699,7 @@ def write_smoke_script(path)
             { key: "empty-alpha", name: "Empty Alpha", status: "configured" },
             { key: "empty-beta", name: "Empty Beta", status: "configured" },
           ];
+          state.agentSort = "project_asc";
           render();
         });
         await agentsRegressionPage.waitForSelector(".agent-ledger", { state: "visible", timeout: 10_000 });

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -11865,18 +11865,18 @@ function projectMoreMenuHtml(project) {
       icon: "fileText",
       attrs: `data-open-project-diff="${escapeAttr(project.key)}" data-diff-scope="worktree"`,
     }),
+    moreMenuButton({
+      label: "Edit project",
+      sublabel: project.name || project.key,
+      icon: "pencil",
+      attrs: `data-edit-project="${escapeAttr(project.key)}"`,
+    }),
     moreMenuSeparator(),
     moreMenuButton({
       label: "New agent",
       sublabel: project.name || project.key,
       icon: "plus",
       attrs: `data-create-agent="${escapeAttr(project.key)}"`,
-    }),
-    moreMenuButton({
-      label: "Edit project",
-      sublabel: project.name || project.key,
-      icon: "pencil",
-      attrs: `data-edit-project="${escapeAttr(project.key)}"`,
     }),
   ]);
 }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -56,8 +56,9 @@ const OPTIMISTIC_PROMPT_QUEUE_STORAGE_PREFIX = "hq.remote.optimisticPromptQueue.
 const SERVER_TOKENS_STORAGE_KEY = "hq.remote.serverTokens";
 const FORM_DRAFT_TEXT_INPUT_TYPES = new Set(["text", "search", "email", "url", "tel", "password", "number"]);
 const AGENT_SORT_STORAGE_KEY = "hq.remote.agentSort";
-const DEFAULT_AGENT_SORT = "project_asc";
+const DEFAULT_AGENT_SORT = "relevancy";
 const AGENT_SORT_OPTIONS = [
+  { value: "relevancy", label: "Relevancy", icon: "sparkles", scope: "agents" },
   { value: "agent_name_asc", label: "Agents A-Z", icon: "arrowDownAZ", scope: "agents" },
   { value: "agent_name_desc", label: "Agents Z-A", icon: "arrowDownZA", scope: "agents" },
   { value: "agent_updated_desc", label: "Agents latest update", icon: "clockArrowDown", scope: "agents" },
@@ -4323,7 +4324,7 @@ function agentMobileToolbarMenuHtml() {
         moreMenuButton({
           label: "All servers",
           sublabel: state.filters.server ? "Show every server" : "Current server filter",
-          icon: "server",
+          icon: "globe",
           attrs: 'data-agent-server-choice=""',
         }),
         ...state.servers.map((server) => moreMenuButton({
@@ -7554,10 +7555,6 @@ function renderProject(key) {
       ${project.pr_number ? metadataBadge(`PR #${project.pr_number}`, "chip") : ""}
       ${metadataBadge(project.branch || "branch n/a", "chip")}
       ${statusBadge(project.dirty ? `${project.dirty_files} dirty` : "Clean", project.dirty ? "need" : "done", "chip")}
-    </div>
-    <div class="button-row project-primary-actions">
-      <button class="primary inline-icon-button ui-button" data-variant="brand" type="button" data-open-project-workspace="${escapeAttr(project.key)}">${iconSvg("folder")}<span>Browse workspace</span></button>
-      <button class="inline-icon-button ui-button" type="button" data-open-project-diff="${escapeAttr(project.key)}" data-diff-scope="worktree">${iconSvg("fileText")}<span>See diff</span></button>
     </div>
     <section class="agent-group project-overview-list">
       <div class="agent-row project-overview-row ${resourceStaleClass(project)}">
@@ -11863,16 +11860,23 @@ function projectMoreMenuHtml(project) {
       attrs: `data-open-project-workspace="${escapeAttr(project.key)}"`,
     }),
     moreMenuButton({
-      label: "Edit project",
-      sublabel: project.name || project.key,
-      icon: "pencil",
-      attrs: `data-edit-project="${escapeAttr(project.key)}"`,
-    }),
-    moreMenuButton({
       label: "See diff",
       sublabel: projectDiffSublabel(project),
       icon: "fileText",
       attrs: `data-open-project-diff="${escapeAttr(project.key)}" data-diff-scope="worktree"`,
+    }),
+    moreMenuSeparator(),
+    moreMenuButton({
+      label: "New agent",
+      sublabel: project.name || project.key,
+      icon: "plus",
+      attrs: `data-create-agent="${escapeAttr(project.key)}"`,
+    }),
+    moreMenuButton({
+      label: "Edit project",
+      sublabel: project.name || project.key,
+      icon: "pencil",
+      attrs: `data-edit-project="${escapeAttr(project.key)}"`,
     }),
   ]);
 }

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -137,6 +137,8 @@
 
   function compareAgentsBySort(a, b, sort, config = {}) {
     switch (normalizeAgentSort(sort, config)) {
+      case "relevancy":
+        return compareQuickSwitchAgents(a, b);
       case "agent_name_desc":
         return compareAgentsByNameDesc(a, b);
       case "agent_updated_desc":

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -4822,8 +4822,8 @@ module RemoteServerTest
            "expected selected Remote UI nav clicks to scroll the current tab to the top")
     assert(js[:body].include?('route.type === "tab" && route.tab === tab'),
            "expected selected Remote UI nav detection to require the current top-level tab")
-    assert(js[:body].include?('const DEFAULT_AGENT_SORT = "project_asc"'),
-           "expected agent sorting to default to project grouping ascending")
+    assert(js[:body].include?('const DEFAULT_AGENT_SORT = "relevancy"'),
+           "expected agent sorting to default to the Relevancy list")
     assert(js[:body].include?('const AGENT_SORT_STORAGE_KEY = "hq.remote.agentSort"'),
            "expected agent sort selection to use session storage")
     assert(js[:body].include?("data-agent-sort-choice"),
@@ -5475,6 +5475,12 @@ module RemoteServerTest
            "expected push setup to replace expired or VAPID-mismatched browser subscriptions")
     assert(js[:body].include?("function renderAgentForm"),
            "expected Remote UI to render create/edit agent forms")
+    assert(js[:body].include?('const DEFAULT_AGENT_SORT = "relevancy"') &&
+           js[:body].include?('{ value: "relevancy", label: "Relevancy"'),
+           "expected the Agents page to default to the direct Relevancy agent list")
+    assert(helpers_js[:body].include?('case "relevancy":') &&
+           helpers_js[:body].include?("return compareQuickSwitchAgents(a, b);"),
+           "expected Relevancy to reuse the quick switch ordering")
     assert(js[:body].include?("function renderOnboardingCliGuide") &&
            js[:body].include?("data-select-onboarding-cli") &&
            js[:body].include?("agent_cli_guides"),
@@ -5502,6 +5508,14 @@ module RemoteServerTest
            js[:body].include?("function renderProjectWorkspace") &&
            js[:body].include?("function ensureProjectWorkspacePreview"),
            "expected Project detail to expose the read-only workspace browser")
+    assert(!js[:body].include?("project-primary-actions"),
+           "expected Project detail to keep Browse workspace and See diff out of the main surface")
+    assert(js[:body].include?('label: "New agent"') &&
+           js[:body].include?("moreMenuSeparator(),\n    moreMenuButton({\n      label: \"New agent\""),
+           "expected Project More menu to offer New agent after a divider")
+    assert(js[:body].include?('label: "All servers"') &&
+           js[:body].include?('icon: "globe"'),
+           "expected the All servers action to use a globe icon")
     assert(js[:body].include?("function performProjectWorkspaceRequest") &&
            js[:body].include?("requests[key] !== requestId"),
            "expected workspace navigation responses to be race-safe")

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5511,8 +5511,9 @@ module RemoteServerTest
     assert(!js[:body].include?("project-primary-actions"),
            "expected Project detail to keep Browse workspace and See diff out of the main surface")
     assert(js[:body].include?('label: "New agent"') &&
-           js[:body].include?("moreMenuSeparator(),\n    moreMenuButton({\n      label: \"New agent\""),
-           "expected Project More menu to offer New agent after a divider")
+           js[:body].include?("attrs: `data-edit-project=\"${escapeAttr(project.key)}\"`,\n    }),\n    moreMenuSeparator(),\n    moreMenuButton({\n      label: \"New agent\"") &&
+           js[:body].include?("attrs: `data-create-agent=\"${escapeAttr(project.key)}\"`,\n    }),\n  ]);"),
+           "expected Project More menu to isolate New agent after a divider as its final action")
     assert(js[:body].include?('label: "All servers"') &&
            js[:body].include?('icon: "globe"'),
            "expected the All servers action to use a globe icon")

--- a/test/remote_ui_agent_search_test.rb
+++ b/test/remote_ui_agent_search_test.rb
@@ -70,6 +70,14 @@ module RemoteUIAgentSearchTest
       if (switched.map((agent) => agent.key).join(",") !== "actionable-read-newer,actionable-unread,no-action-read-newer,no-action-unread") {
         throw new Error(`quick switcher did not keep actionable agents and no-action agents in recency order: ${JSON.stringify(switched)}`);
       }
+      const relevancy = [noActionReadNewer, actionableReadNewer, noActionUnread, actionableUnread]
+        .sort((left, right) => helpers.compareAgentsBySort(left, right, "relevancy", {
+          defaultSort: "relevancy",
+          options: [{ value: "relevancy", scope: "agents" }],
+        }));
+      if (relevancy.map((agent) => agent.key).join(",") !== switched.map((agent) => agent.key).join(",")) {
+        throw new Error(`relevancy sorting diverged from quick switching: ${JSON.stringify(relevancy)}`);
+      }
       if (helpers.compareAgentsBySort(actionableUnread, noActionReadNewer, "agent_name_asc", {}) >= 0) {
         throw new Error("named agent sorting must not be changed by no-action status");
       }


### PR DESCRIPTION
## Summary
- make the direct Agents list default to Relevancy, sharing quick-switch ordering
- move project workspace, diff, and edit actions into More; isolate New agent as the final action after a divider
- use a globe for the All servers action and update browser regressions

## Fizzy
- https://fizzy.startkit.tech/1/cards/165
- https://fizzy.startkit.tech/1/cards/167

## Validation
- bundle exec ruby test/remote_ui_agent_search_test.rb
- bundle exec ruby test/remote_server_test.rb
- bin/remote-ui-smoke
- bin/test