### PR TITLE
Cache FRED timezone boundaries across requests

### DIFF
--- a/docs/PERSONAL_ASSISTANT.md
+++ b/docs/PERSONAL_ASSISTANT.md
@@ -101,7 +101,9 @@ conversation before the final structured result is persisted.
 The Remote Server shares a bounded timezone snapshot cache across its short-lived
 services. It computes the local date and next daily boundary together in a
 child-only timezone environment, reuses them until the derived boundary, and
-never changes process-global `TZ`. The isolated 101-agent fixture reduced
-active status from roughly 476 ms to 123 ms; warm status/actions/current-work
-reads measured about 0.6/0.7/0.6 ms. These are fixture measurements, not
-production SLAs. Bootstrap `/setup` remained a separate 3.47 s catalog step.
+never changes process-global `TZ`. The synthetic 101-agent inventory/progress
+fixture (100 non-running agents plus one FRED session with a projected semantic
+event) reduced status serialization from roughly 476 ms to 123 ms; warm
+status/actions/current-work reads measured about 0.6/0.7/0.6 ms. No harness
+ran in this fixture. These are fixture measurements, not production SLAs.
+Bootstrap `/setup` remained a separate 3.47 s catalog step.

--- a/docs/PERSONAL_ASSISTANT.md
+++ b/docs/PERSONAL_ASSISTANT.md
@@ -89,3 +89,19 @@ and omits preflight and precondition authority. When the archived agent is
 available, `archived_conversation` supplies read-only agent and conversation
 paths. These records are factual continuity only; they cannot be confirmed,
 retried, or executed in the new generation.
+
+### Progress and measured latency
+
+Conversation polling reads the durable `AgentEventJournal` projection. Stable
+`event_id`, `run_id`, source, and journal sequence metadata make repeated full
+reads safe across reconnects; partial structured output never enters the
+action proposal store. A projected semantic assistant event is visible through
+conversation before the final structured result is persisted.
+
+The Remote Server shares a bounded timezone snapshot cache across its short-lived
+services. It computes the local date and next daily boundary together in a
+child-only timezone environment, reuses them until the derived boundary, and
+never changes process-global `TZ`. The isolated 101-agent fixture reduced
+active status from roughly 476 ms to 123 ms; warm status/actions/current-work
+reads measured about 0.6/0.7/0.6 ms. These are fixture measurements, not
+production SLAs. Bootstrap `/setup` remained a separate 3.47 s catalog step.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -111,7 +111,10 @@ Durable mutations use one server-lifetime bounded worker with frozen previews,
 conservative outcome verification, and read-only archived-action history whose
 `expired_actions` subset contains only unconfirmed approvals; the
 measured fixture optimization coalesces repeated status/actions/current-work
-work without holding a global lock across long effects.
+work and caches timezone boundaries across request services without holding a
+global lock across long effects. Phase3 measurement also confirms that durable
+semantic conversation events appear before final structured output, so focused
+polling remains sufficient without a new stream protocol.
 Preserve the protected daily role, server-local identity, exact confirmation
 for each mutation, and no blind retry after an uncertain execution outcome.
 

--- a/lib/hq/domain/personal_assistant.rb
+++ b/lib/hq/domain/personal_assistant.rb
@@ -32,6 +32,54 @@ module HQ
     }.freeze
     INTRODUCTION = "I’m FRED, your Tycho Personal Assistant. I can explain Tycho, inspect agents, projects, schedules, and recent runs, and prepare project or agent work on this server.\n\nI report action results as data. I only propose mutations for exact Tycho confirmation; I never make arbitrary tooling changes. Creating an agent prepares it, and starting or messaging it needs its own confirmation.\n\nI use one daily conversation with a bounded handoff to the next day. Try: ‘Show running agents’, ‘Explain schedules’, or ‘Prepare an agent to review this project’."
 
