### PR TITLE
Make FRED messages responsive and recoverable

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -26,9 +26,11 @@ end
 def write_fixture(dir)
   config_dir = File.join(dir, "config")
   home_dir = File.join(dir, "home")
+  tycho_home_dir = File.join(dir, "tycho-home")
   workspace = File.join(dir, "workspace")
   FileUtils.mkdir_p(config_dir)
   FileUtils.mkdir_p(home_dir)
+  FileUtils.mkdir_p(tycho_home_dir)
   FileUtils.mkdir_p(workspace)
 
   config_path = File.join(config_dir, "hq.yml")
@@ -118,6 +120,7 @@ def write_fixture(dir)
     fake_codex_path: fake_codex_path,
     fake_gh_path: fake_gh_path,
     home_dir: home_dir,
+    tycho_home_dir: tycho_home_dir,
     logs_dir: File.join(dir, "logs")
   }
 end
@@ -777,6 +780,537 @@ def write_smoke_script(path)
       }
 
       await assertPersonalAssistantConversationShell();
+
+      async function assertPersonalAssistantPhase1() {
+        const fredBackendUrl = process.env.TYCHO_REMOTE_UI_FRED_PHASE1_BACKEND_URL;
+        if (!fredBackendUrl) return;
+
+        const holdPath = process.env.TYCHO_REMOTE_UI_FRED_HOLD_PATH;
+        const inquiryPath = process.env.TYCHO_REMOTE_UI_FRED_INQUIRY_PATH;
+        const codexPath = process.env.TYCHO_REMOTE_UI_FRED_CODEX_PATH;
+        if (!holdPath || !inquiryPath || !codexPath) throw new Error("Phase 1 browser fixture needs hold, inquiry, and Codex paths");
+
+        const phaseRequests = [];
+        const phaseErrors = [];
+        const expectedRecoveryConsoleErrors = [];
+        let expectedQueueConflictPath = "";
+        let expectedInquiryConflictPath = "";
+        const expectedFairAcceptanceIds = new Set();
+        const phaseContext = await browser.newContext({ viewport: { width: 390, height: 844 }, isMobile: true });
+        const phasePage = await phaseContext.newPage();
+        await phasePage.emulateMedia({ reducedMotion: "reduce" });
+        phasePage.on("console", (message) => {
+          if (message.type() !== "error") return;
+          const index = expectedRecoveryConsoleErrors.indexOf(message.text());
+          if (index >= 0) expectedRecoveryConsoleErrors.splice(index, 1);
+          else phaseErrors.push(message.text());
+        });
+        phasePage.on("pageerror", (error) => phaseErrors.push(error.message));
+
+        const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+        const requestBody = (request) => {
+          const raw = request.postData();
+          if (!raw) return {};
+          try { return JSON.parse(raw); } catch (_error) { return {}; }
+        };
+        const fredPath = (pathname) => pathname === "/personal-assistant" ||
+          pathname.startsWith("/personal-assistant/") || /^\\/agents\\/[^/]+\\/conversation$/.test(pathname);
+        const shellPath = (pathname) => pathname === "/setup" || pathname.startsWith("/setup/") ||
+          pathname === "/schedules" || pathname.startsWith("/schedules/") || pathname.startsWith("/servers/resources");
+        const upstreamResponse = async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const headers = { ...request.headers() };
+          ["host", "content-length", "origin", "referer"].forEach((name) => delete headers[name]);
+          const options = {
+            url: new URL(`${url.pathname}${url.search}`, fredBackendUrl).toString(),
+            method: request.method(),
+            headers,
+          };
+          const postData = request.postData();
+          if (postData !== null) options.postData = postData;
+          return route.fetch(options);
+        };
+        await phasePage.route("**/*", async (route) => {
+          const request = route.request();
+          let url;
+          try { url = new URL(request.url()); } catch (_error) { return route.continue(); }
+          if (!shellPath(url.pathname) && !fredPath(url.pathname)) return route.continue();
+          if (shellPath(url.pathname)) {
+            await sleep(1_800);
+            return route.continue();
+          }
+
+          const body = requestBody(request);
+          const phaseRequest = { method: request.method(), path: url.pathname, body };
+          phaseRequests.push(phaseRequest);
+          const delayedPrompt = "phase1 delayed first message";
+          const lostPrompt = "phase1 lost response";
+          if (request.method() === "POST" && url.pathname === "/personal-assistant/messages" && body.prompt === delayedPrompt) {
+            await sleep(1_200);
+          }
+          if (request.method() === "POST" && url.pathname === "/personal-assistant/messages" && body.prompt === lostPrompt) {
+            const response = await upstreamResponse(route);
+            await response.body();
+            expectedRecoveryConsoleErrors.push("Failed to load resource: net::ERR_FAILED");
+            return route.abort("failed");
+          }
+          if (request.method() === "POST" && url.pathname.startsWith("/personal-assistant/inquiries/") && url.pathname.endsWith("/dismiss") &&
+              phaseRequests.filter((candidate) => candidate.method === "POST" && candidate.path === url.pathname).length > 1) {
+            await sleep(350);
+          }
+          const response = await upstreamResponse(route);
+          const status = response.status();
+          const fairAcceptanceId = url.pathname.startsWith("/personal-assistant/messages/acceptance/")
+            ? decodeURIComponent(url.pathname.split("/").at(-1) || "") : "";
+          if (status === 404 && request.method() === "GET" && expectedFairAcceptanceIds.has(fairAcceptanceId)) {
+            expectedRecoveryConsoleErrors.push("Failed to load resource: the server responded with a status of 404 (Not Found)");
+          }
+          if (request.method() === "PATCH" && url.pathname === expectedQueueConflictPath && [404, 409].includes(status)) {
+            expectedRecoveryConsoleErrors.push(`Failed to load resource: the server responded with a status of ${status} (${status === 404 ? "Not Found" : "Conflict"})`);
+          }
+          if (request.method() === "POST" && url.pathname === expectedInquiryConflictPath && phaseRequests.filter((candidate) => (
+            candidate.method === "POST" && candidate.path === url.pathname
+          )).length > 1 && status === 409) {
+            expectedRecoveryConsoleErrors.push("Failed to load resource: the server responded with a status of 409 (Conflict)");
+          }
+          if ((request.method() === "DELETE" && url.pathname.startsWith("/personal-assistant/prompt-queue/")) ||
+              (request.method() === "POST" && url.pathname === "/personal-assistant/messages")) {
+            const responseBody = await response.body();
+            try { phaseRequest.response = JSON.parse(responseBody.toString()); } catch (_error) { phaseRequest.response = {}; }
+            return route.fulfill({ response, body: responseBody });
+          }
+          return route.fulfill({ response });
+        });
+
+        const submit = async (prompt) => {
+          const input = phasePage.locator("#composer #prompt-input");
+          await input.fill(prompt);
+          await phasePage.locator("#composer button[type='submit']:visible").last().click();
+        };
+        const userMessageIds = async (prompt) => phasePage.locator("article.message.user").evaluateAll((articles, expected) => (
+          articles.filter((article) => article.textContent.includes(expected)).map((article) => article.dataset.clientRequestId).filter(Boolean)
+        ), prompt);
+        const waitForNode = async (predicate, timeout = 10_000, label = "") => {
+          const deadline = Date.now() + timeout;
+          while (!predicate()) {
+            if (Date.now() >= deadline) {
+              const snapshot = await phasePage.evaluate(() => ({
+                hash: location.hash,
+                forms: Array.from(document.querySelectorAll("[data-prompt-queue-edit-form]")).map((form) => ({
+                  entryId: form.dataset.entryId,
+                  hidden: form.classList.contains("hidden"),
+                  prompt: form.querySelector("textarea")?.value,
+                  submitDisabled: form.querySelector("button[type='submit']")?.disabled,
+                  pending: form.getAttribute("aria-busy"),
+                })),
+              }));
+              throw new Error(`${label || "Phase 1 browser state"} timed out: ${JSON.stringify(snapshot)}`);
+            }
+            await phasePage.waitForTimeout(100);
+          }
+        };
+        const assertNoNestedForms = async (label) => {
+          const nestedForms = await phasePage.evaluate(() => Array.from(document.querySelectorAll("form form")).map((form) => ({
+            id: form.id,
+            entryId: form.dataset.entryId || "",
+            owner: form.closest("form")?.id || "",
+          })));
+          if (nestedForms.length) throw new Error(`${label} produced nested forms: ${JSON.stringify(nestedForms)}`);
+        };
+        const waitForUserMessageCount = (prompt, count, timeout = 10_000) => phasePage.waitForFunction(({ expectedPrompt, expectedCount }) => (
+          Array.from(document.querySelectorAll("article.message.user"))
+            .filter((article) => article.textContent.includes(expectedPrompt)).length >= expectedCount
+        ), { expectedPrompt: prompt, expectedCount: count }, { timeout, polling: 100 });
+        const waitForMessageStatus = (prompt, status, timeout = 12_000) => phasePage.waitForFunction(({ expectedPrompt, expectedStatus }) => (
+          Array.from(document.querySelectorAll("article.message.user")).some((article) => {
+            if (!article.textContent.includes(expectedPrompt)) return false;
+            return article.nextElementSibling?.dataset.paMessageStatus === expectedStatus;
+          })
+        ), { expectedPrompt: prompt, expectedStatus: status }, { timeout, polling: 100 });
+        const mutationRequests = () => phaseRequests.filter((request) => ["POST", "PATCH", "PUT", "DELETE"].includes(request.method));
+        const requestsFor = (path, method = null) => phaseRequests.filter((request) => request.path === path && (!method || request.method === method));
+
+        try {
+          const shellStartedAt = Date.now();
+          await phasePage.goto(`${baseUrl}/ui#personal-assistant`, { waitUntil: "domcontentloaded" });
+          await phasePage.waitForSelector(".personal-assistant-page[data-personal-assistant-state='active']", { state: "visible", timeout: 10_000 });
+          const shellReadyMs = Date.now() - shellStartedAt;
+          if (shellReadyMs >= 1_600) throw new Error(`FRED status/conversation waited for the delayed shell: ${shellReadyMs}ms`);
+          await phasePage.waitForSelector("#composer #prompt-input", { state: "visible", timeout: 10_000 });
+          await assertNoNestedForms("initial FRED composer");
+
+          const delayedPrompt = "phase1 delayed first message";
+          const newerDraft = "phase1 newer draft stays intact";
+          fs.writeFileSync(holdPath, "hold");
+          const pendingStartedAt = Date.now();
+          await submit(delayedPrompt);
+          await phasePage.waitForSelector("[data-pa-message-status='sending']", { state: "visible", timeout: 2_000 });
+          const firstPendingPaintMs = Date.now() - pendingStartedAt;
+          if (firstPendingPaintMs >= 1_000) throw new Error(`First FRED message did not paint promptly: ${firstPendingPaintMs}ms`);
+          await phasePage.locator("#composer #prompt-input").fill(newerDraft);
+          fs.rmSync(holdPath, { force: true });
+          await phasePage.waitForSelector("[data-pa-message-status='running']", { state: "visible", timeout: 10_000 });
+          const runningSeenAt = Date.now();
+          const activePollDelay = await phasePage.evaluate(() => personalAssistantPollDelay());
+          if (activePollDelay !== 4_000) throw new Error(`Active FRED polling lost its measured 4s cadence: ${activePollDelay}`);
+          await waitForMessageStatus(delayedPrompt, "accepted");
+          const terminalFreshnessMs = Date.now() - runningSeenAt;
+          if ((await phasePage.locator("#composer #prompt-input").inputValue()) !== newerDraft) {
+            throw new Error("A newer FRED draft was overwritten by the completed response");
+          }
+
+          const duplicatePrompt = "phase1 duplicate intended text";
+          await submit(duplicatePrompt);
+          await waitForUserMessageCount(duplicatePrompt, 1);
+          await submit(duplicatePrompt);
+          await waitForUserMessageCount(duplicatePrompt, 2);
+          await waitForMessageStatus(duplicatePrompt, "accepted");
+          const duplicateIds = await userMessageIds(duplicatePrompt);
+          if (new Set(duplicateIds).size !== 2) throw new Error(`Duplicate intended text did not retain two request identities: ${JSON.stringify(duplicateIds)}`);
+
+          const fairUnknownIds = await phasePage.evaluate(() => {
+            const context = personalAssistantSessionContext();
+            const agentKey = state.personalAssistant?.active_key || "";
+            return Array.from({ length: 6 }, (_value, index) => {
+              const clientRequestId = `client-phase1-fair-${Date.now().toString(36)}-${index}`;
+              updatePersonalAssistantSubmission(clientRequestId, "unknown", {
+                prompt: `phase1 unresolved ${index}`,
+                agent_key: agentKey,
+                active_key: context.active_key,
+                generation: context.generation,
+                server_key: context.server_key,
+                acceptance_state: "unknown",
+                message_recorded: false,
+              });
+              return clientRequestId;
+            });
+          });
+          fairUnknownIds.forEach((clientRequestId) => expectedFairAcceptanceIds.add(clientRequestId));
+          await phasePage.evaluate(() => reconcilePersonalAssistantSubmissions());
+          await phasePage.evaluate(() => reconcilePersonalAssistantSubmissions());
+          const fairAcceptanceRequests = phaseRequests.filter((request) => request.method === "GET" &&
+            request.path.startsWith("/personal-assistant/messages/acceptance/") &&
+            fairUnknownIds.includes(decodeURIComponent(request.path.split("/").at(-1) || "")));
+          const fairAcceptanceIds = new Set(fairAcceptanceRequests.map((request) => decodeURIComponent(request.path.split("/").at(-1) || "")));
+          if (fairAcceptanceIds.size !== fairUnknownIds.length) {
+            throw new Error(`FRED acceptance reconciliation starved older unresolved records: ${JSON.stringify({ fairUnknownIds, fairAcceptanceRequests })}`);
+          }
+          const retainedFairUnknownIds = await phasePage.evaluate((ids) => ids.filter((id) => (
+            state.personalAssistantSubmissionStates[personalAssistantSubmissionStorageId({
+              server_key: personalAssistantServerKey(),
+              active_key: personalAssistantSessionContext()?.active_key,
+              generation: personalAssistantSessionContext()?.generation,
+              client_request_id: id,
+            })]?.state === "unknown"
+          )), fairUnknownIds);
+          if (retainedFairUnknownIds.length !== fairUnknownIds.length) {
+            throw new Error(`FRED unresolved acceptance records were evicted: ${JSON.stringify({ fairUnknownIds, retainedFairUnknownIds })}`);
+          }
+
+          const queueSeedPrompt = "phase1 queue seed holds the run";
+          const queueKeepPrompt = "phase1 queue retained for failure";
+          const queueDeletePrompt = "phase1 queue deleted explicitly";
+          fs.writeFileSync(holdPath, "hold");
+          await submit(queueSeedPrompt);
+          await phasePage.waitForSelector("[data-pa-message-status='running']", { state: "visible", timeout: 10_000 });
+          await submit(queueKeepPrompt);
+          await submit(queueDeletePrompt);
+          await phasePage.waitForSelector("[data-prompt-queue]", { state: "visible", timeout: 10_000 });
+          await assertNoNestedForms("FRED queue first paint");
+          await phasePage.locator("[data-prompt-queue]").evaluate((queue) => { queue.open = true; });
+          await phasePage.waitForFunction(() => document.querySelectorAll("[data-prompt-queue-entry]").length >= 2, null, { timeout: 10_000, polling: 100 });
+          const fullScreenToggle = phasePage.locator("#composer [data-toggle-composer-full-screen]");
+          if (await fullScreenToggle.count()) {
+            await fullScreenToggle.click();
+            try {
+              await phasePage.waitForSelector("#composer.composer-full-screen", { state: "visible", timeout: 5_000 });
+            } catch (error) {
+              const fullScreenDebug = await phasePage.evaluate(() => ({
+                composer: document.querySelector("#composer")?.outerHTML.slice(0, 500) || "",
+                fullScreenKeys: Array.from(state.fullScreenComposerKeys || []),
+                hash: location.hash,
+              }));
+              throw new Error(`FRED full-screen editor did not render: ${JSON.stringify({ fullScreenDebug, error: error.message })}`);
+            }
+            const fullScreenInput = phasePage.locator("#composer #prompt-input");
+            const fullScreenDraft = "phase1 full-screen draft survives refresh";
+            await fullScreenInput.fill(fullScreenDraft);
+            await fullScreenInput.focus();
+            await phasePage.evaluate(() => refresh({ force: true, forceConversation: true }));
+            await phasePage.waitForFunction((expected) => document.querySelector("#composer #prompt-input")?.value === expected, fullScreenDraft, { timeout: 10_000, polling: 100 });
+            await assertNoNestedForms("full-screen FRED refresh");
+            const fullScreenQueueState = await phasePage.evaluate(() => ({
+              activeElement: document.activeElement?.id || "",
+              queueInsideComposer: Boolean(document.querySelector("#composer [data-prompt-queue]")),
+              queueInDock: Boolean(document.querySelector("[data-agent-dock] > [data-prompt-queue]")),
+            }));
+            if (fullScreenQueueState.queueInsideComposer || !fullScreenQueueState.queueInDock || fullScreenQueueState.activeElement !== "prompt-input") {
+              throw new Error(`Full-screen FRED refresh moved the queue or lost editor focus: ${JSON.stringify(fullScreenQueueState)}`);
+            }
+            await phasePage.locator("#composer [data-toggle-composer-full-screen]").click();
+            await phasePage.waitForSelector("#composer:not(.composer-full-screen)", { state: "visible", timeout: 5_000 });
+            await assertNoNestedForms("dock FRED after full-screen close");
+          }
+          const queueEntries = phasePage.locator("[data-prompt-queue-entry]");
+          const keepEntry = queueEntries.filter({ hasText: queueKeepPrompt }).first();
+          const deleteEntry = queueEntries.filter({ hasText: queueDeletePrompt }).first();
+          if (await keepEntry.count() !== 1 || await deleteEntry.count() !== 1) throw new Error("FRED queue fixture did not expose both queued controls");
+          const deleteEntryId = await deleteEntry.getAttribute("data-prompt-queue-entry");
+          await keepEntry.locator("[data-edit-queued-prompt]").click();
+          const entryId = await keepEntry.getAttribute("data-prompt-queue-entry");
+          const saveOwnership = await keepEntry.locator("[data-prompt-queue-edit-form] button[type='submit']").evaluate((button) => ({
+            formId: button.form?.id || "",
+            formEntryId: button.form?.dataset.entryId || "",
+          }));
+          if (saveOwnership.formId === "composer" || saveOwnership.formEntryId !== entryId) {
+            throw new Error(`FRED queue Save has the wrong browser form owner: ${JSON.stringify({ entryId, saveOwnership })}`);
+          }
+          const editState = await keepEntry.evaluate((entry) => ({
+            buttonDisabled: entry.querySelector("[data-edit-queued-prompt]")?.disabled,
+            formHidden: entry.querySelector("[data-prompt-queue-edit-form]")?.classList.contains("hidden"),
+          }));
+          if (editState.buttonDisabled || editState.formHidden) throw new Error(`FRED queue edit control did not open: ${JSON.stringify(editState)}`);
+          const editedQueuePrompt = "phase1 queue retained after edit";
+          await keepEntry.locator("[data-prompt-queue-edit-form] textarea").fill(editedQueuePrompt);
+          const editedValue = await keepEntry.locator("[data-prompt-queue-edit-form] textarea").inputValue();
+          if (editedValue !== editedQueuePrompt) throw new Error(`FRED queue edit did not retain typed value: ${editedValue}`);
+          await keepEntry.locator("[data-prompt-queue-edit-form] button[type='submit']").click();
+          await waitForNode(() => phaseRequests.some((request) => request.method === "PATCH" && request.path.startsWith("/personal-assistant/prompt-queue/")), 10_000, "FRED queue edit request");
+          await phasePage.waitForFunction((prompt) => Array.from(document.querySelectorAll("[data-prompt-queue-entry] strong")).some((strong) => strong.textContent.includes(prompt)), editedQueuePrompt, { timeout: 10_000, polling: 100 });
+
+          const queueConflictPrompt = "phase1 queue conflict stays editable locally";
+          await submit(queueConflictPrompt);
+          const conflictEntry = queueEntries.filter({ hasText: queueConflictPrompt }).first();
+          await conflictEntry.waitFor({ state: "visible", timeout: 10_000 });
+          const conflictEntryId = await conflictEntry.getAttribute("data-prompt-queue-entry");
+          expectedQueueConflictPath = `/personal-assistant/prompt-queue/${encodeURIComponent(conflictEntryId)}`;
+          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" &&
+            request.path === "/personal-assistant/messages" &&
+            request.response?.acceptance?.client_request_id === conflictEntryId &&
+            request.response?.acceptance?.queue_entry_id === conflictEntryId), 10_000, "FRED queue conflict acceptance");
+          const conflictDelete = await phasePage.evaluate(async (entryId) => {
+            const context = state.personalAssistant;
+            const response = await fetch(`/personal-assistant/prompt-queue/${encodeURIComponent(entryId)}`, {
+              method: "DELETE",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ active_key: context.active_key, generation: context.generation }),
+            });
+            return { status: response.status, body: await response.json() };
+          }, conflictEntryId);
+          if (conflictDelete.status !== 200 || conflictDelete.body.acceptance?.state !== "canceled") {
+            const conflictState = await phasePage.evaluate(() => {
+              const item = state.personalAssistant;
+              const agent = item?.active_key ? (state.agentDetails[item.active_key] || item.agent) : null;
+              return {
+                entries: (agent?.prompt_queue?.entries || []).map((entry) => ({ id: entry.id, clientRequestId: entry.client_request_id, prompt: entry.prompt, state: entry.state })),
+                agentRunning: agent?.running,
+              };
+            });
+            const conflictPost = phaseRequests.find((request) => request.method === "POST" &&
+              request.path === "/personal-assistant/messages" && request.response?.acceptance?.client_request_id === conflictEntryId);
+            throw new Error(`FRED queue conflict fixture did not delete through the reviewed route: ${JSON.stringify({ conflictDelete, conflictPost, conflictEntryId, conflictState })}`);
+          }
+          await conflictEntry.locator("[data-edit-queued-prompt]").click();
+          const conflictEditPrompt = "phase1 stale queue edit remains in the form";
+          await conflictEntry.locator("[data-prompt-queue-edit-form] textarea").fill(conflictEditPrompt);
+          await conflictEntry.locator("[data-prompt-queue-edit-form] button[type='submit']").click();
+          const conflictError = phasePage.locator(`[data-pa-control-error='queue-edit:${conflictEntryId}']`);
+          await conflictError.waitFor({ state: "visible", timeout: 10_000 });
+          const conflictErrorText = await conflictError.textContent();
+          if (!(conflictErrorText.includes("no longer editable") || conflictErrorText.includes("Unknown queued prompt"))) {
+            throw new Error(`FRED queue conflict error was not factual: ${await conflictError.textContent()}`);
+          }
+          if (await conflictEntry.locator("[data-prompt-queue-edit-form] textarea").inputValue() !== conflictEditPrompt) {
+            throw new Error("FRED queue conflict discarded the edited text");
+          }
+          await phasePage.evaluate(() => refresh({ force: true, forceConversation: true }));
+          await phasePage.waitForFunction((entryId) => !document.querySelector(`[data-prompt-queue-entry='${CSS.escape(entryId)}']`), conflictEntryId, { timeout: 10_000, polling: 100 });
+          await assertNoNestedForms("forced FRED queue refresh");
+
+          await deleteEntry.locator("[data-delete-queued-prompt]").click();
+          await waitForNode(() => phaseRequests.some((request) => request.method === "DELETE" &&
+            request.path.endsWith(`/${deleteEntryId}`) && request.response), 10_000, "FRED queue delete response");
+          const queuePatch = requestsFor("/personal-assistant/prompt-queue/", "PATCH");
+          const queueDelete = requestsFor("/personal-assistant/prompt-queue/", "DELETE");
+          if (!phaseRequests.some((request) => request.method === "PATCH" && request.path.startsWith("/personal-assistant/prompt-queue/")) ||
+              !phaseRequests.some((request) => request.method === "DELETE" && request.path.startsWith("/personal-assistant/prompt-queue/"))) {
+            throw new Error(`FRED queue edit/delete did not use dedicated routes: ${JSON.stringify({ queuePatch, queueDelete, phaseRequests })}`);
+          }
+          const queueMutationBodies = phaseRequests.filter((request) => request.path.startsWith("/personal-assistant/prompt-queue/") && ["PATCH", "DELETE"].includes(request.method));
+          if (!queueMutationBodies.every((request) => request.body.active_key && Number.isInteger(request.body.generation))) {
+            throw new Error(`FRED queue mutations lost captured session context: ${JSON.stringify(queueMutationBodies)}`);
+          }
+          const deletedQueueRequest = phaseRequests.find((request) => request.method === "DELETE" && request.path.endsWith(`/${deleteEntryId}`));
+          if (deletedQueueRequest?.response?.acceptance?.state !== "canceled" || deletedQueueRequest.response?.canceled !== true) {
+            throw new Error(`FRED queue deletion did not return a durable canceled receipt: ${JSON.stringify(deletedQueueRequest)}`);
+          }
+          await phasePage.waitForFunction((clientRequestId) => (
+            Object.values(state.personalAssistantSubmissionStates || {}).some((record) => (
+              record.client_request_id === clientRequestId && record.state === "canceled"
+            ))
+          ), deleteEntryId, { timeout: 5_000, polling: 100 });
+          const canceledLookup = await phasePage.evaluate(async (clientRequestId) => {
+            const response = await fetch(`/personal-assistant/messages/acceptance/${encodeURIComponent(clientRequestId)}`);
+            return response.json();
+          }, deleteEntryId);
+          if (canceledLookup.acceptance?.state !== "canceled") {
+            throw new Error(`FRED canceled acceptance did not survive read-only lookup: ${JSON.stringify(canceledLookup)}`);
+          }
+
+          fs.renameSync(codexPath, `${codexPath}.disabled`);
+          fs.rmSync(holdPath, { force: true });
+          await phasePage.waitForSelector(".prompt-queue-error", { state: "visible", timeout: 12_000 });
+          await waitForMessageStatus(editedQueuePrompt, "failed");
+          if (await phasePage.locator(`[data-pa-submission-recovery]`).filter({ hasText: editedQueuePrompt }).count() !== 1) {
+            throw new Error("Queued start failure did not remain visible as a FRED recovery record");
+          }
+          fs.renameSync(`${codexPath}.disabled`, codexPath);
+          await phasePage.locator("[data-retry-prompt-queue]").click();
+          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === "/personal-assistant/prompt-queue/retry"));
+          const retryRequest = phaseRequests.find((request) => request.method === "POST" && request.path === "/personal-assistant/prompt-queue/retry");
+          if (!retryRequest.body.active_key || !Number.isInteger(retryRequest.body.generation)) throw new Error(`Queue retry lost FRED session context: ${JSON.stringify(retryRequest)}`);
+          await phasePage.waitForFunction(() => {
+            const item = state.personalAssistant;
+            const agent = item?.active_key ? (state.agentDetails[item.active_key] || item.agent) : null;
+            return Boolean(agent) && !agent.running && !agent.prompt_queue?.dispatch_error && !(agent.prompt_queue?.entries || []).length;
+          }, null, { timeout: 12_000, polling: 100 });
+
+          const failedRunPrompt = "phase1 terminal failed run";
+          await submit(failedRunPrompt);
+          await waitForMessageStatus(failedRunPrompt, "failed", 15_000);
+          const failedRunRecovery = phasePage.locator("[data-pa-submission-recovery]").filter({ hasText: failedRunPrompt }).first();
+          await failedRunRecovery.waitFor({ state: "visible", timeout: 10_000 });
+          const failedRunCopy = await failedRunRecovery.textContent();
+          if (!failedRunCopy.includes("FRED run failed") || failedRunCopy.includes("Message failed to send") || failedRunCopy.includes("FRED did not accept this message")) {
+            throw new Error(`Terminal FRED run failure used delivery-failure copy: ${failedRunCopy}`);
+          }
+
+          const lostPrompt = "phase1 lost response";
+          const lostPostCountBefore = requestsFor("/personal-assistant/messages", "POST").length;
+          await submit(lostPrompt);
+          const lostRecovery = phasePage.locator("[data-pa-submission-recovery]").filter({ hasText: lostPrompt }).first();
+          await lostRecovery.waitFor({ state: "visible", timeout: 10_000 });
+          await phasePage.waitForSelector("[data-pa-message-status='unknown']", { state: "visible", timeout: 2_000 });
+          if (requestsFor("/personal-assistant/messages", "POST").length !== lostPostCountBefore + 1) {
+            throw new Error("Lost FRED response triggered an automatic retry");
+          }
+          await lostRecovery.locator("[data-check-pa-submission]").click();
+          await phasePage.waitForFunction((prompt) => {
+            const article = Array.from(document.querySelectorAll("article.message.user")).find((candidate) => candidate.textContent.includes(prompt));
+            const status = article?.nextElementSibling?.dataset.paMessageStatus;
+            return status === "accepted" || status === "running";
+          }, lostPrompt, { timeout: 12_000, polling: 100 });
+          if (requestsFor("/personal-assistant/messages", "POST").length !== lostPostCountBefore + 1) throw new Error("Acceptance lookup retried the lost FRED message");
+
+          const navigationPrompt = "phase1 response after navigation";
+          await submit(navigationPrompt);
+          await phasePage.evaluate(() => navigate({ type: "tab", tab: "agents" }));
+          await phasePage.waitForFunction(() => location.hash === "#agents", null, { timeout: 5_000, polling: 100 });
+          await phasePage.waitForTimeout(1_500);
+          if (await phasePage.evaluate(() => location.hash) !== "#agents" || await phasePage.locator(".personal-assistant-page").count() !== 0) {
+            throw new Error("A stale FRED response forced navigation back to the conversation");
+          }
+
+          await phasePage.setViewportSize({ width: 1440, height: 900 });
+          await phasePage.goto(`${baseUrl}/ui#personal-assistant`, { waitUntil: "domcontentloaded" });
+          await phasePage.waitForSelector(".personal-assistant-page", { state: "visible", timeout: 10_000 });
+          fs.writeFileSync(inquiryPath, "inquiry");
+          const inquiryPrompt = "phase1 inquiry controls";
+          await submit(inquiryPrompt);
+          try {
+            await phasePage.waitForSelector("#inquiry-form", { state: "visible", timeout: 12_000 });
+          } catch (error) {
+            const inquiryResponse = phaseRequests.filter((request) => request.method === "POST" && request.path === "/personal-assistant/messages").at(-1);
+            const viewState = await phasePage.evaluate(() => ({
+              route: location.hash,
+              personalAssistant: state.personalAssistant,
+              agent: state.personalAssistant?.active_key ? state.agentDetails[state.personalAssistant.active_key] : null,
+            }));
+            throw new Error(`FRED inquiry did not render: ${JSON.stringify({ inquiryResponse, viewState, error: error.message })}`);
+          }
+          const inquiryId = await phasePage.locator("#inquiry-form").getAttribute("data-inquiry-id");
+          expectedInquiryConflictPath = `/personal-assistant/inquiries/${encodeURIComponent(inquiryId)}/dismiss`;
+          const inquiryConflict = await phasePage.evaluate(async (id) => {
+            const context = state.personalAssistant;
+            const response = await fetch(`/personal-assistant/inquiries/${encodeURIComponent(id)}/dismiss`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ active_key: context.active_key, generation: context.generation }),
+            });
+            return { status: response.status, body: await response.json() };
+          }, inquiryId);
+          if (inquiryConflict.status !== 200) throw new Error(`FRED inquiry conflict fixture could not establish a stale action: ${JSON.stringify(inquiryConflict)}`);
+          await phasePage.locator("#inquiry-form .composer-action-menu > summary").click();
+          await phasePage.locator(`[data-inquiry-lifecycle-action='dismiss'][data-inquiry-id='${inquiryId}']`).click();
+          await phasePage.waitForFunction((id) => {
+            const button = document.querySelector(`[data-inquiry-lifecycle-action='dismiss'][data-inquiry-id='${CSS.escape(id)}']`);
+            const agentKey = button?.dataset.agentKey;
+            return Boolean(button) && button.disabled && state.pendingInquiryActions.get(agentKey) === "dismiss";
+          }, inquiryId, { timeout: 2_000, polling: 25 });
+          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/dismiss`));
+          const inquiryError = phasePage.locator(`[data-pa-control-error='inquiry-dismiss:${inquiryId}']`);
+          try {
+            await inquiryError.waitFor({ state: "visible", timeout: 10_000 });
+          } catch (error) {
+            const inquiryDebug = await phasePage.evaluate((id) => ({
+              agent: state.personalAssistant?.active_key ? state.agentDetails[state.personalAssistant.active_key] : null,
+              controlErrors: state.personalAssistantControlErrors,
+              context: personalAssistantSessionContext(),
+              controls: Array.from(document.querySelectorAll("[data-pa-control-error]")).map((element) => ({
+                text: element.textContent,
+                value: element.getAttribute("data-pa-control-error"),
+              })),
+              form: document.querySelector("#inquiry-form")?.outerHTML.slice(0, 1200) || "",
+              inquiryId: id,
+              pending: Array.from(state.pendingInquiryActions.entries()),
+            }), inquiryId);
+            throw new Error(`FRED inquiry control error did not render: ${JSON.stringify({ inquiryDebug, error: error.message })}`);
+          }
+          if (!(await inquiryError.textContent()).includes("Inquiry has changed")) {
+            throw new Error(`FRED inquiry conflict error was not factual: ${await inquiryError.textContent()}`);
+          }
+          await phasePage.evaluate(() => refresh({ force: true, forceConversation: true }));
+          await phasePage.waitForFunction(() => !document.querySelector("#inquiry-form") && document.querySelector("#composer"), null, { timeout: 10_000, polling: 100 });
+          await phasePage.locator("#composer .composer-action-menu > summary").click();
+          const restoreInquiry = phasePage.locator(`[data-inquiry-lifecycle-action='restore'][data-inquiry-id='${inquiryId}']`);
+          await restoreInquiry.waitFor({ state: "visible", timeout: 10_000 });
+          await phasePage.waitForFunction((id) => {
+            const button = document.querySelector(`[data-inquiry-lifecycle-action='restore'][data-inquiry-id='${CSS.escape(id)}']`);
+            return Boolean(button) && !button.disabled;
+          }, inquiryId, { timeout: 10_000, polling: 100 });
+          await restoreInquiry.click();
+          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/restore`));
+          await phasePage.waitForSelector("#inquiry-form", { state: "visible", timeout: 10_000 });
+          await phasePage.locator("#inquiry-form [data-inquiry-control]").first().fill("continue");
+          await phasePage.locator("#inquiry-form button[type='submit']").click();
+          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/answer`));
+          const answerRequest = phaseRequests.find((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/answer`);
+          if (!answerRequest?.body.active_key || !Number.isInteger(answerRequest.body.generation) || !answerRequest.body.client_request_id) {
+            throw new Error(`FRED inquiry answer lost stable identity/context: ${JSON.stringify(answerRequest)}`);
+          }
+
+          const invalidGeneric = mutationRequests().filter((request) => request.path.startsWith("/agents/") &&
+            (request.path.includes("/messages") || request.path.includes("/inquiries/") || request.path.includes("/prompt-queue/")));
+          if (invalidGeneric.length) throw new Error(`FRED controls used protected generic endpoints: ${JSON.stringify(invalidGeneric)}`);
+          if (phaseErrors.length) throw new Error(`Phase 1 browser console errors: ${phaseErrors.join(" | ")}`);
+          if (captureDir) {
+            await phasePage.goto(`${baseUrl}/ui#personal-assistant`, { waitUntil: "domcontentloaded" });
+            await phasePage.screenshot({ path: path.join(captureDir, "fred-phase1-desktop.png"), fullPage: false });
+            await phasePage.setViewportSize({ width: 390, height: 844 });
+            await phasePage.screenshot({ path: path.join(captureDir, "fred-phase1-mobile.png"), fullPage: false });
+          }
+          console.log(`remote-ui-smoke: FRED Phase 1 ok (first pending ${firstPendingPaintMs}ms, terminal freshness ${terminalFreshnessMs}ms, active poll ${activePollDelay}ms)`);
+        } finally {
+          fs.rmSync(holdPath, { force: true });
+          fs.rmSync(inquiryPath, { force: true });
+          if (fs.existsSync(`${codexPath}.disabled`) && !fs.existsSync(codexPath)) fs.renameSync(`${codexPath}.disabled`, codexPath);
+          await phasePage.unrouteAll({ behavior: "ignoreErrors" });
+          await phaseContext.close();
+        }
+      }
+
+      if (process.env.TYCHO_REMOTE_UI_FRED_PHASE1_BACKEND_URL) await assertPersonalAssistantPhase1();
 
       async function assertLoadingShellFailureRecovery() {
         const failurePage = await browser.newPage({ viewport: { width: 390, height: 844 } });
@@ -7059,6 +7593,7 @@ Dir.mktmpdir("tycho-remote-ui-smoke") do |dir|
   base_url = "http://127.0.0.1:#{port}"
   log_path = File.join(dir, "remote-server.log")
   env = {
+    "TYCHO_HOME" => fixture.fetch(:tycho_home_dir),
     "TYCHO_SKILLS_HOME" => fixture.fetch(:home_dir),
     "TYCHO_CONFIG_PATH" => fixture.fetch(:config_path),
     "TYCHO_SYSTEM_PROMPTS_PATH" => fixture.fetch(:prompts_path),
@@ -7149,6 +7684,11 @@ Dir.mktmpdir("tycho-remote-ui-smoke") do |dir|
       "TYCHO_REMOTE_UI_TAKEOVER_AGENT_KEY" => security_agent_key,
       "CHROME_PATH" => browser
     }
+    smoke_env["TYCHO_REMOTE_UI_FRED_PHASE1_BACKEND_URL"] = ENV["TYCHO_REMOTE_UI_FRED_PHASE1_BACKEND_URL"] if ENV["TYCHO_REMOTE_UI_FRED_PHASE1_BACKEND_URL"]
+    %w[HOLD_PATH DELAY_PATH INQUIRY_PATH CODEX_PATH].each do |suffix|
+      key = "TYCHO_REMOTE_UI_FRED_#{suffix}"
+      smoke_env[key] = ENV[key] if ENV[key]
+    end
     if ENV["TYCHO_REMOTE_UI_SMOKE_RENDERING_ONLY"].to_s == "1"
       smoke_env["TYCHO_REMOTE_UI_SMOKE_RENDERING_ONLY"] = "1"
     end

--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -1282,10 +1282,67 @@ def write_smoke_script(path)
           await restoreInquiry.click();
           await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/restore`));
           await phasePage.waitForSelector("#inquiry-form", { state: "visible", timeout: 10_000 });
+          const inquiryAgentKey = await phasePage.evaluate(() => state.personalAssistant?.active_key || "");
+          const preparationFailureAnswer = "phase1 answer retained after attachment preparation";
+          await phasePage.locator("#inquiry-form [data-inquiry-control]").first().fill(preparationFailureAnswer);
+          await phasePage.locator("#inquiry-feedback").fill("Retain this answer while attachment preparation fails.");
+          await phasePage.evaluate((key) => {
+            state.pendingPromptAttachments[key] = [{
+              id: "phase1-inquiry-attachment-prep-failure",
+              filename: "phase1-preparation-failure.txt",
+              mimeType: "text/plain",
+              type: "text",
+              size: 7,
+              file: new File(["fixture"], "phase1-preparation-failure.txt", { type: "text/plain" }),
+            }];
+            window.__originalInquiryAttachmentPayloads = pendingAttachmentPayloads;
+            pendingAttachmentPayloads = async () => {
+              throw new Error("Phase 1 attachment preparation failed");
+            };
+          }, inquiryAgentKey);
+          const answerPath = `/personal-assistant/inquiries/${inquiryId}/answer`;
+          const answerPostCountBeforePreparationFailure = requestsFor(answerPath, "POST").length;
+          await phasePage.locator("#inquiry-form button[type='submit']").click();
+          await phasePage.waitForFunction(({ key, prompt }) => {
+            const recovery = Array.from(document.querySelectorAll("[data-pa-submission-recovery]")).find((element) => element.textContent.includes(prompt));
+            const record = Object.values(state.personalAssistantSubmissionStates || {}).find((candidate) => candidate.prompt?.includes(prompt));
+            const answer = document.querySelector("#inquiry-form [data-inquiry-control]");
+            const attachment = pendingAttachmentsFor(key).find((candidate) => candidate.id === "phase1-inquiry-attachment-prep-failure");
+            return Boolean(recovery && record && record.state === "failed" && answer?.value === prompt && attachment);
+          }, { key: inquiryAgentKey, prompt: preparationFailureAnswer }, { timeout: 10_000, polling: 100 });
+          const preparationFailureState = await phasePage.evaluate(({ key, prompt }) => {
+            const recovery = Array.from(document.querySelectorAll("[data-pa-submission-recovery]")).find((element) => element.textContent.includes(prompt));
+            const record = Object.values(state.personalAssistantSubmissionStates || {}).find((candidate) => candidate.prompt?.includes(prompt));
+            return {
+              answer: document.querySelector("#inquiry-form [data-inquiry-control]")?.value || "",
+              feedback: document.querySelector("#inquiry-feedback")?.value || "",
+              attachmentRetained: pendingAttachmentsFor(key).some((candidate) => candidate.id === "phase1-inquiry-attachment-prep-failure"),
+              recovery: recovery?.textContent || "",
+              failureKind: recovery?.dataset.paSubmissionFailureKind || "",
+              state: record?.state || "",
+            };
+          }, { key: inquiryAgentKey, prompt: preparationFailureAnswer });
+          if (requestsFor(answerPath, "POST").length !== answerPostCountBeforePreparationFailure ||
+              preparationFailureState.state === "sending" ||
+              !preparationFailureState.recovery.includes("Message was not sent") ||
+              !preparationFailureState.recovery.includes("Phase 1 attachment preparation failed") ||
+              preparationFailureState.recovery.includes("Delivery status is unknown") ||
+              preparationFailureState.failureKind !== "pre_post" ||
+              preparationFailureState.answer !== preparationFailureAnswer ||
+              preparationFailureState.feedback !== "Retain this answer while attachment preparation fails." ||
+              !preparationFailureState.attachmentRetained) {
+            throw new Error(`FRED inquiry attachment preparation failure was not recoverable before POST: ${JSON.stringify({ answerPostCountBeforePreparationFailure, answerPostCountAfter: requestsFor(answerPath, "POST").length, preparationFailureState })}`);
+          }
+          await phasePage.evaluate((key) => {
+            pendingAttachmentPayloads = window.__originalInquiryAttachmentPayloads;
+            state.pendingPromptAttachments[key] = [];
+            state.renderedViewHtml = "";
+            render({ preserveLiveEditor: true });
+          }, inquiryAgentKey);
           await phasePage.locator("#inquiry-form [data-inquiry-control]").first().fill("continue");
           await phasePage.locator("#inquiry-form button[type='submit']").click();
-          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/answer`));
-          const answerRequest = phaseRequests.find((request) => request.method === "POST" && request.path === `/personal-assistant/inquiries/${inquiryId}/answer`);
+          await waitForNode(() => phaseRequests.some((request) => request.method === "POST" && request.path === answerPath));
+          const answerRequest = phaseRequests.find((request) => request.method === "POST" && request.path === answerPath);
           if (!answerRequest?.body.active_key || !Number.isInteger(answerRequest.body.generation) || !answerRequest.body.client_request_id) {
             throw new Error(`FRED inquiry answer lost stable identity/context: ${JSON.stringify(answerRequest)}`);
           }

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -5761,6 +5761,18 @@ select {
 .pa-lifecycle, .pa-danger-zone { color: var(--muted); font-size: 13px; }.pa-lifecycle summary, .pa-danger-zone summary { cursor: pointer; color: var(--text); font-weight: 700; }.pa-lifecycle p, .pa-danger-zone p { margin: 8px 0; line-height: 1.45; }
 .pa-setup, .pa-loading-state { max-width: 520px; margin: 12px auto; }.pa-setup h2 { margin: 6px 0; font-size: 20px; }.pa-setup p { margin: 0 0 12px; color: var(--muted); line-height: 1.45; }.pa-config-form { gap: 10px; }.pa-config-form .ui-field { gap: 3px; }.pa-config-form .ui-field__description { font-size: 12px; }.pa-confirmation { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 13px; }.pa-confirmation input { min-height: var(--touch-target); width: var(--touch-target); }
 .pa-inline-notice { max-width: 640px; margin: 14px auto 0; color: var(--muted); }
+.pa-message-send-status { max-width: 640px; margin: -7px auto 2px; font-size: 12px; font-weight: 700; }
+.pa-message-send-status.pending { color: var(--muted); }
+.pa-message-send-status.info { color: var(--accent); }
+.pa-message-send-status.danger { color: var(--danger); }
+.pa-message-send-status.warning { color: var(--warning); }
+.pa-submission-recovery { display: grid; gap: 8px; max-width: 640px; margin: 14px auto 0; }
+.pa-submission-recovery h3 { margin: 0; font-size: 14px; }
+.pa-submission-recovery article { display: grid; gap: 6px; border: 1px solid var(--border); border-left: 4px solid var(--warning); border-radius: 10px; padding: 11px 12px; background: var(--panel); }
+.pa-submission-recovery article.failed { border-left-color: var(--danger); }
+.pa-submission-recovery p, .pa-submission-recovery blockquote { margin: 0; color: var(--muted); font-size: 13px; line-height: 1.45; }
+.pa-submission-recovery blockquote { color: var(--text); white-space: pre-wrap; overflow-wrap: anywhere; }
+.pa-submission-recovery-actions { display: flex; flex-wrap: wrap; gap: 8px; }
 .pa-inline-action { display: grid; gap: 10px; max-width: 640px; margin: 12px 0 12px; border: 1px solid color-mix(in srgb, var(--accent) 72%, var(--border)); border-left: 4px solid var(--accent); border-radius: 12px; padding: 14px; background: color-mix(in srgb, var(--panel) 94%, var(--accent)); }
 .pa-inline-action.receipt { border-color: color-mix(in srgb, var(--success) 70%, var(--border)); border-left-color: var(--success); }
 .pa-action-label { color: var(--accent); font-size: 12px; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; }
@@ -5812,6 +5824,7 @@ select {
   body:has(.personal-assistant-page) .content.agent-detail:has(.agent-workspace.conversation-only) { height: calc(100dvh - var(--app-header-height, 64px)); }
 }
 @media (max-width: 760px) { .pa-inline-action dl div { grid-template-columns: 64px minmax(0, 1fr); }.pa-project-starter-form { grid-template-columns: 1fr; }.pa-project-starter-form .ui-button { width: 100%; }.pa-continuity summary { display: grid; gap: 2px; }.pa-continuity summary span { text-align: left; } }
+@media (prefers-reduced-motion: reduce) { .message.user.pending { animation: none; } }
 
 
 .agent-dock:has(.skill-flyout:not(.hidden)) {
@@ -6258,8 +6271,33 @@ select {
   font-size: 12px;
 }
 
+.pa-control-error {
+  display: grid;
+  border: 1px solid color-mix(in srgb, var(--danger) 42%, var(--border));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--danger) 7%, var(--panel));
+  padding: 7px 8px;
+  color: var(--danger);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.prompt-queue-control-error {
+  margin-top: 1px;
+}
+
 .prompt-queue-blocked {
   margin: 0;
+}
+
+.inquiry-lifecycle-action {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.inquiry-control-error {
+  max-width: 260px;
 }
 
 .composer-editor-shell {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -9,6 +9,23 @@ const AGENT_ACTIVITY_POLL_INTERVALS = {
   visibleMs: 3_000,
   hiddenMs: 30_000,
 };
+const PERSONAL_ASSISTANT_POLL_INTERVALS = {
+  activeMs: 4_000,
+  idleMs: 12_000,
+  hiddenMs: 30_000,
+};
+const PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY = "hq.remote.personalAssistantSubmissions";
+const PERSONAL_ASSISTANT_SUBMISSION_LIMIT = 24;
+const PERSONAL_ASSISTANT_SUBMISSION_STATES = ["sending", "accepted", "running", "queued", "failed", "unknown", "canceled"];
+const PERSONAL_ASSISTANT_SUBMISSION_TRANSITIONS = {
+  sending: ["sending", "accepted", "queued", "running", "failed", "unknown"],
+  accepted: ["accepted", "queued", "running", "failed", "unknown"],
+  queued: ["queued", "running", "failed", "unknown", "canceled"],
+  running: ["running", "accepted", "failed", "unknown"],
+  failed: ["failed"],
+  unknown: ["unknown", "accepted", "queued", "running", "failed", "canceled"],
+  canceled: ["canceled"],
+};
 const AGENT_ACTIVITY_FIELDS = [
   "name", "project_key", "template_key", "scheduled", "schedule_key", "agent", "model", "reasoning_effort",
   "status", "running", "unread", "awaiting_input", "blocked", "run_count", "created_at", "started_at",
@@ -689,8 +706,23 @@ const state = {
   responseStyle: null,
   setup: null,
   personalAssistant: null,
+  personalAssistantLoadState: "unknown",
+  personalAssistantLoadError: "",
   personalAssistantHistoryEntry: null,
   personalAssistantSettingsEditing: false,
+  personalAssistantProposals: [],
+  personalAssistantSubmissionStates: {},
+  personalAssistantSubmissionStatesLoaded: false,
+  personalAssistantControlErrors: {},
+  personalAssistantRequests: {
+    coordinator: { sequence: 0, applied: 0, reconciliationSessionKey: "", reconciliationCursor: 0 },
+    status: null,
+    actions: {},
+    conversations: {},
+    acceptance: {},
+    shell: null,
+  },
+  composerDraftRevisions: {},
   pendingPersonalAssistantProposalIds: new Set(),
   onboardingGuide: "",
   settingsSection: "connection",
@@ -1896,6 +1928,117 @@ async function apiDelete(path, body = {}) {
   return scopeApiResponse(await readJson(response), request.server);
 }
 
+function personalAssistantAgent(value) {
+  const key = typeof value === "string" ? value : value?.key;
+  if (!key) return false;
+
+  const item = state.personalAssistant;
+  return item?.active_key === key || item?.agent?.key === key || value?.role === "personal_assistant_daily";
+}
+
+function personalAssistantSessionContext(item = state.personalAssistant) {
+  const activeKey = String(item?.active_key || "").trim();
+  const generation = Number(item?.generation);
+  if (!activeKey || !Number.isInteger(generation)) return null;
+  return { active_key: activeKey, generation, server_key: personalAssistantServerKey(item) };
+}
+
+function personalAssistantSessionMatches(context, item = state.personalAssistant) {
+  const current = personalAssistantSessionContext(item);
+  return Boolean(current && context && current.server_key === context.server_key &&
+    current.active_key === context.active_key && current.generation === context.generation);
+}
+
+function personalAssistantControlErrorKey(agentKey, control, id = "", context = null) {
+  const session = context || personalAssistantSessionContext();
+  return [
+    session?.server_key || personalAssistantServerKey(),
+    session?.active_key || "no-session",
+    Number.isInteger(session?.generation) ? session.generation : "no-generation",
+    String(agentKey || ""),
+    String(control || ""),
+    String(id || ""),
+  ].join(":");
+}
+
+function personalAssistantControlError(agentKey, control, id = "", context = null) {
+  const key = personalAssistantControlErrorKey(agentKey, control, id, context);
+  return state.personalAssistantControlErrors[key] || null;
+}
+
+function setPersonalAssistantControlError(agentKey, control, id, error, context = null) {
+  const message = String(error?.message || error || "FRED control failed.").trim();
+  if (!message) return null;
+  const session = context || personalAssistantSessionContext();
+  const key = personalAssistantControlErrorKey(agentKey, control, id, session);
+  const record = {
+    message,
+    server_key: session?.server_key || personalAssistantServerKey(),
+    active_key: session?.active_key || "",
+    generation: session?.generation,
+  };
+  state.personalAssistantControlErrors[key] = record;
+  return record;
+}
+
+function clearPersonalAssistantControlError(agentKey, control, id = "", context = null) {
+  delete state.personalAssistantControlErrors[personalAssistantControlErrorKey(agentKey, control, id, context)];
+}
+
+function personalAssistantEndpointAdapter(agentOrKey, options = {}) {
+  const key = typeof agentOrKey === "string" ? agentOrKey : agentOrKey?.key;
+  const agent = typeof agentOrKey === "string" ? findAgent(agentOrKey) : agentOrKey;
+  const personalAssistant = options.personalAssistant === undefined
+    ? personalAssistantAgent(agent || key)
+    : options.personalAssistant === true;
+  const encodedKey = encodeURIComponent(String(key || ""));
+  const context = options.context || (personalAssistant ? personalAssistantSessionContext() : null);
+  const genericMessagePath = `/agents/${encodedKey}/messages`;
+
+  return {
+    key: String(key || ""),
+    personalAssistant,
+    context,
+    messagePath: personalAssistant ? "/personal-assistant/messages" : genericMessagePath,
+    inquiryPath(inquiryId, action) {
+      const encodedInquiryId = encodeURIComponent(String(inquiryId || ""));
+      const genericPath = action === "answer"
+        ? `/agents/${encodedKey}/inquiries/${encodeURIComponent(inquiryId)}/answer`
+        : `/agents/${encodedKey}/inquiries/${encodedInquiryId}/${action}`;
+      return personalAssistant ? `/personal-assistant/inquiries/${encodedInquiryId}/${action}` : genericPath;
+    },
+    queuePath(entryId = "") {
+      const encodedEntryId = encodeURIComponent(String(entryId || ""));
+      return personalAssistant
+        ? `/personal-assistant/prompt-queue/${encodedEntryId}`
+        : `/agents/${encodedKey}/prompt-queue/${encodedEntryId}`;
+    },
+    queueRetryPath: personalAssistant
+      ? "/personal-assistant/prompt-queue/retry"
+      : `/agents/${encodedKey}/prompt-queue/retry`,
+    writeBody(body = {}, clientRequestId = "") {
+      if (!personalAssistant) return body;
+      if (!context?.active_key || !Number.isInteger(context.generation)) {
+        throw new Error("FRED session is unavailable; refresh and try again.");
+      }
+      return {
+        ...body,
+        active_key: context.active_key,
+        generation: context.generation,
+        ...(clientRequestId ? { client_request_id: clientRequestId } : {}),
+      };
+    },
+  };
+}
+
+function personalAssistantRequestIsCurrent(adapter, routeHashAtStart) {
+  if (!adapter?.personalAssistant) return true;
+  return location.hash === routeHashAtStart &&
+    parseRoute().type === "personalAssistant" &&
+    state.personalAssistant?.active_key === adapter.key &&
+    personalAssistantSessionMatches(adapter.context);
+}
+
 async function readJson(response) {
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
@@ -1903,6 +2046,8 @@ async function readJson(response) {
     const error = new Error(message);
     error.status = response.status;
     error.details = data.details || null;
+    error.code = data.code || data.details?.code || null;
+    error.data = data;
     throw error;
   }
   return data;
@@ -2008,16 +2153,35 @@ function agentSplitRoute(route) {
 
 function pollDelay() {
   const intervals = refreshIntervals();
+  const route = parseRoute();
+  if (route.type === "personalAssistant") return personalAssistantPollDelay();
   if (document.hidden) return intervals.hiddenMs;
   if (state.failureCount > 1) return intervals.hiddenMs;
   if (state.failureCount > 0) return intervals.idleMs;
-  const route = parseRoute();
   const workspaceRoute = agentWorkspaceRoute(route);
   const routeAgent = workspaceRoute ? findAgent(workspaceRoute.key) : null;
   const refreshingServer = state.servers.some((server) => server.refreshing || server.status === "loading");
   const active = refreshingServer || routeAgent?.running || state.agents.some((agent) => agent.running) || route.type === "agent";
   if (active) return intervals.activeMs;
   return intervals.idleMs;
+}
+
+function personalAssistantPollDelay() {
+  if (document.hidden) return PERSONAL_ASSISTANT_POLL_INTERVALS.hiddenMs;
+  const item = state.personalAssistant;
+  const agent = item?.active_key ? (state.agentDetails[item.active_key] || item.agent) : null;
+  const proposalWork = state.personalAssistantProposals?.some((proposal) =>
+    ["executing", "running"].includes(proposal?.state));
+  const queueWork = agent?.prompt_queue?.entries?.some((entry) =>
+    ["submitting", "dispatching"].includes(entry?.state));
+  const active = Boolean(agent?.running || proposalWork || queueWork);
+  const session = personalAssistantSessionContext();
+  const pending = personalAssistantSubmissionEntries({
+    serverKey: personalAssistantServerKey(),
+    session,
+  }).some((entry) =>
+    ["sending", "queued", "unknown", "running"].includes(entry?.state));
+  return active || (session && pending) ? PERSONAL_ASSISTANT_POLL_INTERVALS.activeMs : PERSONAL_ASSISTANT_POLL_INTERVALS.idleMs;
 }
 
 function refreshIntervals() {
@@ -2027,6 +2191,442 @@ function refreshIntervals() {
     idleMs: configured.idle_ms || DEFAULT_REFRESH_INTERVALS.idleMs,
     hiddenMs: configured.hidden_ms || DEFAULT_REFRESH_INTERVALS.hiddenMs,
   };
+}
+
+function normalizePersonalAssistantSubmissionState(value, fallback = "unknown") {
+  const raw = typeof value === "object" ? (value?.state || value?.status) : value;
+  const normalized = String(raw || "").trim().toLowerCase();
+  const mapped = { dispatched: "running", start_failed: "failed", acceptance_unknown: "unknown" }[normalized] || normalized;
+  return PERSONAL_ASSISTANT_SUBMISSION_STATES.includes(mapped) ? mapped : fallback;
+}
+
+function personalAssistantSubmissionStateLabel(value) {
+  return {
+    sending: "Sending",
+    accepted: "Accepted",
+    running: "Running",
+    queued: "Queued",
+    failed: "Failed",
+    unknown: "Unknown",
+    canceled: "Canceled",
+  }[normalizePersonalAssistantSubmissionState(value)] || "Unknown";
+}
+
+function personalAssistantSubmissionStateIntent(value) {
+  const stateName = normalizePersonalAssistantSubmissionState(value);
+  if (stateName === "failed") return "danger";
+  if (stateName === "unknown") return "warning";
+  if (stateName === "running") return "info";
+  return "pending";
+}
+
+function personalAssistantSubmissionTransition(previous, next) {
+  const current = normalizePersonalAssistantSubmissionState(previous, "");
+  const candidate = normalizePersonalAssistantSubmissionState(next, current || "unknown");
+  if (!current) return candidate;
+  return PERSONAL_ASSISTANT_SUBMISSION_TRANSITIONS[current]?.includes(candidate) ? candidate : current;
+}
+
+function createPersonalAssistantClientRequestId(prefix = "fred") {
+  const random = Math.random().toString(36).slice(2, 12);
+  return `client-${prefix}-${Date.now().toString(36)}-${random}`.slice(0, 100);
+}
+
+function loadPersonalAssistantSubmissionStates() {
+  if (state.personalAssistantSubmissionStatesLoaded) return;
+  state.personalAssistantSubmissionStatesLoaded = true;
+  let parsed = [];
+  try {
+    const stored = JSON.parse(safeLocalStorageGet(PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY) || "[]");
+    parsed = Array.isArray(stored) ? stored : Object.values(stored || {});
+  } catch (_error) {
+    safeLocalStorageRemove(PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY);
+  }
+
+  parsed.filter((entry) => String(entry?.client_request_id || entry?.id || "").trim()).forEach((entry) => {
+    const clientRequestId = String(entry.client_request_id || entry.id).trim();
+    const recoveredState = entry.state === "sending" ? "unknown" : normalizePersonalAssistantSubmissionState(entry.state);
+    const record = {
+      ...entry,
+      client_request_id: clientRequestId,
+      server_key: String(entry.server_key || "local"),
+      state: recoveredState,
+      updated_at: entry.updated_at || entry.submitted_at || new Date().toISOString(),
+    };
+    state.personalAssistantSubmissionStates[personalAssistantSubmissionStorageId(record)] = record;
+  });
+}
+
+function persistPersonalAssistantSubmissionStates() {
+  const entries = Object.values(state.personalAssistantSubmissionStates || {});
+  const unresolved = entries.filter(personalAssistantSubmissionNeedsRetention);
+  const settled = entries
+    .filter((entry) => !personalAssistantSubmissionNeedsRetention(entry))
+    .sort((left, right) => String(left.updated_at || "").localeCompare(String(right.updated_at || "")))
+    .slice(-PERSONAL_ASSISTANT_SUBMISSION_LIMIT);
+  const retained = [...unresolved, ...settled]
+    .sort((left, right) => String(left.updated_at || "").localeCompare(String(right.updated_at || "")));
+  state.personalAssistantSubmissionStates = Object.fromEntries(retained.map((entry) => [personalAssistantSubmissionStorageId(entry), entry]));
+  if (retained.length) safeLocalStorageSet(PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY, JSON.stringify(retained));
+  else safeLocalStorageRemove(PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY);
+}
+
+function personalAssistantSubmissionNeedsRetention(record) {
+  return ["sending", "queued", "unknown", "running", "failed"].includes(
+    normalizePersonalAssistantSubmissionState(record?.state)
+  );
+}
+
+function personalAssistantSubmissionStorageId(record) {
+  return [
+    String(record?.server_key || "local"),
+    String(record?.active_key || "no-session"),
+    Number.isInteger(Number(record?.generation)) ? Number(record.generation) : "no-generation",
+    String(record?.client_request_id || ""),
+  ].join(":");
+}
+
+function personalAssistantSubmissionEntries(options = {}) {
+  loadPersonalAssistantSubmissionStates();
+  const serverKey = options.serverKey === undefined ? null : String(options.serverKey || "local");
+  const session = options.session || null;
+  return Object.values(state.personalAssistantSubmissionStates || {})
+    .filter((record) => !serverKey || String(record.server_key || "local") === serverKey)
+    .filter((record) => !session || (
+      String(record.active_key || "") === String(session.active_key || "") &&
+      Number(record.generation) === Number(session.generation)
+    ));
+}
+
+function findPersonalAssistantSubmission(clientRequestId, options = {}) {
+  const id = String(clientRequestId || "").trim();
+  if (!id) return null;
+  return personalAssistantSubmissionEntries(options)
+    .filter((record) => record.client_request_id === id)
+    .sort((left, right) => String(right.updated_at || "").localeCompare(String(left.updated_at || "")))[0] || null;
+}
+
+function personalAssistantSubmissionForQueueEntry(entryId, response = {}) {
+  const id = String(response?.client_request_id || response?.acceptance?.client_request_id || "").trim();
+  const session = personalAssistantSessionContext();
+  const serverKey = personalAssistantServerKey();
+  if (id) return findPersonalAssistantSubmission(id, { serverKey, session });
+
+  const queueId = String(entryId || "").trim();
+  return personalAssistantSubmissionEntries({ serverKey, session }).find((record) => (
+    record.client_request_id === queueId ||
+    String(record.queue_entry_id || record.acceptance?.queue_entry_id || "") === queueId
+  )) || null;
+}
+
+function rememberPersonalAssistantSubmission({ clientRequestId, prompt, agentKey, context, draftRevision }) {
+  loadPersonalAssistantSubmissionStates();
+  const now = new Date().toISOString();
+  const record = {
+    ...(findPersonalAssistantSubmission(clientRequestId, { serverKey: context?.server_key, session: context }) || {}),
+    client_request_id: clientRequestId,
+    prompt: String(prompt || ""),
+    agent_key: String(agentKey || ""),
+    active_key: context?.active_key || "",
+    generation: context?.generation,
+    server_key: context?.server_key || personalAssistantServerKey(),
+    draft_revision: Number(draftRevision || 0),
+    state: "sending",
+    acceptance_state: "pending",
+    message_recorded: false,
+    submitted_at: now,
+    updated_at: now,
+  };
+  state.personalAssistantSubmissionStates[personalAssistantSubmissionStorageId(record)] = record;
+  persistPersonalAssistantSubmissionStates();
+  return record;
+}
+
+function personalAssistantServerKey(item = state.personalAssistant) {
+  return String(item?.server_key || item?.server || "local").trim() || "local";
+}
+
+function personalAssistantBlockRequestIds(block) {
+  const metadata = block?.metadata || {};
+  const values = [
+    block?.client_request_id,
+    block?.message_id,
+    metadata.personal_assistant_client_request_id,
+    metadata.personal_assistant_client_request_ids,
+  ];
+  return values.flatMap((value) => Array.isArray(value) ? value : [value])
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+}
+
+function personalAssistantBlockRequestId(block) {
+  return personalAssistantBlockRequestIds(block)[0] || "";
+}
+
+function personalAssistantSubmissionStatePriority(value) {
+  return {
+    failed: 6,
+    unknown: 5,
+    running: 4,
+    queued: 3,
+    sending: 2,
+    accepted: 1,
+  }[normalizePersonalAssistantSubmissionState(value)] || 0;
+}
+
+function personalAssistantSubmissionForBlock(block) {
+  const session = personalAssistantSessionContext();
+  return personalAssistantBlockRequestIds(block)
+    .map((id) => findPersonalAssistantSubmission(id, { serverKey: personalAssistantServerKey(), session }))
+    .filter(Boolean)
+    .sort((left, right) => personalAssistantSubmissionStatePriority(right.state) - personalAssistantSubmissionStatePriority(left.state))[0] || null;
+}
+
+function updatePersonalAssistantSubmission(clientRequestId, nextState, attributes = {}) {
+  const id = String(clientRequestId || "").trim();
+  if (!id) return null;
+  loadPersonalAssistantSubmissionStates();
+  const { session: requestedSession, ...recordAttributes } = attributes;
+  const serverKey = String(recordAttributes.server_key || personalAssistantServerKey());
+  const session = requestedSession || (
+    String(recordAttributes.active_key || "").trim() && Number.isInteger(Number(recordAttributes.generation))
+      ? { active_key: String(recordAttributes.active_key).trim(), generation: Number(recordAttributes.generation), server_key: serverKey }
+      : null
+  );
+  const existing = findPersonalAssistantSubmission(id, { serverKey, session }) || {
+    client_request_id: id,
+    server_key: serverKey,
+  };
+  const record = {
+    ...existing,
+    ...recordAttributes,
+    client_request_id: id,
+    state: personalAssistantSubmissionTransition(existing.state, nextState),
+    updated_at: new Date().toISOString(),
+  };
+  Object.keys(state.personalAssistantSubmissionStates).forEach((key) => {
+    if (state.personalAssistantSubmissionStates[key]?.client_request_id === id &&
+        state.personalAssistantSubmissionStates[key]?.server_key === serverKey &&
+        (!session || (
+          String(state.personalAssistantSubmissionStates[key]?.active_key || "") === String(session.active_key || "") &&
+          Number(state.personalAssistantSubmissionStates[key]?.generation) === Number(session.generation)
+        ))) delete state.personalAssistantSubmissionStates[key];
+  });
+  state.personalAssistantSubmissionStates[personalAssistantSubmissionStorageId(record)] = record;
+  Object.values(state.pendingConversationMessages || {}).forEach((blocks) => {
+    blocks?.forEach((block) => {
+      if (!personalAssistantBlockRequestIds(block).includes(id)) return;
+      block.send_status = record.state;
+      block.send_error = record.error || "";
+      if (record.message_recorded && record.state !== "sending") {
+        removePendingConversationMessage(record.agent_key, block.id, { render: false });
+      }
+    });
+  });
+  persistPersonalAssistantSubmissionStates();
+  return record;
+}
+
+function personalAssistantSubmissionRunId(record) {
+  return String(record?.acceptance?.run_id || record?.run_id || "").trim();
+}
+
+function personalAssistantRunTerminalState(record, blocks = null) {
+  const runId = personalAssistantSubmissionRunId(record);
+  if (!runId) return "";
+  const conversation = Array.isArray(blocks)
+    ? blocks
+    : state.conversations[record?.agent_key]?.blocks || [];
+  const summary = [...conversation].reverse().find((block) => {
+    if (block?.kind !== "run_summary") return false;
+    const metadata = block.metadata || {};
+    return String(block.run_id || metadata.run_id || "") === runId;
+  });
+  if (!summary) return "";
+
+  const status = String(summary.metadata?.status || summary.status || "").trim().toLowerCase();
+  if (["success", "succeeded", "no_action_needed", "partial", "completed", "complete", "input_required", "awaiting-input", "awaiting_input"].includes(status)) return "accepted";
+  if (["failed", "error", "stopped", "cancelled", "canceled", "blocked"].includes(status)) return "failed";
+  return "";
+}
+
+function reconcilePersonalAssistantTerminalRuns(agentKey, blocks = null) {
+  const key = String(agentKey || "");
+  const session = personalAssistantSessionContext();
+  if (!key || !session) return;
+  personalAssistantSubmissionEntries({ serverKey: session.server_key, session })
+    .filter((record) => record.agent_key === key && normalizePersonalAssistantSubmissionState(record.state) === "running")
+    .forEach((record) => {
+      const terminalState = personalAssistantRunTerminalState(record, blocks);
+      if (!terminalState) return;
+      updatePersonalAssistantSubmission(record.client_request_id, terminalState, {
+        server_key: record.server_key,
+        active_key: record.active_key,
+        generation: record.generation,
+        agent_key: key,
+        run_terminal_state: terminalState,
+        error: terminalState === "failed" ? (record.error || "FRED run finished with a failure.") : "",
+      });
+    });
+}
+
+function personalAssistantRequest(requests, key, factory) {
+  const existing = requests[key];
+  if (existing?.promise) return existing.promise;
+  const request = { promise: Promise.resolve().then(factory) };
+  requests[key] = request;
+  request.promise.finally(() => {
+    if (requests[key] === request) delete requests[key];
+  }).catch(() => {});
+  return request.promise;
+}
+
+function applyPersonalAssistantItem(item) {
+  const previousContext = personalAssistantSessionContext();
+  const previousKey = state.personalAssistant?.active_key || "";
+  state.personalAssistant = item || null;
+  state.personalAssistantLoadState = "ready";
+  state.personalAssistantLoadError = "";
+  if (state.personalAssistant?.agent) {
+    state.agentDetails[state.personalAssistant.agent.key] = state.personalAssistant.agent;
+  }
+  if (previousContext && !personalAssistantSessionMatches(previousContext)) {
+    state.personalAssistantProposals = [];
+    state.personalAssistantRequests.actions = {};
+    state.personalAssistantControlErrors = {};
+  }
+  transferPersonalAssistantDraftArtifacts(previousKey, state.personalAssistant?.active_key || "");
+  return state.personalAssistant;
+}
+
+function personalAssistantSubmissionStateFromResponse(response) {
+  return normalizePersonalAssistantSubmissionState(response?.acceptance?.state || response?.state, response?.accepted ? "accepted" : "unknown");
+}
+
+function personalAssistantAcceptanceState(response) {
+  return String(response?.acceptance?.state || response?.state || "").trim().toLowerCase() || "unknown";
+}
+
+function personalAssistantSubmissionStateFromError(error) {
+  const acceptance = error?.data?.acceptance || error?.details?.acceptance;
+  const acceptanceState = normalizePersonalAssistantSubmissionState(acceptance, "");
+  if (acceptanceState) return acceptanceState;
+  const code = String(error?.code || error?.data?.code || error?.details?.code || "").toLowerCase();
+  if (code === "acceptance_unknown" || code === "unknown") return "unknown";
+  if (code === "start_failed") return "failed";
+  if (String(error?.message || "").startsWith("FRED session is unavailable")) return "failed";
+  if (!error?.status) return "unknown";
+  return "failed";
+}
+
+function requestPersonalAssistantStatus(force = false, routeHashAtStart = location.hash) {
+  loadPersonalAssistantSubmissionStates();
+  const requests = state.personalAssistantRequests;
+  if (!force && requests.status?.promise) return requests.status.promise;
+  if (requests.status?.promise) return requests.status.promise;
+  const coordinator = requests.coordinator;
+  const sequence = ++coordinator.sequence;
+  const promise = personalAssistantRequest(requests, "status", async () => {
+    const data = await apiGet("/personal-assistant");
+    if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return data;
+    if (sequence < coordinator.applied) return data;
+    coordinator.applied = sequence;
+    applyPersonalAssistantItem(data.personal_assistant || null);
+    return data;
+  });
+  return promise.catch((error) => {
+    if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant") {
+      state.personalAssistantLoadState = "error";
+      state.personalAssistantLoadError = error.message;
+    }
+    throw error;
+  });
+}
+
+function requestPersonalAssistantActions(routeHashAtStart = location.hash, context = null) {
+  const requests = state.personalAssistantRequests;
+  const requestKey = [context?.server_key || personalAssistantServerKey(), context?.active_key || "no-session", context?.generation ?? "no-generation"].join(":");
+  const request = personalAssistantRequest(requests.actions, requestKey, async () => {
+    const data = await apiGet("/personal-assistant/actions");
+    if (location.hash !== routeHashAtStart || (context && !personalAssistantSessionMatches(context))) return data;
+    state.personalAssistantProposals = data.proposals || [];
+    return data;
+  });
+  return request;
+}
+
+function requestPersonalAssistantAcceptance(clientRequestId, options = {}) {
+  const id = String(clientRequestId || "").trim();
+  if (!id) return Promise.resolve(null);
+  const routeHashAtStart = options.routeHashAtStart || location.hash;
+  const session = options.session || personalAssistantSessionContext();
+  const serverKey = session?.server_key || personalAssistantServerKey();
+  const record = findPersonalAssistantSubmission(id, { serverKey, session });
+  const requests = state.personalAssistantRequests.acceptance;
+  const requestKey = [serverKey, session?.active_key || "no-session", session?.generation ?? "no-generation", id].join(":");
+  return personalAssistantRequest(requests, requestKey, async () => {
+    try {
+      const data = await apiGet(`/personal-assistant/messages/acceptance/${encodeURIComponent(id)}`);
+      const current = Boolean(session && location.hash === routeHashAtStart &&
+        parseRoute().type === "personalAssistant" && personalAssistantSessionMatches(session));
+      if (data.acceptance && current) {
+        const updated = updatePersonalAssistantSubmission(id, personalAssistantSubmissionStateFromResponse(data), {
+          acceptance: data.acceptance,
+          acceptance_state: personalAssistantAcceptanceState(data),
+          error: "",
+          server_key: record?.server_key || personalAssistantServerKey(),
+          active_key: record?.active_key || data.acceptance.active_key || "",
+          generation: record?.generation ?? data.acceptance.generation,
+          agent_key: record?.agent_key || "",
+        });
+        reconcilePersonalAssistantTerminalRuns(updated?.agent_key || record?.agent_key, state.conversations[updated?.agent_key || record?.agent_key]?.blocks);
+        if (parseRoute().type === "personalAssistant") {
+          state.renderedViewHtml = "";
+          render({ preserveLiveEditor: true });
+        }
+      }
+      return data;
+    } catch (error) {
+      if (error.status === 404 || error.code === "acceptance_not_found") return null;
+      throw error;
+    }
+  });
+}
+
+function personalAssistantReconciliationBatch(records, session) {
+  const coordinator = state.personalAssistantRequests.coordinator;
+  const sessionKey = [session?.server_key || "", session?.active_key || "", session?.generation ?? ""].join(":");
+  if (coordinator.reconciliationSessionKey !== sessionKey) {
+    coordinator.reconciliationSessionKey = sessionKey;
+    coordinator.reconciliationCursor = 0;
+  }
+
+  const ordered = records.slice().sort((left, right) => {
+    const leftKey = String(left.submitted_at || left.created_at || left.updated_at || left.client_request_id || "");
+    const rightKey = String(right.submitted_at || right.created_at || right.updated_at || right.client_request_id || "");
+    return leftKey.localeCompare(rightKey) || String(left.client_request_id || "").localeCompare(String(right.client_request_id || ""));
+  });
+  if (!ordered.length) {
+    coordinator.reconciliationCursor = 0;
+    return [];
+  }
+
+  const start = coordinator.reconciliationCursor % ordered.length;
+  const count = Math.min(4, ordered.length);
+  const batch = Array.from({ length: count }, (_value, index) => ordered[(start + index) % ordered.length]);
+  coordinator.reconciliationCursor = (start + count) % ordered.length;
+  return batch;
+}
+
+async function reconcilePersonalAssistantSubmissions() {
+  const routeHashAtStart = location.hash;
+  const session = personalAssistantSessionContext();
+  const unresolved = personalAssistantSubmissionEntries({ serverKey: personalAssistantServerKey(), session })
+    .filter((record) => ["queued", "unknown", "running"].includes(normalizePersonalAssistantSubmissionState(record.state)));
+  const records = personalAssistantReconciliationBatch(unresolved, session);
+  await Promise.all(records.map((record) => requestPersonalAssistantAcceptance(record.client_request_id, { routeHashAtStart, session }).catch(() => null)));
+  const agentKey = state.personalAssistant?.active_key;
+  if (agentKey) reconcilePersonalAssistantTerminalRuns(agentKey, state.conversations[agentKey]?.blocks);
 }
 
 function schedule(ms = pollDelay()) {
@@ -2268,6 +2868,88 @@ function syncAgentFloatingActions(agent, route = parseRoute()) {
   }
 }
 
+function personalAssistantShellRefreshNeeded(options = {}) {
+  const shellAge = state.lastShellUpdatedAt ? Date.now() - state.lastShellUpdatedAt.getTime() : Infinity;
+  return options.forceShell === true || shellAge >= 10_000;
+}
+
+function refreshPersonalAssistantShell(options = {}) {
+  const requests = state.personalAssistantRequests;
+  if (requests.shell?.promise) return requests.shell.promise;
+  return personalAssistantRequest(requests, "shell", async () => {
+    try {
+      const catalogData = await loadResourceCatalog();
+      applyResourceCatalog(catalogData);
+      const [setupData, schedulesData] = await Promise.all([
+        apiGet("/setup"),
+        apiGet("/schedules"),
+      ]);
+      state.setup = setupData.setup || null;
+      state.schedules = (schedulesData.schedules || []).map(normalizeLocalSchedule);
+      state.scheduleDaemon = schedulesData.daemon || null;
+      return true;
+    } finally {
+      state.lastShellUpdatedAt = new Date();
+      if (parseRoute().type === "personalAssistant") {
+        state.renderedViewHtml = "";
+        render({ preserveLiveEditor: true });
+      }
+    }
+  }).catch((error) => {
+    console.warn("FRED shell refresh degraded", error.message);
+    return null;
+  });
+}
+
+async function refreshPersonalAssistant(options = {}) {
+  const routeHashAtStart = location.hash;
+  loadPersonalAssistantSubmissionStates();
+  setConnection("Refreshing", { preserveHeaderSubtitle: true });
+  try {
+    await requestPersonalAssistantStatus(true, routeHashAtStart);
+    if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return;
+
+    let item = state.personalAssistant;
+    if (item?.configured && !item.active_key &&
+        ["ready", "dormant", "unconfigured"].includes(item.state)) {
+      const opened = await apiPost("/personal-assistant/open", {});
+      if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return;
+      item = applyPersonalAssistantItem(opened.personal_assistant || opened);
+    }
+
+    state.lastUpdatedAt = new Date();
+    state.failureCount = 0;
+    setConnection(refreshedText(), { preserveHeaderSubtitle: true });
+    render({ preserveLiveEditor: true });
+    if (personalAssistantShellRefreshNeeded(options)) void refreshPersonalAssistantShell(options);
+
+    const context = personalAssistantSessionContext(item);
+    const agent = item?.active_key
+      ? (state.agentDetails[item.active_key] || item.agent || null)
+      : null;
+    const work = [
+      agent ? ensureConversation(agent, options.forceConversation === true) : null,
+      item?.active_key ? requestPersonalAssistantActions(routeHashAtStart, context) : null,
+      reconcilePersonalAssistantSubmissions(),
+    ].filter(Boolean);
+    await Promise.allSettled(work);
+    if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return;
+    state.lastUpdatedAt = new Date();
+    setConnection(refreshedText(), { preserveHeaderSubtitle: true });
+    render({ preserveLiveEditor: true });
+    dismissBootShell();
+  } catch (error) {
+    if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant") {
+      setConnection("FRED unavailable: " + error.message, { preserveHeaderSubtitle: true });
+      state.renderedViewHtml = "";
+      render({ preserveLiveEditor: true });
+      dismissBootShell();
+    }
+  } finally {
+    if (!state.timer) schedule(personalAssistantPollDelay());
+  }
+}
+
 async function refresh(options = {}) {
   clearTimeout(state.timer);
   state.timer = null;
@@ -2281,6 +2963,7 @@ async function refresh(options = {}) {
     schedule();
     return;
   }
+  if (parseRoute().type === "personalAssistant") return refreshPersonalAssistant(options);
 
   const initialRouteHash = location.hash;
   const preserveWorkspace = preserveWorkspaceDuringPoll(options);
@@ -2318,17 +3001,13 @@ async function refresh(options = {}) {
       state.setup = setupData.setup || null;
       state.schedules = (schedulesData.schedules || []).map(normalizeLocalSchedule);
       state.scheduleDaemon = schedulesData.daemon || null;
-      const previousPersonalAssistantKey = state.personalAssistant?.active_key || "";
-      state.personalAssistant = personalAssistantData.personal_assistant || null;
+      loadPersonalAssistantSubmissionStates();
+      applyPersonalAssistantItem(personalAssistantData.personal_assistant || null);
       if (parseRoute().type === "personalAssistant" && state.personalAssistant?.configured &&
           !state.personalAssistant.active_key && ["ready", "dormant", "unconfigured"].includes(state.personalAssistant.state)) {
         const opened = await apiPost("/personal-assistant/open", {});
-        state.personalAssistant = opened.personal_assistant;
+        applyPersonalAssistantItem(opened.personal_assistant || opened);
       }
-      if (state.personalAssistant?.agent) {
-        state.agentDetails[state.personalAssistant.agent.key] = state.personalAssistant.agent;
-      }
-      transferPersonalAssistantDraftArtifacts(previousPersonalAssistantKey, state.personalAssistant?.active_key || "");
       if (parseRoute().type === "personalAssistant") {
         const actionData = await apiGet("/personal-assistant/actions");
         state.personalAssistantProposals = actionData.proposals || [];
@@ -2385,16 +3064,16 @@ async function refresh(options = {}) {
 async function ensureRouteData(options = {}) {
   const route = parseRoute();
   cancelBackgroundPullRequestDiffFetchesExcept(route.type === "agentPullRequests" ? route.key : "");
+  if (route.type === "personalAssistant") {
+    await refreshPersonalAssistant({ ...options, forceStatus: false });
+    return;
+  }
   let agentShellData = Promise.resolve();
   if (route.type === "tab" && route.tab === "settings") {
     await Promise.all([
       ensureResponseStyle(options.forceResponseStyle || options.force),
       refreshCurrentPushConfig(),
     ]);
-  }
-  if (route.type === "personalAssistant" && state.personalAssistant?.active_key) {
-    const agent = state.agentDetails[state.personalAssistant.active_key] || state.personalAssistant.agent;
-    if (agent) await ensureConversation(agent, options.forceConversation);
   }
   if (agentShellRoute(route)) {
     await ensureAgentDetail(route.key, options.forceAgent || options.force);
@@ -2881,6 +3560,56 @@ function prunePullRequestDiffState(activeAgentKeys) {
 
 async function ensureConversation(agent, force = false) {
   const cached = state.conversations[agent.key];
+  if (personalAssistantAgent(agent)) {
+    const requests = state.personalAssistantRequests.conversations;
+    const context = personalAssistantSessionContext();
+    const requestKey = [agent.key, context?.server_key || "local", context?.active_key || "no-session", context?.generation ?? "no-generation"].join(":");
+    if (requests[requestKey]?.promise) return requests[requestKey].promise;
+    if (!force && cached && cached.revision === agent.revision && !cached.loading && !cached.error) return;
+
+    const routeHashAtStart = location.hash;
+    const capturedRevision = agent.revision;
+    setConversationLoading(agent.key, true, cached);
+    render({ preserveLiveEditor: true });
+    return personalAssistantRequest(requests, requestKey, async () => {
+      try {
+        const data = await apiGet("/agents/" + encodeURIComponent(agent.key) + "/conversation");
+        const currentAgent = findAgent(agent.key);
+        const revisionMatches = !capturedRevision || !currentAgent?.revision ||
+          currentAgent.revision === capturedRevision;
+        const current = location.hash === routeHashAtStart &&
+          parseRoute().type === "personalAssistant" &&
+          state.personalAssistant?.active_key === agent.key &&
+          personalAssistantSessionMatches(context) &&
+          revisionMatches;
+        if (!current) return null;
+        state.conversations[agent.key] = {
+          revision: capturedRevision,
+          blocks: data.conversation || [],
+          loaded: true,
+          loading: false,
+        };
+        reconcilePersonalAssistantConversation(agent.key, state.conversations[agent.key].blocks);
+        reconcilePersonalAssistantTerminalRuns(agent.key, state.conversations[agent.key].blocks);
+        return data;
+      } catch (error) {
+        if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant" &&
+            personalAssistantSessionMatches(context)) {
+          state.conversations[agent.key] = {
+            ...(state.conversations[agent.key] || {}),
+            revision: capturedRevision,
+            blocks: state.conversations[agent.key]?.blocks || [],
+            loaded: false,
+            loading: false,
+            error: error.message,
+          };
+        }
+        throw error;
+      } finally {
+        setConversationLoading(agent.key, false);
+      }
+    });
+  }
   if (cached?.loading) return;
   if (!force && cached && cached.revision === agent.revision && !cached.loading) return;
 
@@ -3142,7 +3871,10 @@ function replaceView(html) {
   const snapshot = sameRoute ? captureViewState(preservedPollContent) : null;
   clearSummaryAttachmentOverlay();
   const reconciled = liveEditorPlan ? reconcileViewAroundEditor(liveEditorPlan) : false;
-  if (reconciled) syncLiveEditorPromptQueue(liveEditorPlan);
+  if (reconciled) {
+    syncLiveEditorPromptQueue(liveEditorPlan);
+    syncLiveEditorInquiryControls(liveEditorPlan);
+  }
   if (!reconciled && state.speechRecognition) stopSpeechMode({ immediate: true });
   if (!reconciled) replaceViewContent(html);
   transplantPreservedPollContent(els.view, preservedPollContent);
@@ -3224,23 +3956,118 @@ function reconcileViewAroundEditor(plan) {
 }
 
 function syncLiveEditorPromptQueue(plan) {
-  syncPromptQueueElement(plan.editor, plan.incomingEditor.querySelector("[data-prompt-queue]"));
+  const currentDock = promptQueueDockFor(plan.editor, els.view);
+  const incomingDock = promptQueueDockFor(plan.incomingEditor, plan.incomingRoot);
+  if (!currentDock || !incomingDock) return;
+
+  syncPromptQueueElement(currentDock, promptQueueElementFor(incomingDock));
 }
 
-function syncPromptQueueElement(editor, incoming) {
-  const current = editor.querySelector("[data-prompt-queue]");
+function syncLiveEditorInquiryControls(plan) {
+  const currentActions = Array.from(plan.editor.querySelectorAll("[data-inquiry-lifecycle-action]"));
+  const incomingActions = Array.from(plan.incomingEditor.querySelectorAll("[data-inquiry-lifecycle-action]"));
+  const incomingErrors = new Set();
+
+  incomingActions.forEach((incomingAction) => {
+    const currentAction = currentActions.find((candidate) =>
+      candidate.dataset.inquiryLifecycleAction === incomingAction.dataset.inquiryLifecycleAction &&
+      candidate.dataset.inquiryId === incomingAction.dataset.inquiryId
+    );
+    if (!currentAction) return;
+
+    syncElementAttributes(currentAction, incomingAction);
+    currentAction.disabled = incomingAction.disabled;
+    const incomingError = incomingAction.closest(".inquiry-lifecycle-action")?.querySelector("[data-pa-control-error]");
+    const currentWrapper = currentAction.closest(".inquiry-lifecycle-action");
+    const currentError = currentWrapper?.querySelector("[data-pa-control-error]");
+    if (incomingError) {
+      const errorKey = incomingError.dataset.paControlError || "";
+      incomingErrors.add(errorKey);
+      if (currentError) {
+        syncElementAttributes(currentError, incomingError);
+        currentError.textContent = incomingError.textContent;
+      } else {
+        currentWrapper?.insertBefore(incomingError.cloneNode(true), currentWrapper.firstChild);
+      }
+    } else {
+      currentError?.remove();
+    }
+  });
+
+  currentActions.forEach((currentAction) => {
+    const currentError = currentAction.closest(".inquiry-lifecycle-action")?.querySelector("[data-pa-control-error]");
+    if (currentError && !incomingErrors.has(currentError.dataset.paControlError || "")) currentError.remove();
+  });
+}
+
+function promptQueueDockFor(editor, root) {
+  return editor?.closest?.("[data-agent-dock]") || root?.querySelector?.("[data-agent-dock]") || null;
+}
+
+function promptQueueElementFor(dock) {
+  if (!dock) return null;
+  return Array.from(dock.children).find((element) => element.matches("[data-prompt-queue]")) ||
+    dock.querySelector("[data-prompt-queue]");
+}
+
+function promptQueueInsertionAnchor(dock) {
+  return Array.from(dock.children).find((element) => element.matches("#composer, #inquiry-form, .inquiry-loading-skeleton")) || null;
+}
+
+function insertPromptQueueIntoDock(dock, queue) {
+  const anchor = promptQueueInsertionAnchor(dock);
+  if (anchor) dock.insertBefore(queue, anchor);
+  else dock.appendChild(queue);
+}
+
+function syncPromptQueueElement(dock, incoming) {
+  if (!dock) return;
+  const currentElements = Array.from(dock.querySelectorAll("[data-prompt-queue]"));
+  const current = promptQueueElementFor(dock) || currentElements[0] || null;
   if (!incoming) {
-    current?.remove();
+    currentElements.forEach((element) => element.remove());
     return;
   }
 
   if (current) {
+    const editState = new Map(Array.from(current.querySelectorAll("[data-prompt-queue-edit-form]")).map((form) => {
+      const textarea = form.querySelector("textarea");
+      return [form.dataset.entryId, {
+        active: form.contains(document.activeElement),
+        end: textarea?.selectionEnd,
+        hidden: form.classList.contains("hidden"),
+        start: textarea?.selectionStart,
+        value: textarea?.value,
+      }];
+    }));
     incoming.open = current.open;
-    current.replaceWith(incoming);
+    if (current.parentElement === dock) current.replaceWith(incoming);
+    else {
+      insertPromptQueueIntoDock(dock, incoming);
+      current.remove();
+    }
+    editState.forEach((snapshot, entryId) => {
+      const form = incoming.querySelector(`[data-prompt-queue-edit-form][data-entry-id="${CSS.escape(entryId)}"]`);
+      if (!form) return;
+      form.classList.toggle("hidden", snapshot.hidden);
+      const textarea = form.querySelector("textarea");
+      if (textarea && snapshot.value !== undefined) {
+        textarea.value = snapshot.value;
+        if (snapshot.active) {
+          textarea.focus({ preventScroll: true });
+          if (snapshot.start !== undefined && snapshot.end !== undefined) {
+            const start = Math.min(snapshot.start, textarea.value.length);
+            const end = Math.min(snapshot.end, textarea.value.length);
+            textarea.setSelectionRange(start, end);
+          }
+        }
+      }
+    });
+    currentElements.filter((element) => element !== current).forEach((element) => element.remove());
     return;
   }
 
-  (editor.querySelector(".composer-content") || editor).prepend(incoming);
+  insertPromptQueueIntoDock(dock, incoming);
 }
 
 function reconcileNodesAroundAnchor(currentAnchor, incomingAnchor, currentRoot, incomingRoot) {
@@ -3529,6 +4356,13 @@ function formDraftRouteKey(form) {
   return routeStateKey(parseRoute());
 }
 
+function noteComposerDraftRevision(form) {
+  const key = String(form?.dataset?.agentKey || "");
+  if (!key) return 0;
+  state.composerDraftRevisions[key] = (state.composerDraftRevisions[key] || 0) + 1;
+  return state.composerDraftRevisions[key];
+}
+
 function transferPersonalAssistantDraftArtifacts(previousKey, nextKey) {
   const from = String(previousKey || "");
   const to = String(nextKey || "");
@@ -3592,9 +4426,9 @@ function persistOptimisticPromptQueue(agentKey, entries) {
   }
 }
 
-function addOptimisticPromptQueueEntry(agentKey, prompt, attachments = []) {
+function addOptimisticPromptQueueEntry(agentKey, prompt, attachments = [], entryId = "") {
   const entry = {
-    id: `client-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    id: entryId || `client-${Date.now()}-${Math.random().toString(16).slice(2)}`,
     prompt,
     state: "submitting",
     attachments: attachments.map((attachment) => ({
@@ -4896,6 +5730,81 @@ function personalAssistantHasRealConversation(blocks) {
   return blocks.some((block) => block?.kind === "message" && ["user", "assistant"].includes(block.role));
 }
 
+function personalAssistantBlockMatchesSubmission(block, record) {
+  if (!block || !record) return false;
+  return personalAssistantBlockRequestIds(block).includes(record.client_request_id);
+}
+
+function reconcilePersonalAssistantConversation(agentKey, blocks) {
+  loadPersonalAssistantSubmissionStates();
+  const key = String(agentKey || "");
+  const conversation = Array.isArray(blocks) ? blocks : [];
+  personalAssistantSubmissionEntries({ serverKey: personalAssistantServerKey(), session: personalAssistantSessionContext() }).forEach((record) => {
+    if (record.agent_key && record.agent_key !== key) return;
+    if (!conversation.some((block) => personalAssistantBlockMatchesSubmission(block, record))) return;
+    updatePersonalAssistantSubmission(record.client_request_id, record.state, {
+      server_key: record.server_key,
+      active_key: record.active_key,
+      generation: record.generation,
+      agent_key: key,
+      message_recorded: true,
+    });
+  });
+}
+
+function renderPersonalAssistantSubmissionRecovery() {
+  loadPersonalAssistantSubmissionStates();
+  const records = personalAssistantSubmissionEntries({ serverKey: personalAssistantServerKey(), session: personalAssistantSessionContext() })
+    .filter((record) => ["failed", "unknown"].includes(normalizePersonalAssistantSubmissionState(record.state)))
+    .sort((left, right) => String(right.updated_at || "").localeCompare(String(left.updated_at || "")))
+    .slice(0, 4);
+  if (!records.length) return "";
+  return "<section class=\"pa-submission-recovery\" aria-label=\"FRED message delivery\" aria-live=\"polite\">"
+    + "<h3>Message delivery</h3>"
+    + records.map((record) => {
+      const stateName = normalizePersonalAssistantSubmissionState(record.state);
+      const unknown = stateName === "unknown";
+      const failureCopy = personalAssistantSubmissionFailureCopy(record);
+      const heading = unknown ? "Delivery status is unknown" : failureCopy.heading;
+      const detail = record.error || (unknown ? "Tycho could not prove whether FRED accepted this message. Check its acceptance record before sending it again." : failureCopy.detail);
+      return "<article class=\"" + (unknown ? "unknown" : "failed") + "\" data-pa-submission-recovery=\"" + escapeAttr(record.client_request_id) + "\" data-pa-submission-failure-kind=\"" + escapeAttr(failureCopy.kind) + "\" role=\"alert\">"
+        + "<strong>" + escapeHtml(heading) + "</strong><p>" + escapeHtml(detail) + "</p><blockquote>" + escapeHtml(record.prompt || "Message unavailable") + "</blockquote>"
+        + "<div class=\"pa-submission-recovery-actions\"><button class=\"ui-button\" type=\"button\" data-check-pa-submission=\"" + escapeAttr(record.client_request_id) + "\">Check acceptance status</button></div>"
+        + "</article>";
+    }).join("")
+    + "</section>";
+}
+
+function personalAssistantSubmissionFailureCopy(record) {
+  const acceptanceState = String(record?.acceptance_state || record?.acceptance?.state || "").trim().toLowerCase();
+  if (record?.run_terminal_state === "failed") {
+    return {
+      kind: "run",
+      heading: "FRED run failed",
+      detail: "FRED recorded this message, but its run finished with a failure. Review the run before deciding whether to send another message.",
+    };
+  }
+  if (acceptanceState === "start_failed" || record?.acceptance?.code === "start_failed") {
+    return {
+      kind: "start",
+      heading: "FRED run failed to start",
+      detail: "FRED recorded this message, but the requested run could not start. Check the setup before trying again.",
+    };
+  }
+  if (record?.message_recorded || acceptanceState === "message_recorded") {
+    return {
+      kind: "recorded",
+      heading: "Message recorded; run not started",
+      detail: "FRED recorded this message, but no run was started. Check the acceptance status before sending it again.",
+    };
+  }
+  return {
+    kind: "delivery",
+    heading: "Message failed to send",
+    detail: "FRED did not accept this message.",
+  };
+}
+
 function personalAssistantProposalMatchesBlock(proposal, block) {
   const metadata = block?.metadata || {};
   if (String(metadata.personal_assistant_action_proposal_id || "") === String(proposal?.id || "")) return true;
@@ -4953,25 +5862,45 @@ function renderPersonalAssistantSetup(item) {
 }
 
 function renderPersonalAssistant() {
-  const item = state.personalAssistant || { state: "unconfigured", configured: false, config: {}, introduction: "Loading FRED…" };
+  const loaded = state.personalAssistantLoadState === "ready";
+  const item = loaded
+    ? (state.personalAssistant || { state: "unconfigured", configured: false, config: {}, introduction: "FRED is not set up yet." })
+    : null;
   const proposals = state.personalAssistantProposals || [];
   setHeader("FRED", "", "A", { titleHtml: personalAssistantHeaderTitleHtml(), hideSubtitle: true });
   setHeaderMore(personalAssistantMoreMenuHtml(), "FRED actions", "personal-assistant");
+  if (!loaded) {
+    const body = state.personalAssistantLoadState === "error"
+      ? feedbackMessage("FRED is unavailable", state.personalAssistantLoadError || "Refresh to try again.", { intent: "danger" })
+      : tychoLoadingState("Loading FRED", { className: "pa-loading-state", body: "Checking today’s session." });
+    replaceView(renderConversationWorkspace({
+      classNames: ["conversation-only", "agent-workspace-conversation", "personal-assistant-page"],
+      conversationStateKey: "personal-assistant-thread",
+      conversationHtml: body + renderPersonalAssistantSubmissionRecovery(),
+      dockHtml: "",
+      attributes: "data-personal-assistant-state=\"loading\"",
+    }));
+    return;
+  }
   const agent = item.active_key ? (state.agentDetails[item.active_key] || item.agent || null) : null;
   const blocks = agent ? (state.conversations[agent.key]?.blocks || []) : [];
+  const allBlocks = agent ? conversationBlocksForAgent(agent, blocks) : [];
   const blocked = ["closing", "summarizing", "archiving"].includes(item.state);
-  const starter = agent && item.state === "active" && !personalAssistantHasRealConversation(blocks);
+  const starter = agent && item.state === "active" && !personalAssistantHasRealConversation(allBlocks);
   const renderedProposals = new Set();
   const continuity = item.configured ? renderPersonalAssistantContinuity(item, proposals) : "";
   const thread = agent
-    ? `${continuity}${starter ? renderPersonalAssistantWelcome(item) : renderAgentConversationView(agent, blocks, { floatingActions: false, loading: conversationLoading(agent.key), personalAssistant: true, personalAssistantProposals: proposals, renderedPersonalAssistantProposals: renderedProposals })}${renderPersonalAssistantUnattachedProposals(proposals, renderedProposals)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}${blocked ? `<p class="pa-inline-notice">${escapeHtml({ closing: "Finishing today’s conversation. Your draft is kept for the next conversation.", summarizing: "Saving today’s continuity. Your draft is kept for the next conversation.", archiving: "Closing today’s conversation. Your draft is kept for the next conversation." }[item.state] || "FRED is unavailable right now.")}</p>` : ""}`
-    : `${item.configured ? `${continuity}${tychoLoadingState("Loading FRED", { className: "pa-loading-state", body: "Fetching today’s session." })}` : renderPersonalAssistantSetup(item)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}`;
-  const dock = agent && item.state === "active" ? renderAgentComposerPlacement(agent, [], {}).dock : "";
+    ? `${continuity}${starter ? renderPersonalAssistantWelcome(item) : renderAgentConversationView(agent, blocks, { floatingActions: false, loading: conversationLoading(agent.key), personalAssistant: true, personalAssistantProposals: proposals, renderedPersonalAssistantProposals: renderedProposals })}${renderPersonalAssistantUnattachedProposals(proposals, renderedProposals)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}${blocked ? `<p class="pa-inline-notice">${escapeHtml({ closing: "Finishing today’s conversation. Your draft is kept for the next conversation.", summarizing: "Saving today’s continuity. Your draft is kept for the next conversation.", archiving: "Closing today’s conversation. Your draft is kept for the next conversation." }[item.state] || "FRED is unavailable right now.")}</p>` : ""}${renderPersonalAssistantSubmissionRecovery()}`
+    : `${item.configured ? `${continuity}${tychoLoadingState("Loading FRED", { className: "pa-loading-state", body: "Fetching today’s session." })}` : renderPersonalAssistantSetup(item)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}${renderPersonalAssistantSubmissionRecovery()}`;
+  const composerPlacement = agent && item.state === "active"
+    ? renderAgentComposerPlacement(agent, [], {})
+    : { dock: "", overlay: "" };
   replaceView(renderConversationWorkspace({
     classNames: ["conversation-only", "agent-workspace-conversation", "personal-assistant-page"],
     conversationStateKey: "personal-assistant-thread",
     conversationHtml: thread,
-    dockHtml: dock,
+    dockHtml: composerPlacement.dock,
+    overlayHtml: composerPlacement.overlay,
     attributes: `data-personal-assistant-state="${escapeAttr(item.state)}"`,
   }));
 }
@@ -6206,7 +7135,17 @@ function renderAgentConversationView(agent, blocks, options = {}) {
 }
 
 function personalAssistantVisibleConversationBlocks(blocks) {
-  return blocks.filter((block) => block?.kind === "message" && ["user", "assistant"].includes(block.role));
+  return blocks
+    .filter((block) => block?.kind === "message" && ["user", "assistant"].includes(block.role))
+    .map((block) => {
+      const record = personalAssistantSubmissionForBlock(block);
+      return record ? {
+        ...block,
+        client_request_id: record.client_request_id,
+        send_status: record.state,
+        send_error: record.error || "",
+      } : block;
+    });
 }
 
 function renderAgentRelationshipContext(agent) {
@@ -6806,21 +7745,22 @@ function renderAgentPullRequestsToggle(agent) {
 
 function renderAgentComposerPlacement(agent, skills, options = {}) {
   if (agent?.archived) return { dock: "", overlay: "" };
+  const promptQueue = renderPromptQueue(agent);
   const composerState = REMOTE_HELPERS.agentComposerState(agent);
   if (composerState === "inquiry") {
     const inquiryForm = renderInquiryForm(agent, options);
     return state.fullScreenInquiryKeys.has(agent.key)
       ? { dock: "", overlay: inquiryForm }
-      : { dock: `${renderPromptQueue(agent)}${inquiryForm}`, overlay: "" };
+      : { dock: `${promptQueue}${inquiryForm}`, overlay: "" };
   }
   if (composerState === "inquiry-loading") {
-    return { dock: `${renderPromptQueue(agent)}${renderInquiryLoadingSkeleton(agent)}`, overlay: "" };
+    return { dock: `${promptQueue}${renderInquiryLoadingSkeleton(agent)}`, overlay: "" };
   }
 
   const composer = renderAgentComposer(agent, skills, options);
   return state.fullScreenComposerKeys.has(agent.key)
-    ? { dock: "", overlay: composer }
-    : { dock: composer, overlay: "" };
+    ? { dock: promptQueue, overlay: composer }
+    : { dock: `${promptQueue}${composer}`, overlay: "" };
 }
 
 function renderInquiryLoadingSkeleton(agent) {
@@ -6852,7 +7792,6 @@ function renderAgentComposer(agent, skills, options = {}) {
     <form id="composer" class="composer${fullScreen ? " composer-full-screen" : ""}" data-agent-key="${escapeAttr(agent.key)}" data-agent-running="${running ? "true" : "false"}" data-speech-state="${escapeAttr(speechState)}"${modalAttributes}>
       ${fullScreen ? `<button class="icon-button composer-close-button ui-button ui-icon-button" type="button" data-toggle-composer-full-screen="${escapeAttr(agent.key)}" aria-label="Close full-screen editor" title="Close full-screen editor">${iconSvg("x")}</button>` : ""}
       <div class="composer-content">
-        ${renderPromptQueue(agent)}
         <div class="composer-editor-shell">
           <textarea id="prompt-input" name="prompt" rows="2" placeholder="${escapeAttr(placeholder)}" aria-label="Prompt" enterkeyhint="enter"></textarea>
           ${fullScreen ? "" : `<button class="composer-full-screen-button" type="button" data-toggle-composer-full-screen="${escapeAttr(agent.key)}" aria-label="Open full-screen editor" title="Full-screen editor" aria-pressed="false">${iconSvg("maximize2")}</button>`}
@@ -7115,6 +8054,7 @@ function renderInquiryLifecycleMenu(agent, action) {
   const inquiryId = String(inquiry?.id || "").trim();
   if (!inquiryId) return "";
 
+  const controlError = personalAssistantControlError(agent.key, `inquiry-${action}`, inquiryId);
   const pendingAction = state.pendingInquiryActions.get(agent.key);
   const pending = pendingAction === action;
   const label = action === "dismiss" ? "Dismiss inquiry" : "Restore inquiry";
@@ -7127,12 +8067,15 @@ function renderInquiryLifecycleMenu(agent, action) {
     pending ? 'aria-busy="true"' : "",
   ].filter(Boolean).join(" ");
   return `
-    <details class="composer-action-menu" data-overlay-menu data-overlay-key="inquiry-actions:${escapeAttr(agent.key)}" data-state-key="inquiry-actions:${escapeAttr(agent.key)}:${action}">
-      <summary class="ui-button ui-icon-button" aria-label="${pending ? pendingLabel : "Inquiry actions"}" title="Inquiry actions" aria-haspopup="menu"${pending ? ' aria-busy="true"' : ""}>${iconSvg("ellipsis")}</summary>
-      <div class="composer-action-popover ui-overlay-surface" role="menu" aria-label="Inquiry actions" data-overlay-kind="menu">
-        ${moreMenuButton({ label: pending ? pendingLabel : label, icon: action === "dismiss" ? "x" : "rotateCcw", attrs, disabled: Boolean(pendingAction) })}
-      </div>
-    </details>
+    <div class="inquiry-lifecycle-action">
+      ${controlError ? `<div class="pa-control-error inquiry-control-error" role="alert" data-pa-control-error="inquiry-${escapeAttr(action)}:${escapeAttr(inquiryId)}">${escapeHtml(controlError.message)}</div>` : ""}
+      <details class="composer-action-menu" data-overlay-menu data-overlay-key="inquiry-actions:${escapeAttr(agent.key)}" data-state-key="inquiry-actions:${escapeAttr(agent.key)}:${action}">
+        <summary class="ui-button ui-icon-button" aria-label="${pending ? pendingLabel : "Inquiry actions"}" title="Inquiry actions" aria-haspopup="menu"${pending ? ' aria-busy="true"' : ""}>${iconSvg("ellipsis")}</summary>
+        <div class="composer-action-popover ui-overlay-surface" role="menu" aria-label="Inquiry actions" data-overlay-kind="menu">
+          ${moreMenuButton({ label: pending ? pendingLabel : label, icon: action === "dismiss" ? "x" : "rotateCcw", attrs, disabled: Boolean(pendingAction) })}
+        </div>
+      </details>
+    </div>
   `;
 }
 
@@ -7148,6 +8091,7 @@ function renderPromptQueue(agent) {
   const first = entries[0]?.prompt || "Queued prompt";
   const excerpt = first.length > 72 ? `${first.slice(0, 69)}...` : first;
   const error = queue.dispatch_error?.message || "";
+  const retryError = personalAssistantControlError(agent.key, "queue-retry");
   return `
     <details class="prompt-queue" data-prompt-queue data-state-key="agent-prompt-queue:${escapeAttr(agent.key)}">
       <summary>
@@ -7161,6 +8105,7 @@ function renderPromptQueue(agent) {
             <button type="button" class="ui-button" data-retry-prompt-queue="${escapeAttr(agent.key)}">Retry queue</button>
           </div>
         ` : ""}
+        ${retryError ? `<div class="pa-control-error prompt-queue-control-error" role="alert" data-pa-control-error="queue-retry">${escapeHtml(retryError.message)}</div>` : ""}
         ${queue.blocked_by_inquiry ? `<p class="prompt-queue-blocked" role="status">Queued work will start after the inquiry is answered and its run finishes.</p>` : ""}
         <ol class="prompt-queue-list">
           ${entries.map((entry, index) => renderPromptQueueEntry(agent, entry, index)).join("")}
@@ -7177,6 +8122,8 @@ function renderPromptQueueEntry(agent, entry, index) {
     entry.state === "dispatching" ? "Dispatching" :
       entry.state === "submitting" ? "Queueing..." : "Queued";
   const attachmentLabel = attachments.length ? ` · ${attachments.length} attachment${attachments.length === 1 ? "" : "s"}` : "";
+  const editError = personalAssistantControlError(agent.key, "queue-edit", entry.id);
+  const deleteError = personalAssistantControlError(agent.key, "queue-delete", entry.id);
   return `
     <li class="prompt-queue-entry" data-prompt-queue-entry="${escapeAttr(entry.id)}">
       <div class="prompt-queue-entry-copy">
@@ -7187,7 +8134,9 @@ function renderPromptQueueEntry(agent, entry, index) {
         <button type="button" class="ui-button" data-edit-queued-prompt="${escapeAttr(entry.id)}" data-agent-key="${escapeAttr(agent.key)}" ${editable ? "" : "disabled"}>Edit</button>
         <button type="button" class="ui-button" data-delete-queued-prompt="${escapeAttr(entry.id)}" data-agent-key="${escapeAttr(agent.key)}" ${editable ? "" : "disabled"}>Delete</button>
       </div>
-      <form class="prompt-queue-edit hidden" data-prompt-queue-edit-form data-agent-key="${escapeAttr(agent.key)}" data-entry-id="${escapeAttr(entry.id)}">
+      ${editError ? `<div class="pa-control-error prompt-queue-control-error" role="alert" data-pa-control-error="queue-edit:${escapeAttr(entry.id)}">${escapeHtml(editError.message)}</div>` : ""}
+      ${deleteError ? `<div class="pa-control-error prompt-queue-control-error" role="alert" data-pa-control-error="queue-delete:${escapeAttr(entry.id)}">${escapeHtml(deleteError.message)}</div>` : ""}
+      <form class="prompt-queue-edit hidden" data-prompt-queue-edit-form data-preserve-open data-state-key="prompt-queue-edit:${escapeAttr(entry.id)}" data-agent-key="${escapeAttr(agent.key)}" data-entry-id="${escapeAttr(entry.id)}">
         <label for="queued-prompt-${escapeAttr(entry.id)}">Edit queued prompt ${index + 1}</label>
         <textarea id="queued-prompt-${escapeAttr(entry.id)}" name="prompt" rows="3">${escapeHtml(entry.prompt)}</textarea>
         <div class="prompt-queue-entry-actions">
@@ -9265,10 +10214,14 @@ function renderMessage(block, options = {}) {
   const ts = blockTimestamp(block);
   const timeHtml = ts ? `<time class="message-time" datetime="${escapeAttr(ts)}">${escapeHtml(relativeTimeShort(ts))}</time>` : "";
   const summaryId = block.kind === "run_summary" ? runSummaryId(block) : "";
-  const pendingStatus = block.pending ? `<div class="message-send-status">sending...</div>` : "";
+  const sendState = personalAssistantMessageSendState(block, options);
+  const pendingStatus = sendState
+    ? `<div class="message-send-status pa-message-send-status ${escapeAttr(personalAssistantSubmissionStateIntent(sendState))}" data-pa-message-status="${escapeAttr(sendState)}" role="status" aria-live="polite">${escapeHtml(personalAssistantSubmissionStateLabel(sendState))}</div>`
+    : block.pending ? `<div class="message-send-status">sending...</div>` : "";
   const identity = personalAssistantMessageIdentity(block, options);
+  const requestId = options.personalAssistant ? personalAssistantBlockRequestId(block) : "";
   return `
-    <article class="${escapeAttr(messageClassName(block))}"${summaryId ? ` data-run-summary-id="${escapeAttr(summaryId)}"` : ""}>
+    <article class="${escapeAttr(messageClassName(block))}"${summaryId ? ` data-run-summary-id="${escapeAttr(summaryId)}"` : ""}${requestId ? ` data-client-request-id="${escapeAttr(requestId)}"` : ""}>
       <div class="message-header">
         <div class="message-role">${identity || `${messageIcon(block)}<span>${escapeHtml(messageRoleLabel(block))}</span>`}${timeHtml}</div>
         ${block.pending ? "" : renderBlockMenuAnchor(block, menuId)}
@@ -9278,6 +10231,13 @@ function renderMessage(block, options = {}) {
     </article>
     ${pendingStatus}
   `;
+}
+
+function personalAssistantMessageSendState(block, options = {}) {
+  if (!options.personalAssistant || block?.kind !== "message" || block.role !== "user") return "";
+  const explicit = normalizePersonalAssistantSubmissionState(block.send_status, "");
+  if (explicit) return explicit;
+  return personalAssistantSubmissionForBlock(block)?.state || (block.pending ? "sending" : "");
 }
 
 function personalAssistantMessageIdentity(block, options = {}) {
@@ -9819,7 +10779,7 @@ function renderPendingAttachment(agentKey, attachment) {
   `;
 }
 
-function pendingPromptMessageBlock(agentKey, prompt, attachments = [], pullRequestContexts = []) {
+function pendingPromptMessageBlock(agentKey, prompt, attachments = [], pullRequestContexts = [], clientRequestId = "") {
   const metadataAttachments = attachments.map((attachment) => ({
     title: attachment.filename,
     target: attachment.filename,
@@ -9835,7 +10795,9 @@ function pendingPromptMessageBlock(agentKey, prompt, attachments = [], pullReque
     content: prompt,
     created_at: new Date().toISOString(),
     pending: true,
+    ...(clientRequestId ? { client_request_id: clientRequestId, send_status: "sending" } : {}),
     metadata: {
+      ...(clientRequestId ? { personal_assistant_client_request_id: clientRequestId } : {}),
       ...(metadataAttachments.length ? { attachments: metadataAttachments } : {}),
       ...(pullRequestContexts.length ? { pull_request_contexts: pullRequestContexts.map((context) => ({
         repository: context.repository,
@@ -9874,6 +10836,16 @@ function removePendingConversationMessage(agentKey, id, options = {}) {
   render();
 }
 
+function updatePendingPersonalAssistantMessage(agentKey, messageId, nextState, errorMessage = "") {
+  const key = String(agentKey || "");
+  if (!key || !messageId) return;
+  (state.pendingConversationMessages[key] || []).forEach((block) => {
+    if (block.id !== messageId) return;
+    block.send_status = normalizePersonalAssistantSubmissionState(nextState);
+    block.send_error = String(errorMessage || "");
+  });
+}
+
 async function submitComposerPrompt(options) {
   const {
     form,
@@ -9885,7 +10857,51 @@ async function submitComposerPrompt(options) {
     submittedPullRequestContexts,
     pendingMessageId,
     retireInquiryId,
+    endpointAdapter,
+    personalAssistant,
+    clientRequestId,
+    draftRevision,
+    routeHashAtSubmit,
+    personalAssistantSubmission,
   } = options;
+  const adapter = endpointAdapter || personalAssistantEndpointAdapter(key, { personalAssistant: personalAssistant === true });
+  const isPersonalAssistant = personalAssistant === undefined ? adapter.personalAssistant : personalAssistant === true;
+  const submissionId = clientRequestId || (isPersonalAssistant ? createPersonalAssistantClientRequestId() : "");
+  const capturedContext = adapter.context;
+  const capturedRouteHash = routeHashAtSubmit || location.hash;
+  const currentPersonalAssistantRequest = () => personalAssistantRequestIsCurrent(adapter, capturedRouteHash);
+  const applyPersonalAssistantResponse = (response) => {
+    const acceptance = response?.acceptance || {};
+    const nextState = personalAssistantSubmissionStateFromResponse(response);
+    const responseConversation = Array.isArray(response?.conversation) ? response.conversation : [];
+    const existing = findPersonalAssistantSubmission(submissionId, {
+      serverKey: capturedContext?.server_key || personalAssistantServerKey(),
+    });
+    const messageRecorded = responseConversation.some((block) => personalAssistantBlockRequestIds(block).includes(submissionId));
+    const record = updatePersonalAssistantSubmission(submissionId, nextState, {
+      acceptance,
+      acceptance_state: personalAssistantAcceptanceState(response),
+      error: "",
+      server_key: capturedContext?.server_key || personalAssistantServerKey(),
+      active_key: response?.active_key || capturedContext?.active_key || "",
+      generation: response?.generation ?? capturedContext?.generation,
+      agent_key: key,
+      message_recorded: Boolean(existing?.message_recorded || messageRecorded),
+    });
+    if (!currentPersonalAssistantRequest()) return record;
+    if (response.agent) upsertAgent(response.agent);
+    if (responseConversation.length) {
+      state.conversations[key] = {
+        revision: response.agent?.revision || state.conversations[key]?.revision,
+        blocks: responseConversation,
+        loaded: true,
+        loading: false,
+      };
+      reconcilePersonalAssistantConversation(key, responseConversation);
+      reconcilePersonalAssistantTerminalRuns(key, responseConversation);
+    }
+    return record;
+  };
 
   try {
     setConnection(queueing ? "Queueing" : "Sending");
@@ -9893,20 +10909,26 @@ async function submitComposerPrompt(options) {
     const pullRequestContexts = submittedPullRequestContexts.map((context) => ({
       ...promptPullRequestContextPayload(context, { includeComment: true }),
     }));
-    const personalAssistant = parseRoute().type === "personalAssistant" && state.personalAssistant?.active_key === key;
-    const response = await apiPost(personalAssistant ? "/personal-assistant/messages" : `/agents/${encodeURIComponent(key)}/messages`, {
+    const response = await apiPost(adapter.messagePath, adapter.writeBody({
       prompt,
       start: true,
       attachments,
       pull_request_contexts: pullRequestContexts,
       ...(retireInquiryId ? { retire_inquiry_id: retireInquiryId } : {}),
-      ...(optimisticQueueEntry ? { client_request_id: optimisticQueueEntry.id } : {}),
-    });
-    if (response.agent) upsertAgent(response.agent);
-    if (optimisticQueueEntry && !response.queued) {
+    }, isPersonalAssistant ? submissionId : (optimisticQueueEntry?.id || "")));
+    const submissionRecord = isPersonalAssistant ? applyPersonalAssistantResponse(response) : null;
+    const responseState = isPersonalAssistant
+      ? submissionRecord?.state
+      : response.queued ? "queued" : "accepted";
+    const queueAccepted = responseState === "queued";
+    if (!isPersonalAssistant && response.agent) upsertAgent(response.agent);
+    if (optimisticQueueEntry && !queueAccepted) {
       removeOptimisticPromptQueueEntry(key, optimisticQueueEntry.id);
+    } else if (optimisticQueueEntry) {
+      optimisticQueueEntry.state = "queued";
+      persistOptimisticPromptQueue(key, optimisticPromptQueueEntries(key));
     }
-    if (Array.isArray(response.conversation)) {
+    if (!isPersonalAssistant && Array.isArray(response.conversation)) {
       state.conversations[key] = {
         revision: response.agent?.revision,
         blocks: response.conversation,
@@ -9914,17 +10936,42 @@ async function submitComposerPrompt(options) {
         loading: false,
       };
     }
-    if (response.queued) showGrowl("Prompt queued", "done");
+    if (response.queued || responseState === "queued") showGrowl("Prompt queued", "done");
     submittedAttachments.forEach(revokePendingAttachment);
     if (!queueing) setComposerSending(form, false);
-    removePendingConversationMessage(key, pendingMessageId, { render: false });
+    if (!isPersonalAssistant) removePendingConversationMessage(key, pendingMessageId, { render: false });
     state.failureCount = 0;
-    navigate(personalAssistant ? { type: "personalAssistant" } : { type: "agent", key });
-    state.renderedViewHtml = "";
-    render();
-    await refresh({ force: true, forceConversation: true, forcePreflight: true, forceProject: true });
+    if (isPersonalAssistant) {
+      if (currentPersonalAssistantRequest()) {
+        state.renderedViewHtml = "";
+        render({ preserveLiveEditor: true });
+        await refresh({ force: true, forceConversation: true });
+      }
+    } else {
+      navigate({ type: "agent", key });
+      state.renderedViewHtml = "";
+      render();
+      await refresh({ force: true, forceConversation: true, forcePreflight: true, forceProject: true });
+    }
   } catch (error) {
     state.failureCount += 1;
+    if (isPersonalAssistant) {
+      const nextState = personalAssistantSubmissionStateFromError(error);
+      const acceptance = error?.data?.acceptance || error?.details?.acceptance;
+      if (personalAssistantSubmission) {
+        updatePersonalAssistantSubmission(submissionId, nextState, {
+          acceptance: acceptance || personalAssistantSubmission.acceptance || null,
+          acceptance_state: acceptance ? personalAssistantAcceptanceState({ acceptance }) : personalAssistantSubmission.acceptance_state,
+          error: error.message,
+          server_key: capturedContext?.server_key || personalAssistantServerKey(),
+          active_key: capturedContext?.active_key || "",
+          generation: capturedContext?.generation,
+          agent_key: key,
+        });
+      } else {
+        updatePendingPersonalAssistantMessage(key, pendingMessageId, nextState, error.message);
+      }
+    }
     removeOptimisticPromptQueueEntry(key, optimisticQueueEntry?.id);
     restoreSubmittedAttachments(key, submittedAttachments);
     const currentContexts = pendingPullRequestContextsFor(key);
@@ -9935,16 +10982,21 @@ async function submitComposerPrompt(options) {
     ];
     const input = document.querySelector(`#composer[data-agent-key="${CSS.escape(key)}"] #prompt-input`) ||
       form?.querySelector?.("#prompt-input");
-    if (input && !input.value.trim()) input.value = prompt;
-    setConnection(error.message);
-    state.renderedViewHtml = "";
-    render();
-    schedule();
+    const draftChanged = (state.composerDraftRevisions[key] || 0) !== Number(draftRevision || 0);
+    if (currentPersonalAssistantRequest() && input && !draftChanged && !input.value.trim()) input.value = prompt;
+    if (currentPersonalAssistantRequest()) {
+      setConnection(isPersonalAssistant ? `FRED: ${error.message}` : error.message, { preserveHeaderSubtitle: isPersonalAssistant });
+      state.renderedViewHtml = "";
+      render({ preserveLiveEditor: isPersonalAssistant });
+      schedule();
+    }
   } finally {
     if (!queueing) setComposerSending(form, false);
-    removePendingConversationMessage(key, pendingMessageId);
-    state.renderedViewHtml = "";
-    render();
+    if (!isPersonalAssistant) removePendingConversationMessage(key, pendingMessageId, { render: false });
+    if (currentPersonalAssistantRequest()) {
+      state.renderedViewHtml = "";
+      render({ preserveLiveEditor: isPersonalAssistant });
+    }
   }
 }
 
@@ -13962,14 +15014,18 @@ function urlBase64ToUint8Array(value) {
 async function mutate(callback, options = {}) {
   clearTimeout(state.timer);
   const form = options.form || null;
+  const current = () => !options.isCurrent || options.isCurrent();
   if (form) setFormPending(form, true);
   try {
     setConnection("Saving");
     await callback();
+    if (!current()) return;
     state.failureCount = 0;
     await refresh({ force: true, forceConversation: true, forcePreflight: true, forceProject: true });
   } catch (error) {
+    if (!current()) return;
     state.failureCount += 1;
+    options.onError?.(error);
     setConnection(error.message);
     render();
     schedule();
@@ -14296,12 +15352,17 @@ async function runInquiryLifecycleAction(button) {
   state.pendingInquiryActions.set(key, action);
   state.renderedViewHtml = "";
   render();
+  const adapter = personalAssistantEndpointAdapter(key);
+  const routeHashAtStart = location.hash;
+  const currentRequest = () => personalAssistantRequestIsCurrent(adapter, routeHashAtStart);
   try {
+    clearPersonalAssistantControlError(key, `inquiry-${action}`, inquiryId, adapter.context);
     setConnection(action === "dismiss" ? "Dismissing inquiry" : "Restoring inquiry");
     const response = await apiPost(
-      `/agents/${encodeURIComponent(key)}/inquiries/${encodeURIComponent(inquiryId)}/${action}`,
-      {}
+      adapter.inquiryPath(inquiryId, action),
+      adapter.writeBody({})
     );
+    if (!currentRequest()) return;
     if (response.agent) upsertAgent(response.agent);
     if (Array.isArray(response.conversation)) {
       state.conversations[key] = {
@@ -14311,19 +15372,28 @@ async function runInquiryLifecycleAction(button) {
         loading: false,
       };
     }
+    clearPersonalAssistantControlError(
+      key,
+      `inquiry-${action === "dismiss" ? "restore" : "dismiss"}`,
+      inquiryId,
+      adapter.context
+    );
     showGrowl(action === "dismiss" ? "Inquiry dismissed" : "Inquiry restored", "done");
     state.failureCount = 0;
-    await refresh({ force: true, forceConversation: true });
+    void refresh({ force: true, forceConversation: true });
   } catch (error) {
+    if (currentRequest()) setPersonalAssistantControlError(key, `inquiry-${action}`, inquiryId, error, adapter.context);
     state.failureCount += 1;
     const label = action === "dismiss" ? "dismiss" : "restore";
     showGrowl(`Could not ${label} inquiry: ${error.message}`, "need");
     setConnection(error.message);
   } finally {
     state.pendingInquiryActions.delete(key);
-    state.renderedViewHtml = "";
-    render();
-    schedule();
+    if (currentRequest()) {
+      state.renderedViewHtml = "";
+      render({ preserveLiveEditor: adapter.personalAssistant });
+      schedule();
+    }
   }
 }
 
@@ -14439,6 +15509,18 @@ function handleViewClick(event) {
     if (input) { input.value = suggestion.dataset.paSuggestion; input.focus(); input.dispatchEvent(new Event("input", { bubbles: true })); }
     return;
   }
+  const checkPersonalAssistantSubmission = event.target.closest("[data-check-pa-submission]");
+  if (checkPersonalAssistantSubmission) {
+    const clientRequestId = checkPersonalAssistantSubmission.dataset.checkPaSubmission;
+    requestPersonalAssistantAcceptance(clientRequestId).then((data) => {
+      if (data?.acceptance) {
+        showGrowl(`FRED acceptance: ${personalAssistantSubmissionStateLabel(data.acceptance.state)}`, "done");
+      } else {
+        showGrowl("No acceptance record found; nothing was retried.", "need");
+      }
+    }).catch((error) => showGrowl(`Could not check FRED acceptance: ${error.message}`, "need"));
+    return;
+  }
   const inquiryLifecycleAction = event.target.closest("[data-inquiry-lifecycle-action]");
   if (inquiryLifecycleAction) {
     closeDetailsOverlay(inquiryLifecycleAction.closest("[data-overlay-menu]"));
@@ -14462,20 +15544,58 @@ function handleViewClick(event) {
   if (deleteQueuedPrompt) {
     const agentKey = deleteQueuedPrompt.dataset.agentKey;
     const entryId = deleteQueuedPrompt.dataset.deleteQueuedPrompt;
+    const adapter = personalAssistantEndpointAdapter(agentKey);
+    const routeHashAtStart = location.hash;
+    const currentRequest = () => personalAssistantRequestIsCurrent(adapter, routeHashAtStart);
+    clearPersonalAssistantControlError(agentKey, "queue-delete", entryId, adapter.context);
     mutate(async () => {
-      const response = await apiDelete(`/agents/${encodeURIComponent(agentKey)}/prompt-queue/${encodeURIComponent(entryId)}`);
+      const response = await apiDelete(adapter.queuePath(entryId), adapter.writeBody({}));
+      if (!currentRequest()) return;
+      if (adapter.personalAssistant) clearPersonalAssistantControlError(agentKey, "queue-delete", entryId, adapter.context);
+      if (adapter.personalAssistant && (response.canceled || response.acceptance?.state === "canceled")) {
+        const submission = personalAssistantSubmissionForQueueEntry(entryId, response);
+        const clientRequestId = String(response.client_request_id || response.acceptance?.client_request_id || submission?.client_request_id || "").trim();
+        if (clientRequestId) {
+          updatePersonalAssistantSubmission(clientRequestId, "canceled", {
+            acceptance: response.acceptance || submission?.acceptance || null,
+            acceptance_state: personalAssistantAcceptanceState(response),
+            server_key: adapter.context.server_key,
+            active_key: response.active_key || adapter.context.active_key,
+            generation: response.generation ?? adapter.context.generation,
+            agent_key: agentKey,
+            queue_entry_id: entryId,
+            message_recorded: Boolean(submission?.message_recorded),
+          });
+        }
+      }
       if (response.agent) upsertAgent(response.agent);
       showGrowl("Queued prompt deleted", "done");
+    }, {
+      isCurrent: currentRequest,
+      onError: (error) => {
+        if (adapter.personalAssistant) setPersonalAssistantControlError(agentKey, "queue-delete", entryId, error, adapter.context);
+      },
     });
     return;
   }
   const retryPromptQueue = event.target.closest("[data-retry-prompt-queue]");
   if (retryPromptQueue) {
     const agentKey = retryPromptQueue.dataset.retryPromptQueue;
+    const adapter = personalAssistantEndpointAdapter(agentKey);
+    const routeHashAtStart = location.hash;
+    const currentRequest = () => personalAssistantRequestIsCurrent(adapter, routeHashAtStart);
+    clearPersonalAssistantControlError(agentKey, "queue-retry", "", adapter.context);
     mutate(async () => {
-      const response = await apiPost(`/agents/${encodeURIComponent(agentKey)}/prompt-queue/retry`, {});
+      const response = await apiPost(adapter.queueRetryPath, adapter.writeBody({}));
+      if (!currentRequest()) return;
+      if (adapter.personalAssistant) clearPersonalAssistantControlError(agentKey, "queue-retry", "", adapter.context);
       if (response.agent) upsertAgent(response.agent);
       showGrowl("Queue dispatch retried", "done");
+    }, {
+      isCurrent: currentRequest,
+      onError: (error) => {
+        if (adapter.personalAssistant) setPersonalAssistantControlError(agentKey, "queue-retry", "", error, adapter.context);
+      },
     });
     return;
   }
@@ -15485,6 +16605,7 @@ els.view.addEventListener("input", (event) => {
 
   const draftForm = event.target.closest("#composer, #inquiry-form");
   if (draftForm && draftableTextControl(event.target)) {
+    if (draftForm.id === "composer") noteComposerDraftRevision(draftForm);
     queueComposerDraftSave(draftForm);
   }
 });
@@ -15756,11 +16877,36 @@ els.view.addEventListener("submit", (event) => {
     const entryId = form.dataset.entryId;
     const prompt = String(new FormData(form).get("prompt") || "").trim();
     if (!agentKey || !entryId || !prompt) return;
+    const adapter = personalAssistantEndpointAdapter(agentKey);
+    const routeHashAtStart = location.hash;
+    const currentRequest = () => personalAssistantRequestIsCurrent(adapter, routeHashAtStart);
+    clearPersonalAssistantControlError(agentKey, "queue-edit", entryId, adapter.context);
     mutate(async () => {
-      const response = await apiPatch(`/agents/${encodeURIComponent(agentKey)}/prompt-queue/${encodeURIComponent(entryId)}`, { prompt });
+      const response = await apiPatch(adapter.queuePath(entryId), adapter.writeBody({ prompt }));
+      if (!currentRequest()) return;
+      if (adapter.personalAssistant) {
+        clearPersonalAssistantControlError(agentKey, "queue-edit", entryId, adapter.context);
+        const submission = personalAssistantSubmissionForQueueEntry(entryId, response);
+        if (submission) {
+          updatePersonalAssistantSubmission(submission.client_request_id, submission.state, {
+            prompt,
+            server_key: adapter.context.server_key,
+            active_key: adapter.context.active_key,
+            generation: adapter.context.generation,
+            agent_key: agentKey,
+            queue_entry_id: entryId,
+          });
+        }
+      }
       if (response.agent) upsertAgent(response.agent);
       showGrowl("Queued prompt updated", "done");
-    }, { form });
+    }, {
+      form,
+      isCurrent: currentRequest,
+      onError: (error) => {
+        if (adapter.personalAssistant) setPersonalAssistantControlError(agentKey, "queue-edit", entryId, error, adapter.context);
+      },
+    });
     return;
   }
 
@@ -15778,6 +16924,11 @@ els.view.addEventListener("submit", (event) => {
       ? "Please review the attached files."
       : submittedPullRequestContexts.length ? "Please review the attached pull request context." : "");
     if (!key || !prompt) return;
+    const endpointAdapter = personalAssistantEndpointAdapter(key);
+    const personalAssistant = endpointAdapter.personalAssistant && parseRoute().type === "personalAssistant";
+    const clientRequestId = personalAssistant ? createPersonalAssistantClientRequestId() : "";
+    const draftRevision = state.composerDraftRevisions[key] || 0;
+    const routeHashAtSubmit = location.hash;
     const queueing = agentComposerRunning(findAgent(key));
     state.fullScreenComposerKeys.delete(key);
     state.pendingPromptAttachments[key] = [];
@@ -15788,11 +16939,20 @@ els.view.addEventListener("submit", (event) => {
     else form.querySelector("#prompt-input").value = "";
     clearFormDraft(form);
     const optimisticQueueEntry = queueing
-      ? addOptimisticPromptQueueEntry(key, prompt, pendingAttachments)
+      ? addOptimisticPromptQueueEntry(key, prompt, pendingAttachments, clientRequestId)
+      : null;
+    const personalAssistantSubmission = personalAssistant && endpointAdapter.context
+      ? rememberPersonalAssistantSubmission({
+        clientRequestId,
+        prompt,
+        agentKey: key,
+        context: endpointAdapter.context,
+        draftRevision,
+      })
       : null;
     const pendingMessageId = queueing ? "" : addPendingConversationMessage(
       key,
-      pendingPromptMessageBlock(key, prompt, pendingAttachments, submittedPullRequestContexts)
+      pendingPromptMessageBlock(key, prompt, pendingAttachments, submittedPullRequestContexts, clientRequestId)
     );
     if (queueing) {
       state.renderedViewHtml = "";
@@ -15812,6 +16972,12 @@ els.view.addEventListener("submit", (event) => {
       submittedPullRequestContexts,
       pendingMessageId,
       retireInquiryId: String(findAgent(key)?.suspended_inquiry?.id || ""),
+      endpointAdapter,
+      personalAssistant,
+      clientRequestId,
+      draftRevision,
+      routeHashAtSubmit,
+      personalAssistantSubmission,
     });
     return;
   }
@@ -15830,16 +16996,59 @@ els.view.addEventListener("submit", (event) => {
 
     const answer = inquiryAnswerPayload(form);
     const feedback = String(new FormData(form).get("feedback") || "").trim();
+    const adapter = personalAssistantEndpointAdapter(key);
+    const answerClientRequestId = adapter.personalAssistant ? createPersonalAssistantClientRequestId("inquiry") : "";
+    const answerSubmission = adapter.personalAssistant && adapter.context
+      ? rememberPersonalAssistantSubmission({
+        clientRequestId: answerClientRequestId,
+        prompt: typeof answer === "string" ? answer : JSON.stringify(answer),
+        agentKey: key,
+        context: adapter.context,
+        draftRevision: state.composerDraftRevisions[key] || 0,
+      })
+      : null;
+    const routeHashAtStart = location.hash;
+    const currentRequest = () => personalAssistantRequestIsCurrent(adapter, routeHashAtStart);
     state.fullScreenInquiryKeys.delete(key);
     state.expandedInquiryKeys.delete(`${key}:${inquiryId}`);
     schedule();
     closeAttachmentFlyout();
     mutate(async () => {
       const attachments = await pendingAttachmentPayloads(key);
-      await apiPost(`/agents/${encodeURIComponent(key)}/inquiries/${encodeURIComponent(inquiryId)}/answer`, { answer, feedback, start: true, attachments });
-      clearPendingAttachments(key);
-      clearFormDraft(form);
-    }, { form });
+      try {
+        const response = await apiPost(
+          adapter.inquiryPath(inquiryId, "answer"),
+          adapter.writeBody({ answer, feedback, start: true, attachments }, answerClientRequestId)
+        );
+        if (answerSubmission) {
+          updatePersonalAssistantSubmission(answerClientRequestId, personalAssistantSubmissionStateFromResponse(response), {
+            acceptance: response.acceptance || {},
+            acceptance_state: personalAssistantAcceptanceState(response),
+            server_key: adapter.context.server_key,
+            active_key: response.active_key || adapter.context.active_key,
+            generation: response.generation ?? adapter.context.generation,
+            agent_key: key,
+          });
+        }
+      } catch (error) {
+        if (answerSubmission) {
+          updatePersonalAssistantSubmission(answerClientRequestId, personalAssistantSubmissionStateFromError(error), {
+            acceptance: error?.data?.acceptance || error?.details?.acceptance || answerSubmission.acceptance || null,
+            acceptance_state: error?.data?.acceptance ? personalAssistantAcceptanceState({ acceptance: error.data.acceptance }) : answerSubmission.acceptance_state,
+            error: error.message,
+            server_key: adapter.context.server_key,
+            active_key: adapter.context.active_key,
+            generation: adapter.context.generation,
+            agent_key: key,
+          });
+        }
+        throw error;
+      }
+      if (currentRequest()) {
+        clearPendingAttachments(key);
+        clearFormDraft(form);
+      }
+    }, { form, isCurrent: currentRequest });
   }
 
 

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2507,7 +2507,7 @@ function personalAssistantAcceptanceState(response) {
   return String(response?.acceptance?.state || response?.state || "").trim().toLowerCase() || "unknown";
 }
 
-function personalAssistantSubmissionStateFromError(error) {
+function personalAssistantSubmissionStateFromError(error, options = {}) {
   const acceptance = error?.data?.acceptance || error?.details?.acceptance;
   const acceptanceState = normalizePersonalAssistantSubmissionState(acceptance, "");
   if (acceptanceState) return acceptanceState;
@@ -2515,6 +2515,7 @@ function personalAssistantSubmissionStateFromError(error) {
   if (code === "acceptance_unknown" || code === "unknown") return "unknown";
   if (code === "start_failed") return "failed";
   if (String(error?.message || "").startsWith("FRED session is unavailable")) return "failed";
+  if (options.beforePost) return "failed";
   if (!error?.status) return "unknown";
   return "failed";
 }
@@ -5777,6 +5778,13 @@ function renderPersonalAssistantSubmissionRecovery() {
 
 function personalAssistantSubmissionFailureCopy(record) {
   const acceptanceState = String(record?.acceptance_state || record?.acceptance?.state || "").trim().toLowerCase();
+  if (record?.failure_stage === "pre_post") {
+    return {
+      kind: "pre_post",
+      heading: "Message was not sent",
+      detail: "Tycho could not prepare this message locally. Your answer and attachments are still here; fix the problem and try again.",
+    };
+  }
   if (record?.run_terminal_state === "failed") {
     return {
       kind: "run",
@@ -17014,8 +17022,10 @@ els.view.addEventListener("submit", (event) => {
     schedule();
     closeAttachmentFlyout();
     mutate(async () => {
-      const attachments = await pendingAttachmentPayloads(key);
+      let postStarted = false;
       try {
+        const attachments = await pendingAttachmentPayloads(key);
+        postStarted = true;
         const response = await apiPost(
           adapter.inquiryPath(inquiryId, "answer"),
           adapter.writeBody({ answer, feedback, start: true, attachments }, answerClientRequestId)
@@ -17032,10 +17042,11 @@ els.view.addEventListener("submit", (event) => {
         }
       } catch (error) {
         if (answerSubmission) {
-          updatePersonalAssistantSubmission(answerClientRequestId, personalAssistantSubmissionStateFromError(error), {
+          updatePersonalAssistantSubmission(answerClientRequestId, personalAssistantSubmissionStateFromError(error, { beforePost: !postStarted }), {
             acceptance: error?.data?.acceptance || error?.details?.acceptance || answerSubmission.acceptance || null,
             acceptance_state: error?.data?.acceptance ? personalAssistantAcceptanceState({ acceptance: error.data.acceptance }) : answerSubmission.acceptance_state,
             error: error.message,
+            failure_stage: postStarted ? "delivery" : "pre_post",
             server_key: adapter.context.server_key,
             active_key: adapter.context.active_key,
             generation: adapter.context.generation,

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -73,7 +73,7 @@ module RemoteUIAssetSnapshotTest
     required_javascript = [
       "function personalAssistantHasRealConversation(blocks)",
       'block?.kind === "message" && ["user", "assistant"].includes(block.role)',
-      "const starter = agent && item.state === \"active\" && !personalAssistantHasRealConversation(blocks);",
+      "const starter = agent && item.state === \"active\" && !personalAssistantHasRealConversation(allBlocks);",
       "${starter ? renderPersonalAssistantWelcome(",
       'querySelector("#composer #prompt-input")',
       "function personalAssistantProjectForPicker",


### PR DESCRIPTION
## Summary

- Finish the Phase 1 FRED Remote UI integration on top of Beta PR114 snapshot `86270bb`.
- Use stable client-request IDs and captured FRED server/session identity for submission, acceptance, terminal-run, inquiry, and queue reconciliation.
- Keep the shared `renderPromptQueue` markup as a dock sibling outside `#composer` in fresh and live renders; preserve draft text, focus, edit state, and mobile dock layout across refreshes. Generic `/agents` routes remain unchanged.
- Add factual Sending/Accepted/Running/Queued/Failed/Unknown/Canceled states, fair bounded reconciliation, unresolved-record retention, terminal run failure copy, canceled queue receipts, and persistent scoped control errors.
- Keep generic agent endpoints and behavior unchanged. No backend or Phase 2 source changes are included.

## Reviewed backend dependency

Browser integration uses the immutable fixture archive `/tmp/tycho-fred-implementation/backend-phase1-86270bb` at approved Beta PR114 commit `86270bb`. It does not use the evolving Beta Phase 2 worktree or a live FRED session.

## Verification

- `bin/test` passed in isolated temporary `TYCHO_HOME`/`TMPDIR` roots with path aliases cleared.
- Isolated `bundle exec ruby test/remote_server_test.rb` passed with temporary `TYCHO_HOME`/`TMPDIR` roots and path aliases cleared.
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb` passed.
- `bundle exec ruby test/rendering_test.rb` passed.
- `node --check lib/hq/remote_ui/assets/app.js` passed.
- `ruby -c bin/remote-ui-smoke` and `git diff --check` passed.
- Review regression: forced attachment preparation rejection in an inquiry produced no answer POST, retained the answer/feedback/attachment, and rendered the actionable `pre_post` failure recovery without leaving `Sending`.
- `TYCHO_REMOTE_UI_SMOKE_RENDERING_ONLY=1 ruby /tmp/tycho-fred-implementation/run-charlie-phase1-browser.rb` passed in real Google Chrome against `86270bb`: FRED Phase 1 plus HTML/Mermaid/polling/schedule/sticky-toolbar/Now rendering smoke.
- Browser assertions covered delayed first send, lost response, newer draft preservation, route navigation, duplicate prompt identity, six unknown records with fair reconciliation/retention, queue edit/delete/retry and conflicts, no nested forms after forced/full-screen refresh, inquiry dismiss/restore/answer recovery, and terminal failed-run copy.
- Final browser measurements: first pending paint `900ms`, terminal freshness `819ms`, active cadence `4000ms`.

Captures are outside the repository at `/tmp/tycho-fred-phase1-captures.o92QkS` (`fred-phase1-desktop.png` and `fred-phase1-mobile.png`, 390x844 reduced motion).

The broader legacy smoke suite still has the documented pre-existing Settings context-menu assertion mismatch; it is intentionally out of scope for this UI-only PR.
