### PR TITLE
Refresh schedule sessions

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1482,7 +1482,7 @@ Saved safely.
         });
         if (!daemonMenuLayout.found ||
             daemonMenuLayout.labels.join("|") !== "Restart daemon|Stop daemon" ||
-            daemonMenuLayout.scheduleLabels.join("|") !== "Run now|Edit schedule|Delete schedule" ||
+            daemonMenuLayout.scheduleLabels.join("|") !== "Run now|Refresh session|Edit schedule|Delete schedule" ||
             daemonMenuLayout.topDelta > 2 ||
             daemonMenuLayout.toolbarChildren !== 2) {
           throw new Error(`Schedule daemon menu is not aligned beside New schedule: ${JSON.stringify(daemonMenuLayout)}`);

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -17,6 +17,7 @@ module HQ
     RefreshError = Class.new(StandardError)
     DEFAULT_INTERVAL = 30
     MISSED_GRACE_SECONDS = 60
+    REFRESH_STOP_TIMEOUT_SECONDS = 2.0
 
     attr_reader :registry, :schedule_registry, :store
 
@@ -89,7 +90,7 @@ module HQ
       state = store.state_for(store.load, schedule.key)
       target = last_agent(schedule, state, load_agents)
       if target
-        @agent_store.stop_agent!(target.key) if target.running?
+        stop_scheduled_session!(target) if target.running?
         @agent_store.archive_agent!(target.key)
         reconcile_archived_agent!(target.key, archived_agent: target, now:)
       end
@@ -281,6 +282,20 @@ module HQ
       schedule = find_schedule!(key)
       states = store.load
       [schedule, states, store.state_for(states, schedule.key)]
+    end
+
+    def stop_scheduled_session!(target)
+      @agent_store.stop_agent!(target.key)
+      deadline = Time.now + REFRESH_STOP_TIMEOUT_SECONDS
+      loop do
+        current = load_agents.find { |agent| agent.key == target.key }
+        return unless current&.running?
+        break if Time.now >= deadline
+
+        sleep 0.05
+      end
+
+      raise RefreshError, "Scheduled session #{target.key.inspect} did not stop within #{REFRESH_STOP_TIMEOUT_SECONDS.to_i} seconds"
     end
 
     def project_for(schedule)

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -82,12 +82,12 @@ module HQ
       schedule, states, state = schedule_state_for(key)
       ensure_not_expired!(schedule, state, states, now:)
       resume_state!(schedule, state, now:)
-      run_schedule(schedule, states, state, now:, dry_run:)
+      dispatch_and_persist_schedule(schedule, states, state, now:, dry_run:)
     end
 
     def refresh_session(key, now: Time.now)
-      schedule = find_schedule!(key)
-      state = store.state_for(store.load, schedule.key)
+      schedule, states, state = schedule_state_for(key)
+      ensure_not_expired!(schedule, state, states, now:)
       target = last_agent(schedule, state, load_agents)
       if target
         stop_scheduled_session!(target) if target.running?
@@ -104,14 +104,7 @@ module HQ
         store.save(states)
         return { status: :skipped, schedule: schedule_payload(schedule, state) }
       end
-      run_schedule(schedule, states, state, now:, dry_run:)
-    end
-
-    def run_schedule(schedule, states, state, now:, dry_run:)
-      agents = load_agents
-      result = dispatch_schedule(schedule, state, agents, now:, dry_run:)
-      persist(agents, states, dry_run:)
-      result
+      dispatch_and_persist_schedule(schedule, states, state, now:, dry_run:)
     end
 
     def remove(key)
@@ -240,6 +233,13 @@ module HQ
 
       @agent_store.save(agents)
       store.save(states)
+    end
+
+    def dispatch_and_persist_schedule(schedule, states, state, now:, dry_run:)
+      agents = load_agents
+      result = dispatch_schedule(schedule, state, agents, now:, dry_run:)
+      persist(agents, states, dry_run:)
+      result
     end
 
     def schedule_payload(schedule, state, agent: nil)

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -14,6 +14,7 @@ require_relative "web_push_notifier"
 module HQ
   class Scheduler
     LoopStartError = Class.new(StandardError)
+    RefreshError = Class.new(StandardError)
     DEFAULT_INTERVAL = 30
     MISSED_GRACE_SECONDS = 60
 
@@ -69,20 +70,36 @@ module HQ
       schedule = find_schedule!(key)
       states = store.load
       state = store.state_for(states, schedule.key)
-      if schedule.expired?(now)
-        expire_schedule!(schedule, state, now:)
-        store.save(states)
-        raise ScheduleRegistry::Error, "Schedule #{schedule.key.inspect} ended at #{schedule.ends_at.iso8601}"
-      end
-      was_stopped = state.stopped?
-      was_paused = state.paused?
-      state.mark_scheduled!
-      state.next_due_at = schedule.next_due_after(now)
-      state.resumed_at = now if was_stopped || was_paused
-      reason = was_stopped ? "stopped" : (was_paused ? "paused" : "manual")
-      publish("schedule.resumed", schedule, state, reason: reason)
+      ensure_not_expired!(schedule, state, states, now:)
+      resume_state!(schedule, state, now:)
       store.save(states)
       { status: :resumed, schedule: schedule_payload(schedule, state) }
+    end
+
+    def resume_and_run_now(key, now: Time.now, dry_run: false)
+      schedule = find_schedule!(key)
+      states = store.load
+      state = store.state_for(states, schedule.key)
+      ensure_not_expired!(schedule, state, states, now:)
+      resume_state!(schedule, state, now:)
+      agents = load_agents
+      result = dispatch_schedule(schedule, state, agents, now:, dry_run:)
+      persist(agents, states, dry_run:)
+      result
+    end
+
+    def refresh_session(key, now: Time.now)
+      schedule = find_schedule!(key)
+      state = store.state_for(store.load, schedule.key)
+      target = last_agent(schedule, state, load_agents)
+      if target
+        raise RefreshError, "Stop the scheduled session before refreshing it" if target.running?
+
+        @agent_store.archive_agent!(target.key)
+        reconcile_archived_agent!(target.key, archived_agent: target, now:)
+      end
+
+      resume_and_run_now(schedule.key, now:)
     end
 
     def run_now(key, now: Time.now, dry_run: false)
@@ -397,6 +414,7 @@ module HQ
       state.last_target_key = nil
       state.last_target_kind = nil
       state.last_finished_at ||= now
+      state.run_count = 0
       state.mark_scheduled! if state.stopped? || state.paused?
       publish("schedule.agent_archived", schedule, state,
               agent_key: agent_key,
@@ -419,6 +437,24 @@ module HQ
       return nil if key.empty?
 
       agents.find { |agent| agent.key == key }
+    end
+
+    def resume_state!(schedule, state, now:)
+      was_stopped = state.stopped?
+      was_paused = state.paused?
+      state.mark_scheduled!
+      state.next_due_at = schedule.next_due_after(now)
+      state.resumed_at = now if was_stopped || was_paused
+      reason = was_stopped ? "stopped" : (was_paused ? "paused" : "manual")
+      publish("schedule.resumed", schedule, state, reason: reason)
+    end
+
+    def ensure_not_expired!(schedule, state, states, now:)
+      return unless schedule.expired?(now)
+
+      expire_schedule!(schedule, state, now:)
+      store.save(states)
+      raise ScheduleRegistry::Error, "Schedule #{schedule.key.inspect} ended at #{schedule.ends_at.iso8601}"
     end
 
     def interactive_scheduled_session?(schedule, state, agent)

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -39,6 +39,7 @@ module HQ
     def list(now: Time.now)
       schedules = schedule_registry.schedules
       states = store.load
+      agents = load_agents
       changed = false
       rows = schedules.map do |schedule|
         state = store.state_for(states, schedule.key)
@@ -47,7 +48,7 @@ module HQ
                   else
                     ensure_next_due!(schedule, state, now:) || changed
                   end
-        schedule_payload(schedule, state)
+        schedule_payload(schedule, state, agent: last_agent(schedule, state, agents))
       end
       store.save(states) if changed
       rows
@@ -77,15 +78,10 @@ module HQ
     end
 
     def resume_and_run_now(key, now: Time.now, dry_run: false)
-      schedule = find_schedule!(key)
-      states = store.load
-      state = store.state_for(states, schedule.key)
+      schedule, states, state = schedule_state_for(key)
       ensure_not_expired!(schedule, state, states, now:)
       resume_state!(schedule, state, now:)
-      agents = load_agents
-      result = dispatch_schedule(schedule, state, agents, now:, dry_run:)
-      persist(agents, states, dry_run:)
-      result
+      run_schedule(schedule, states, state, now:, dry_run:)
     end
 
     def refresh_session(key, now: Time.now)
@@ -93,8 +89,7 @@ module HQ
       state = store.state_for(store.load, schedule.key)
       target = last_agent(schedule, state, load_agents)
       if target
-        raise RefreshError, "Stop the scheduled session before refreshing it" if target.running?
-
+        @agent_store.stop_agent!(target.key) if target.running?
         @agent_store.archive_agent!(target.key)
         reconcile_archived_agent!(target.key, archived_agent: target, now:)
       end
@@ -103,13 +98,15 @@ module HQ
     end
 
     def run_now(key, now: Time.now, dry_run: false)
-      schedule = find_schedule!(key)
-      states = store.load
-      state = store.state_for(states, schedule.key)
+      schedule, states, state = schedule_state_for(key)
       if expire_schedule!(schedule, state, now:)
         store.save(states)
         return { status: :skipped, schedule: schedule_payload(schedule, state) }
       end
+      run_schedule(schedule, states, state, now:, dry_run:)
+    end
+
+    def run_schedule(schedule, states, state, now:, dry_run:)
       agents = load_agents
       result = dispatch_schedule(schedule, state, agents, now:, dry_run:)
       persist(agents, states, dry_run:)
@@ -244,7 +241,7 @@ module HQ
       store.save(states)
     end
 
-    def schedule_payload(schedule, state)
+    def schedule_payload(schedule, state, agent: nil)
       {
         key: schedule.key,
         name: schedule.name,
@@ -268,6 +265,7 @@ module HQ
         last_error: state.last_error,
         last_target_key: state.last_target_key,
         run_count: state.run_count.to_i,
+        session_run_count: agent ? agent.run_count.to_i : state.run_count.to_i,
         skip_count: state.skip_count.to_i
       }
     end
@@ -277,6 +275,12 @@ module HQ
       raise ScheduleRegistry::Error, "Unknown schedule: #{key}" unless schedule
 
       schedule
+    end
+
+    def schedule_state_for(key)
+      schedule = find_schedule!(key)
+      states = store.load
+      [schedule, states, store.state_for(states, schedule.key)]
     end
 
     def project_for(schedule)
@@ -352,10 +356,14 @@ module HQ
 
       {
         status: :started,
-        schedule: schedule_payload(schedule, state),
+        schedule: schedule_payload(schedule, state, agent: agent),
         agent: agent
       }
     rescue StandardError => e
+      if agent
+        state.last_target_kind = "agent"
+        state.last_target_key = agent.key
+      end
       state.last_status = "failed"
       state.last_error = e.message
       state.mark_stopped!(now:)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -451,8 +451,10 @@ module HQ
         return ok(service.update_schedule_message_file(key, body)) if method == "PUT" && tail == ["message_file"]
         return ok(service.delete_schedule(key)) if method == "DELETE" && tail.empty?
         return ok(service.run_schedule(key)) if method == "POST" && tail == ["run"]
+        return ok(service.refresh_schedule_session(key)) if method == "POST" && tail == ["refresh-session"]
         return ok(schedule: service.pause_schedule(key)) if method == "POST" && tail == ["pause"]
         return ok(service.resume_schedule(key)) if method == "POST" && tail == ["resume"]
+        return ok(service.resume_and_run_schedule(key)) if method == "POST" && tail == ["resume-and-run"]
       end
 
       if parts.length >= 2 && parts.first == "projects"
@@ -2133,7 +2135,12 @@ module HQ
     end
 
     def run_schedule(key)
-      result = scheduler.run_now(key)
+      schedule_result(scheduler.run_now(key))
+    rescue ScheduleRegistry::Error => e
+      raise Error.new(e.message, status: 404)
+    end
+
+    def schedule_result(result)
       if result.fetch(:status) == :failed
         raise Error.new(result.fetch(:error), status: 409)
       end
@@ -2145,6 +2152,12 @@ module HQ
         schedule: result.fetch(:schedule),
         agent: result[:agent] ? agent_payload(result[:agent]) : nil
       }.compact
+    end
+
+    def refresh_schedule_session(key)
+      schedule_result(scheduler.refresh_session(key))
+    rescue Scheduler::RefreshError => e
+      raise Error.new(e.message, status: 409)
     rescue ScheduleRegistry::Error => e
       raise Error.new(e.message, status: 404)
     end
@@ -2165,6 +2178,12 @@ module HQ
         schedule: result.fetch(:schedule),
         agent: result[:agent] ? agent_payload(result[:agent]) : nil
       }.compact