+    # Remote requests construct a fresh lifecycle service, but the derived
+    # timezone boundary is valid for the whole server until that boundary.
+    # Keep this cache narrow and server-owned; it never changes process TZ.
+    class TimezoneSnapshotCache
+      def initialize
+        @lock = Mutex.new
+        @entries = {}
+      end
+
+      def fetch(now, timezone)
+        key = timezone.to_s
+        current = @lock.synchronize { @entries[key] }
+        return current.dup if reusable?(current, now)
+
+        computed = compute(now, key)
+        @lock.synchronize do
+          current = @entries[key]
+          @entries[key] = computed unless reusable?(current, now)
+          (@entries[key] || computed).dup
+        end
+      end
+
+      private
+
+      def reusable?(entry, now)
+        entry.is_a?(Hash) && entry[:next_at] && now.to_f >= entry[:computed_at].to_f && now.to_f < entry[:next_at].to_f
+      end
+
+      def compute(now, timezone)
+        output = IO.popen(
+          { "TZ" => timezone },
+          [
+            RbConfig.ruby, "-rtime", "-rdate", "-e",
+            "now = Time.at(ARGV[0].to_f).getlocal; date = Date.new(now.year, now.month, now.day) + 1; puts [now.strftime('%F'), Time.local(date.year, date.month, date.day).utc.iso8601].join('|')",
+            now.to_f.to_s
+          ],
+          &:read
+        ).to_s.strip
+        date, boundary = output.split("|", 2)
+        next_at = Time.iso8601(boundary).to_f
+        raise "invalid timezone snapshot" if date.to_s.empty?
+
+        { date:, next_rollover_at: boundary, computed_at: now.to_f, next_at: }
+      rescue StandardError
+        { date: now.strftime("%F"), next_rollover_at: nil, computed_at: now.to_f, next_at: nil }
+      end
+    end
+
     class SessionConflict < ArgumentError
       attr_reader :code, :active_key, :generation
 
@@ -52,8 +100,9 @@ module HQ
       end
     end
 
-    def initialize(registry:, agent_store:, clock: -> { Time.now }, state_path: File.join(PERSONAL_ASSISTANT_DIR, "state.json"), summary_runner: nil, archiver: nil)
+    def initialize(registry:, agent_store:, clock: -> { Time.now }, state_path: File.join(PERSONAL_ASSISTANT_DIR, "state.json"), summary_runner: nil, archiver: nil, timezone_cache: nil)
       @registry, @agent_store, @clock, @state_path = registry, agent_store, clock, state_path
+      @timezone_cache = timezone_cache || TimezoneSnapshotCache.new
       @summary_runner = summary_runner
       @archiver = archiver || method(:archive_internal!)
       @synchronization_key = "hq-pa-lifecycle-#{object_id}"
@@ -483,19 +532,11 @@ module HQ
     end
 
     def local_date(now, timezone)
-      output = IO.popen({ "TZ" => timezone }, [RbConfig.ruby, "-e", "puts Time.at(ARGV[0].to_f).getlocal.strftime('%F')", now.to_f.to_s], &:read).to_s.strip
-      output.empty? ? now.strftime("%F") : output
+      @timezone_cache.fetch(now, timezone).fetch(:date)
     end
 
     def next_rollover_at(now, timezone)
-      output = IO.popen(
-        { "TZ" => timezone },
-        [RbConfig.ruby, "-rtime", "-rdate", "-e", "now = Time.at(ARGV[0].to_f).getlocal; date = Date.new(now.year, now.month, now.day) + 1; puts Time.local(date.year, date.month, date.day).utc.iso8601", now.to_f.to_s],
-        &:read
-      ).to_s.strip
-      output.empty? ? nil : output
-    rescue StandardError
-      nil
+      @timezone_cache.fetch(now, timezone).fetch(:next_rollover_at)
     end
 
     def workspace

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -100,6 +100,7 @@ module HQ
       @agent_activity_snapshot = agent_activity_snapshot || AgentActivitySnapshot.new
       @personal_assistant_actions = personal_assistant_action_worker&.respond_to?(:actions) ? personal_assistant_action_worker.actions : build_personal_assistant_action_store
       @personal_assistant_action_worker = personal_assistant_action_worker || build_personal_assistant_action_worker
+      @personal_assistant_timezone_cache = PersonalAssistantLifecycle::TimezoneSnapshotCache.new
       @personal_assistant_snapshot_lock = Mutex.new
       @personal_assistant_snapshot = nil
       @personal_assistant_snapshot_revision = 0
@@ -209,7 +210,8 @@ module HQ
         restartable: restartable?,
         agent_activity_snapshot: @agent_activity_snapshot,
         personal_assistant_actions: @personal_assistant_actions,
-        personal_assistant_action_worker: @personal_assistant_action_worker
+        personal_assistant_action_worker: @personal_assistant_action_worker,
+        personal_assistant_timezone_cache: @personal_assistant_timezone_cache
       )
     end
 
@@ -318,7 +320,8 @@ module HQ
         restartable: restartable?,
         agent_activity_snapshot: @agent_activity_snapshot,
         personal_assistant_actions: @personal_assistant_actions,
-        personal_assistant_action_worker: @personal_assistant_action_worker
+        personal_assistant_action_worker: @personal_assistant_action_worker,
+        personal_assistant_timezone_cache: @personal_assistant_timezone_cache
       )
       result = route(service, request.method, request.path, json_body(request), request)
       status = result.fetch(:status, 200)
@@ -364,7 +367,8 @@ module HQ
       service = RemoteService.new(server_url: "http://#{@host}:#{@port}",
                                   public_url: @public_url,
                                   auth_required: !@token.empty?,
-                                  agent_activity_snapshot: @agent_activity_snapshot)
+                                  agent_activity_snapshot: @agent_activity_snapshot,
+                                  personal_assistant_timezone_cache: @personal_assistant_timezone_cache)
       service.dispatch_agent_push_notifications!
     rescue StandardError => e
       HQ.logger.warn("Push") { "Agent push notification poll failed: #{e.class} - #{e.message}" }
@@ -915,7 +919,8 @@ module HQ
         public_url: @public_url,
         auth_required: !@token.empty?,
         restartable: restartable?,
-        agent_activity_snapshot: @agent_activity_snapshot
+        agent_activity_snapshot: @agent_activity_snapshot,
+        personal_assistant_timezone_cache: @personal_assistant_timezone_cache
       )
       @resource_catalog.reconcile(registry: service.registry, server_url: service.server_url)
       @resource_catalog.refresh(
@@ -1782,13 +1787,15 @@ module HQ
                    agent_activity_snapshot: AgentActivitySnapshot.new,
                    personal_assistant_actions: nil,
                    personal_assistant_action_worker: nil,
+                   personal_assistant_timezone_cache: nil,
                    clock: -> { Time.now })
       @registry = registry
       @clock = clock
       @projects = registry.projects.map { |config| Project.new(config) }
       @agent_store = AgentStore.new(@projects)
       @personal_assistant = PersonalAssistantLifecycle.new(
-        registry:, agent_store: @agent_store, clock: @clock, state_path: File.join(HQ::PERSONAL_ASSISTANT_DIR, "state.json")
+        registry:, agent_store: @agent_store, clock: @clock, state_path: File.join(HQ::PERSONAL_ASSISTANT_DIR, "state.json"),
+        timezone_cache: personal_assistant_timezone_cache
       )
       @personal_assistant_action_worker = personal_assistant_action_worker
       @personal_assistant_actions = personal_assistant_actions || personal_assistant_action_worker&.actions

--- a/test/personal_assistant_phase2_test.rb
+++ b/test/personal_assistant_phase2_test.rb
@@ -127,6 +127,7 @@ class PersonalAssistantPhase2Test
     assert_schedule_precondition_ignores_derived_next_run
     assert_daemon_starts_worker_after_daemonization
     assert_personal_assistant_snapshot_coalesces_bundle_builds
+    assert_timezone_cache_reuses_until_boundary
     assert_current_work_honors_live_visibility
     assert_verification_never_claims_observed_state
     assert_worker_create_preserves_foreground_create
@@ -458,6 +459,20 @@ class PersonalAssistantPhase2Test
       assert(service.bundle_calls == 1, "expected consecutive status/actions/current-work reads to share one bundle build")
       puts "personal_assistant_snapshot: #{elapsed_ms}ms across 3 reads, 1 bundle build"
     end
+  end
+
+  def self.assert_timezone_cache_reuses_until_boundary
+    cache = HQ::PersonalAssistantLifecycle::TimezoneSnapshotCache.new
+    before_boundary = Time.utc(2026, 3, 8, 6, 59, 59)
+    first = cache.fetch(before_boundary, "America/New_York")
+    second = cache.fetch(before_boundary + 1, "America/New_York")
+    assert(first[:date] == second[:date] && first[:next_rollover_at] == second[:next_rollover_at],
+           "expected timezone date and boundary to remain cached before rollover")
+
+    after_boundary = Time.iso8601(first.fetch(:next_rollover_at)) + 1
+    next_day = cache.fetch(after_boundary, "America/New_York")
+    assert(next_day[:date] != first[:date] && next_day[:next_rollover_at] != first[:next_rollover_at],
+           "expected timezone cache to refresh at the derived boundary")
   end
 
   def self.assert_current_work_honors_live_visibility

--- a/test/personal_assistant_phase2_test.rb
+++ b/test/personal_assistant_phase2_test.rb
@@ -463,16 +463,27 @@ class PersonalAssistantPhase2Test
 
   def self.assert_timezone_cache_reuses_until_boundary
     cache = HQ::PersonalAssistantLifecycle::TimezoneSnapshotCache.new