+    rescue ScheduleRegistry::Error => e
+      raise Error.new(e.message, status: 404)
+    end
+
+    def resume_and_run_schedule(key)
+      schedule_result(scheduler.resume_and_run_now(key))
     rescue ScheduleRegistry::Error => e
       raise Error.new(e.message, status: 404)
     end

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3930,6 +3930,7 @@ function renderScheduleRow(schedule) {
         <div class="schedule-row-title">
           <strong>${escapeHtml(schedule.name || schedule.key)}</strong>
           ${statusBadge(titleFromKey(scheduleStatusLabel(schedule)), className)}
+          ${scheduleRunCountBadge(schedule)}
         </div>
         <span>${escapeHtml(scheduleSubtext(schedule))}</span>
       </div>
@@ -3944,12 +3945,24 @@ function renderScheduleRow(schedule) {
   `;
 }
 
+function scheduleRunCountBadge(schedule) {
+  const count = Number(schedule.run_count || 0);
+  const className = count >= 50 ? "fail" : (count >= 30 ? "need" : "info");
+  return `<span class="pill ${className}" title="Runs in current session">${count} ${count === 1 ? "run" : "runs"}</span>`;
+}
+
 function renderScheduleActionsMenu(schedule) {
   const items = [
     moreMenuButton({
       label: "Run now",
       icon: "sportShoe",
       attrs: `data-schedule-action="run" data-schedule-key="${escapeAttr(schedule.key)}"`,
+    }),
+    moreMenuButton({
+      label: "Refresh session",
+      sublabel: "Archive this session and run a fresh one",
+      icon: "refreshCw",
+      attrs: `data-schedule-action="refresh-session" data-schedule-key="${escapeAttr(schedule.key)}"`,
     }),
     moreMenuButton({
       label: "Edit schedule",
@@ -11166,10 +11179,10 @@ function renderAgentScheduleMenu(agent, schedule) {
   const nextRun = schedule.next_due_at ? `Next ${timeShort(schedule.next_due_at)}` : scheduleStatusLabel(schedule);
   const items = [
     moreMenuButton({
-      label: "Run now",
+      label: scheduleStatusLabel(schedule) === "stopped" ? "Resume and run now" : "Run now",
       sublabel: scheduleName,
       icon: "sportShoe",
-      attrs: `data-schedule-action="run" data-schedule-key="${escapeAttr(schedule.key)}"`,
+      attrs: `data-schedule-action="${scheduleStatusLabel(schedule) === "stopped" ? "resume-and-run" : "run"}" data-schedule-key="${escapeAttr(schedule.key)}"`,
     }),
     moreMenuButton({
       label: toggleLabel,
@@ -15489,7 +15502,10 @@ function runScheduleAction(scheduleAction) {
 
   mutate(async () => {
     await apiPost(`/schedules/${encodeURIComponent(key)}/${action}`);
-    setConnection(`Schedule ${action} requested`);
+    const message = action === "refresh-session"
+      ? "Schedule session refreshed"
+      : (action === "resume-and-run" ? "Schedule resumed and run started" : `Schedule ${action} requested`);
+    setConnection(message);
   });
 }
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3946,7 +3946,7 @@ function renderScheduleRow(schedule) {
 }
 
 function scheduleRunCountBadge(schedule) {
-  const count = Number(schedule.run_count || 0);
+  const count = Number(schedule.session_run_count ?? schedule.run_count ?? 0);
   const className = count >= 50 ? "fail" : (count >= 30 ? "need" : "info");
   return `<span class="pill ${className}" title="Runs in current session">${count} ${count === 1 ? "run" : "runs"}</span>`;
 }

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2690,6 +2690,24 @@ module RemoteServerTest
       resumed = server.send(:route, service, "POST", "/schedules/weekday/resume", {}, nil)
       assert(!resumed.dig(:body, :schedule, :paused), "expected schedule resume route")
 
+      refreshed = with_stubbed_agent_start do
+        server.send(:route, service, "POST", "/schedules/weekday/refresh-session", {}, nil)
+      end
+      assert(refreshed.dig(:body, :agent, :key), "expected refresh-session route to start a fresh scheduled session")
+      assert(refreshed.dig(:body, :schedule, :run_count) == 1,
+             "expected refresh-session route to reset the new session run count")
+
+      refreshed_state = HQ::ScheduleStore.new.load.fetch("weekday")
+      refreshed_state.mark_stopped!
+      HQ::ScheduleStore.new.save("weekday" => refreshed_state)
+      resumed_run = with_stubbed_agent_start do
+        server.send(:route, service, "POST", "/schedules/weekday/resume-and-run", {}, nil)
+      end
+      assert(resumed_run.dig(:body, :agent, :key) == refreshed.dig(:body, :agent, :key),
+             "expected resume-and-run route to keep the current scheduled session")
+      assert(resumed_run.dig(:body, :schedule, :run_count) == 2,
+             "expected resume-and-run route to create a new run")
+
       reloaded = server.send(:route, service, "POST", "/schedules/reload", {}, nil)
       assert(reloaded.dig(:body, :ok), "expected schedule reload route")
 
@@ -5414,6 +5432,13 @@ module RemoteServerTest
            "expected Remote UI scheduler controls to call daemon endpoints")
     assert(js[:body].include?("data-schedule-action"),
            "expected Remote UI to expose schedule run/pause/resume controls")
+    assert(js[:body].include?("function scheduleRunCountBadge") &&
+           js[:body].include?("count >= 50 ? \"fail\" : (count >= 30 ? \"need\" : \"info\")") &&
+           js[:body].include?("Runs in current session"),
+           "expected schedule rows to show current-session run counts with threshold colors")
+    assert(js[:body].include?('label: "Refresh session"') &&
+           js[:body].include?('data-schedule-action="refresh-session"'),
+           "expected schedule actions to refresh the current session")
     assert(js[:body].include?('label: "Run now"') &&
            js[:body].include?('attrs: `data-schedule-action="run" data-schedule-key="${escapeAttr(schedule.key)}"`') &&
            !js[:body].include?("schedule-run-button"),
@@ -5426,6 +5451,9 @@ module RemoteServerTest
            js[:body].include?('label: "Run now"') &&
            js[:body].include?('const toggleAction = blocked ? "resume" : "pause"'),
            "expected scheduled agent headers to expose run and pause/resume controls")
+    assert(js[:body].include?('label: scheduleStatusLabel(schedule) === "stopped" ? "Resume and run now" : "Run now"') &&
+           js[:body].include?('data-schedule-action="${scheduleStatusLabel(schedule) === "stopped" ? "resume-and-run" : "run"}"'),
+           "expected stopped schedule menus to resume and create a run in one action")
     assert(js[:body].include?('label: "Remove schedule"') &&
            js[:body].include?("data-remove-agent-schedule") &&
            js[:body].include?("Schedule removed; conversation kept") &&

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5433,6 +5433,7 @@ module RemoteServerTest
     assert(js[:body].include?("data-schedule-action"),
            "expected Remote UI to expose schedule run/pause/resume controls")
     assert(js[:body].include?("function scheduleRunCountBadge") &&
+           js[:body].include?("schedule.session_run_count ?? schedule.run_count ?? 0") &&
            js[:body].include?("count >= 50 ? \"fail\" : (count >= 30 ? \"need\" : \"info\")") &&
            js[:body].include?("Runs in current session"),
            "expected schedule rows to show current-session run counts with threshold colors")

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -24,6 +24,9 @@ module SchedulerTest
       assert_archived_schedule_session_promotes_prompt_to_schedule
       assert_scheduler_stops_interactive_scheduled_agent_until_resume
       assert_schedule_session_refresh_starts_fresh_agent
+      assert_schedule_list_uses_current_agent_run_count
+      assert_refresh_stops_running_session
+      assert_refresh_failure_keeps_replacement_recoverable
       assert_schedule_waits_for_human_input
     end
     assert_schedule_daemon_supervisor_spawns_external_daemon
@@ -377,6 +380,111 @@ module SchedulerTest
       assert(resumed.fetch(:agent).key == replacement.key, "expected resume and run to preserve the current session")
       assert(HQ::ScheduleStore.new.load.fetch("weekday").run_count == 2,
              "expected resume and run to create one additional run")
+    end
+  end
+
+  def assert_schedule_list_uses_current_agent_run_count
+    with_temp_runtime do |dir|
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              message: "Run maintenance."
+      YAML
+      scheduler = build_scheduler(registry, schedule_path)
+      first = scheduler.run_now("weekday")
+      agent_store = HQ::AgentStore.new(registry.projects.map { |config| HQ::Project.new(config) })
+      agent_store.start_agent!(first.fetch(:agent).key)
+
+      row = scheduler.list.find { |schedule| schedule[:key] == "weekday" }
+      assert(row[:run_count] == 1, "expected schedule bookkeeping to retain scheduled-only runs")
+      assert(row[:session_run_count] == 2, "expected the list to include a manual follow-up run in the current session")
+
+      adopted = HQ::ManagedAgent.new(
+        key: "adopted-session", name: "Adopted session", project_key: "web", template_key: "custom",
+        workspace: File.join(dir, "workspace"), prompt: "Continue the existing work.", agent: "codex"
+      )
+      adopted.start!
+      adopted.start!
+      adopted.associate_schedule!("weekday")
+      agent_store.save([adopted])
+      state = HQ::ScheduleStore.new.load.fetch("weekday")
+      state.last_target_key = adopted.key
+      HQ::ScheduleStore.new.save("weekday" => state)
+
+      row = scheduler.list.find { |schedule| schedule[:key] == "weekday" }
+      assert(row[:session_run_count] == 2, "expected the list to use an adopted session's actual run count")
+    end
+  end
+
+  def assert_refresh_stops_running_session
+    with_temp_runtime do |dir|
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              message: "Run maintenance."
+      YAML
+      scheduler = build_scheduler(registry, schedule_path)
+      original = scheduler.run_now("weekday").fetch(:agent)
+      pid = Process.spawn("sleep", "30", pgroup: true)
+      original.instance_variable_set(:@pid, pid)
+      original.instance_variable_set(:@finished_at, nil)
+      HQ::AgentStore.new(registry.projects.map { |config| HQ::Project.new(config) }).save([original])
+
+      refreshed = scheduler.refresh_session("weekday")
+      Process.wait(pid)
+      pid = nil
+      assert(refreshed.fetch(:agent).key != original.key, "expected refresh to replace a running session")
+      assert(HQ::AgentStore.new(registry.projects.map { |config| HQ::Project.new(config) }).load.none? { |agent| agent.key == original.key },
+             "expected refresh to stop and archive the running session")
+    ensure
+      begin
+        Process.kill("TERM", pid) if pid && HQ::ProcessLiveness.alive?(pid)
+        Process.wait(pid) if pid
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+  end
+
+  def assert_refresh_failure_keeps_replacement_recoverable
+    with_temp_runtime do |dir|
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              message: "Run maintenance."
+      YAML
+      scheduler = build_scheduler(registry, schedule_path)
+      original = scheduler.run_now("weekday").fetch(:agent)
+
+      with_stubbed_agent_start_error("replacement start failed") do
+        failed = scheduler.refresh_session("weekday")
+        state = HQ::ScheduleStore.new.load.fetch("weekday")
+        replacement = read_agents.fetch(0)
+        assert(failed[:status] == :failed, "expected refresh to report replacement startup failure")
+        assert(replacement.schedule_key == "weekday", "expected the replacement to remain a schedule session")
+        assert(state.last_target_key == replacement.key, "expected failed replacement to remain discoverable")
+        assert(state.stopped?, "expected failed replacement to leave the schedule stopped")
+        assert(state.previous_target_key == original.key, "expected refresh to preserve the archived session key")
+      end
+
+      recovered = scheduler.resume_and_run_now("weekday")
+      assert(recovered.fetch(:agent).key == HQ::ScheduleStore.new.load.fetch("weekday").last_target_key,
+             "expected the failed replacement to be recoverable through resume and run")
     end
   end
 
@@ -794,6 +902,14 @@ module SchedulerTest
       )
       self
     end
+    yield
+  ensure
+    HQ::ManagedAgent.define_method(:start!, original)
+  end
+
+  def with_stubbed_agent_start_error(message)
+    original = HQ::ManagedAgent.instance_method(:start!)
+    HQ::ManagedAgent.define_method(:start!) { raise message }
     yield
   ensure
     HQ::ManagedAgent.define_method(:start!, original)

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -438,10 +438,10 @@ module SchedulerTest
       pid = Process.spawn("sleep", "30", pgroup: true)
       original.instance_variable_set(:@pid, pid)
       original.instance_variable_set(:@finished_at, nil)
+      original.send(:monitor_agent_process, pid, original.send(:run_status_file_path, original.last_run.run_id))
       HQ::AgentStore.new(registry.projects.map { |config| HQ::Project.new(config) }).save([original])
 
       refreshed = scheduler.refresh_session("weekday")
-      Process.wait(pid)
       pid = nil
       assert(refreshed.fetch(:agent).key != original.key, "expected refresh to replace a running session")
       assert(HQ::AgentStore.new(registry.projects.map { |config| HQ::Project.new(config) }).load.none? { |agent| agent.key == original.key },

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -23,6 +23,7 @@ module SchedulerTest
       assert_scheduler_adopts_existing_session_and_expires_loop
       assert_archived_schedule_session_promotes_prompt_to_schedule
       assert_scheduler_stops_interactive_scheduled_agent_until_resume
+      assert_schedule_session_refresh_starts_fresh_agent
       assert_schedule_waits_for_human_input
     end
     assert_schedule_daemon_supervisor_spawns_external_daemon
@@ -338,6 +339,44 @@ module SchedulerTest
       assert(agents.map(&:key) == [first_agent.key], "expected resume to keep the persistent schedule agent")
       archived = Dir.glob(File.join(HQ::AGENT_ARCHIVE_DIR, "**", File.basename(first_agent.raw_log_path)))
       assert(archived.empty?, "expected resume not to archive the persistent schedule session")
+    end
+  end
+
+  def assert_schedule_session_refresh_starts_fresh_agent
+    with_temp_runtime do |dir|
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              message: "Run maintenance."
+      YAML
+      scheduler = build_scheduler(registry, schedule_path)
+      first = scheduler.run_now("weekday")
+      original = first.fetch(:agent)
+      scheduler.run_now("weekday")
+
+      refreshed = scheduler.refresh_session("weekday")
+      replacement = refreshed.fetch(:agent)
+      state = HQ::ScheduleStore.new.load.fetch("weekday")
+
+      assert(replacement.key != original.key, "expected refresh to create a fresh scheduled session")
+      assert(state.previous_target_key == original.key, "expected refresh to retain the archived session key")
+      assert(state.last_target_key == replacement.key, "expected refresh to target the fresh session")
+      assert(state.run_count == 1, "expected refresh to reset the current session run count")
+      assert(read_agents.map(&:key) == [replacement.key], "expected the previous scheduled session to be archived")
+      archived = Dir.glob(File.join(HQ::AGENT_ARCHIVE_DIR, "**", File.basename(original.raw_log_path)))
+      assert(!archived.empty?, "expected refresh to archive the previous session logs")
+
+      state.mark_stopped!
+      HQ::ScheduleStore.new.save("weekday" => state)
+      resumed = scheduler.resume_and_run_now("weekday")
+      assert(resumed.fetch(:agent).key == replacement.key, "expected resume and run to preserve the current session")
+      assert(HQ::ScheduleStore.new.load.fetch("weekday").run_count == 2,
+             "expected resume and run to create one additional run")
     end
   end
 

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -27,6 +27,7 @@ module SchedulerTest
       assert_schedule_list_uses_current_agent_run_count
       assert_refresh_stops_running_session
       assert_refresh_failure_keeps_replacement_recoverable
+      assert_expired_refresh_preserves_current_session
       assert_schedule_waits_for_human_input
     end
     assert_schedule_daemon_supervisor_spawns_external_daemon
@@ -485,6 +486,40 @@ module SchedulerTest
       recovered = scheduler.resume_and_run_now("weekday")
       assert(recovered.fetch(:agent).key == HQ::ScheduleStore.new.load.fetch("weekday").last_target_key,
              "expected the failed replacement to be recoverable through resume and run")
+    end
+  end
+
+  def assert_expired_refresh_preserves_current_session
+    with_temp_runtime do |dir|
+      now = Time.new(2026, 7, 16, 14, 0, 0, "+07:00")
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            ends_at: "#{(now - 60).iso8601}"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              message: "Run maintenance."
+      YAML
+      scheduler = build_scheduler(registry, schedule_path)
+      original = HQ::ManagedAgent.new(
+        key: "expired-session", name: "Expired session", project_key: "web", template_key: "custom",
+        workspace: File.join(dir, "workspace"), prompt: "Keep this session.", agent: "codex"
+      )
+      original.associate_schedule!("weekday")
+      HQ::AgentStore.new(registry.projects.map { |config| HQ::Project.new(config) }).save([original])
+      state = HQ::ScheduleStore.new.state_for({}, "weekday")
+      state.last_target_key = original.key
+      HQ::ScheduleStore.new.save("weekday" => state)
+
+      assert_raises(HQ::ScheduleRegistry::Error, "expected expired refresh to fail before lifecycle changes") do
+        scheduler.refresh_session("weekday", now:)
+      end
+      retained = read_agents.fetch(0)
+      assert(retained.key == original.key && retained.schedule_key == "weekday",
+             "expected expired refresh to leave the current scheduled session unchanged")
     end
   end
 


### PR DESCRIPTION
## Summary
- Derive Now schedule-session counts from the current target agent, including manual follow-up runs and adopted sessions.
- Refresh validates expiry before stopping or archiving; for active schedules it stops running sessions, waits up to two seconds, then archives and replaces them.
- Keep a failed replacement linked in schedule state so it remains visible and can be resumed or refreshed.
- Share the private dispatch-and-persist pipeline between Run now and Resume and run now.

## Validation
- bundle exec ruby test/scheduler_test.rb
- bundle exec ruby test/remote_server_test.rb

## Tracking and state
- Fizzy card: https://fizzy.startkit.tech/1/cards/168
- No configuration migration. Runtime schedule payloads include session_run_count; ScheduleState#run_count remains scheduler bookkeeping and is only the no-agent fallback.