-    before_boundary = Time.utc(2026, 3, 8, 6, 59, 59)
-    first = cache.fetch(before_boundary, "America/New_York")
-    second = cache.fetch(before_boundary + 1, "America/New_York")
-    assert(first[:date] == second[:date] && first[:next_rollover_at] == second[:next_rollover_at],
-           "expected timezone date and boundary to remain cached before rollover")
+    original_tz = ENV["TZ"]
+    cases = [
+      ["spring", Time.utc(2026, 3, 8, 5), "America/New_York", "2026-03-08", "2026-03-09T04:00:00Z"],
+      ["fall", Time.utc(2026, 11, 1, 4), "America/New_York", "2026-11-01", "2026-11-02T05:00:00Z"],
+      ["backward", Time.utc(2026, 3, 8, 6), "America/New_York", "2026-03-08", "2026-03-09T04:00:00Z"],
+      ["tokyo", Time.utc(2026, 9, 9, 12), "Asia/Tokyo", "2026-09-09", "2026-09-09T15:00:00Z"],
+      ["utc", Time.utc(2026, 9, 9, 12), "UTC", "2026-09-09", "2026-09-10T00:00:00Z"]
+    ]
+    cases.each do |name, now, timezone, date, boundary|
+      value = cache.fetch(now, timezone)
+      assert(value[:date] == date && value[:next_rollover_at] == boundary && value[:next_at] > now.to_f,
+             "expected #{name} timezone snapshot to preserve its date and next boundary")
+    end
 
-    after_boundary = Time.iso8601(first.fetch(:next_rollover_at)) + 1
-    next_day = cache.fetch(after_boundary, "America/New_York")
-    assert(next_day[:date] != first[:date] && next_day[:next_rollover_at] != first[:next_rollover_at],
-           "expected timezone cache to refresh at the derived boundary")
+    before_boundary = cache.fetch(Time.utc(2026, 9, 9, 23, 59, 59), "UTC")
+    at_boundary = cache.fetch(Time.utc(2026, 9, 10), "UTC")
+    assert(before_boundary[:date] == "2026-09-09" && before_boundary[:next_rollover_at] == "2026-09-10T00:00:00Z",
+           "expected the exact-boundary probe to start with the prior UTC day")
+    assert(at_boundary[:date] == "2026-09-10" && at_boundary[:next_rollover_at] == "2026-09-11T00:00:00Z",
+           "expected timezone cache to refresh at the exact derived boundary")
+    assert(ENV["TZ"] == original_tz, "expected timezone calculation not to change process TZ")
   end
 
   def self.assert_current_work_honors_live_visibility


### PR DESCRIPTION
## Summary

- Share a bounded timezone date/next-rollover snapshot cache across the Remote Server's short-lived FRED services.
- Preserve injected clocks, DST behavior, child-only TZ execution, snapshot invalidation, and the existing polling/event contract.
- Document measured Phase3 costs and confirm persisted semantic conversation progress is visible before final structured output.

## Verification

- Post-rebase `bin/test` passed with isolated temporary `TYCHO_HOME`/`TMPDIR`, all runtime path aliases unset, and a missing Codex harness.
- Focused `test/personal_assistant_phase2_test.rb` passed within that full suite.
- `/tmp/tycho-fred-implementation/phase3-measurement.rb` against a synthetic inventory/progress fixture with 101 agents; no active harness ran. Raw before/after runs 2 and 4 are preserved under `/tmp/tycho-fred-implementation/phase3-raw-measurement-*.json`.
- `test/personal_assistant_phase2_test.rb` covers spring/fall DST, backward clocks, UTC/Tokyo isolation, exact-boundary refresh, and process-TZ preservation.

## Coordination

- Rebasing result: exact head `409a06db6cb382bf7c84a69c75fc5ade1d74dab0`, based on merged `main` `f23dc3253aa79e37661a6b7cf6d3e1629e04605`; only Phase3 commits after frozen boundary `f4a5adf` were replayed.
- PR base is now `main`; no Phase2 squash history was replayed into this branch.
- The frozen Phase2 branch remains unchanged at `f4a5adf`; Root owns merge of this PR.
- Backend contract: `/tmp/tycho-fred-implementation/phase3-backend-contract.md`.
- Charlie handoff: `/tmp/tycho-fred-implementation/phase3-charlie-coordination.md`.
- No live FRED session, configuration, logs, or recovery data were touched.
