### PR TITLE
Preserve focused FRED refresh and recovery state

### DIFF
--- a/docs/PERSONAL_ASSISTANT.md
+++ b/docs/PERSONAL_ASSISTANT.md
@@ -107,3 +107,21 @@ event) reduced status serialization from roughly 476 ms to 123 ms; warm
 status/actions/current-work reads measured about 0.6/0.7/0.6 ms. No harness
 ran in this fixture. These are fixture measurements, not production SLAs.
 Bootstrap `/setup` remained a separate 3.47 s catalog step.
+
+The focused Remote UI defers catalog, setup, and schedule discovery on the
+initial configured-FRED conversation path. Unconfigured onboarding and normal
+Settings/navigation still load setup discovery and keep the model, effort,
+timezone, and confirmation controls available. When actual FRED work or an
+unresolved submission is active, visible polling uses a 1.5 s cadence; idle
+polling uses 12 s, and hidden polling uses 30 s. Focused read failures reuse a
+bounded policy: the first visible failure backs off to idle cadence, repeated
+failures reach the hidden cadence, and the count is capped at two. A successful
+refresh restores the normal active/idle choice, while online, tab-return, and
+manual refreshes retry immediately.
+
+Refresh reconciliation keeps the current-work snapshot, composer draft, focus,
+and conversation scroll usable while a background read is pending. Unchanged
+responses use the existing render comparison; changed, unavailable, stale, and
+recovered values still render their factual state. The 3.47 s `/setup`
+measurement above is a historical synthetic catalog observation, not a claim
+about configured-FRED first-render or end-to-end latency.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -114,7 +114,13 @@ measured fixture optimization coalesces repeated status/actions/current-work
 work and caches timezone boundaries across request services without holding a
 global lock across long effects. Phase3 measurement also confirms that durable
 semantic conversation events appear before final structured output, so focused
-polling remains sufficient without a new stream protocol.
+polling remains sufficient without a new stream protocol. Configured FRED
+defers the slow shell/setup discovery on its focused conversation path; actual
+active work polls at 1.5 s, idle work at 12 s, and hidden work at 30 s, with a
+two-failure cap, recovery reset, and immediate explicit retry. Current-work
+reconciliation preserves drafts, focus, scroll, and unchanged DOM. The
+historical synthetic `/setup` observation of 3.47 s remains a catalog
+measurement, not a final UI latency claim.
 Preserve the protected daily role, server-local identity, exact confirmation
 for each mutation, and no blind retry after an uncertain execution outcome.
 
@@ -388,6 +394,7 @@ and queued-run push notification behavior. Schedule-management work remains on
 - [x] Sticky Settings section navigator over one continuous page and copyable native session ID in Conversation Settings
 - [x] In-flow desktop conversation composer with resize-aware mobile content reservation
 - [x] Accessible full-screen Conversation editor with polling-safe autosaved drafts, focus containment, mobile visual-viewport sizing, and Escape-to-exit
+- [x] Focused configured-FRED refresh defers shell discovery, preserves composer state during polling, skips unchanged current-work DOM replacement, and uses bounded visible/idle/hidden recovery cadence
 - [x] Focused Summary/Attachment full-view controls and compact mobile follow-up composer
 - [x] Finalized-run estimated session-cost snapshots on latest and historical Summary pages, including Codex token-delta estimates from an auditable OpenAI model rate card, explicit rebuild backfill, and no startup log scan
 - [ ] Dedicated mobile activity/log detail page

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -10,12 +10,13 @@ const AGENT_ACTIVITY_POLL_INTERVALS = {
   hiddenMs: 30_000,
 };
 const PERSONAL_ASSISTANT_POLL_INTERVALS = {
-  activeMs: 4_000,
+  activeMs: 1_500,
   idleMs: 12_000,
   hiddenMs: 30_000,
 };
 const PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY = "hq.remote.personalAssistantSubmissions";
 const PERSONAL_ASSISTANT_SUBMISSION_LIMIT = 24;
+const PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT = 128;
 const PERSONAL_ASSISTANT_SUBMISSION_STATES = ["sending", "accepted", "running", "queued", "failed", "unknown", "canceled"];
 const PERSONAL_ASSISTANT_SUBMISSION_TRANSITIONS = {
   sending: ["sending", "accepted", "queued", "running", "failed", "unknown"],
@@ -723,6 +724,7 @@ const state = {
   personalAssistantSubmissionStates: {},
   personalAssistantSubmissionStatesLoaded: false,
   personalAssistantControlErrors: {},
+  personalAssistantAnnouncementKeys: new Set(),
   personalAssistantRequests: {
     coordinator: {
       sequence: 0,
@@ -1971,6 +1973,26 @@ function personalAssistantSessionMatches(context, item = state.personalAssistant
     current.active_key === context.active_key && current.generation === context.generation);
 }
 
+function personalAssistantAnnouncementAttributes(identity) {
+  const key = String(identity || "").trim();
+  if (!key) return 'role="status" aria-live="off"';
+
+  const announce = !state.personalAssistantAnnouncementKeys.has(key);
+  return `role="status" data-pa-announcement-key="${escapeAttr(key)}" aria-live="${announce ? "polite" : "off"}"`;
+}
+
+function commitPersonalAssistantAnnouncements() {
+  const announcements = state.personalAssistantAnnouncementKeys;
+  if (!els.view || !announcements) return;
+  els.view.querySelectorAll("[data-pa-announcement-key]").forEach((element) => {
+    const key = String(element.dataset.paAnnouncementKey || "").trim();
+    if (key) announcements.add(key);
+  });
+  while (announcements.size > PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT) {
+    announcements.delete(announcements.values().next().value);
+  }
+}
+
 function personalAssistantControlErrorKey(agentKey, control, id = "", context = null) {
   const session = context || personalAssistantSessionContext();
   return [
@@ -2532,6 +2554,7 @@ function applyPersonalAssistantItem(item) {
     state.personalAssistantRequests.preflights = {};
     state.personalAssistantRequests.currentWork = {};
     state.personalAssistantControlErrors = {};
+    state.personalAssistantAnnouncementKeys.clear();
   }
   transferPersonalAssistantDraftArtifacts(previousKey, state.personalAssistant?.active_key || "");
   return state.personalAssistant;
@@ -2768,9 +2791,10 @@ async function reconcilePersonalAssistantSubmissions() {
 function schedule(ms = pollDelay()) {
   clearTimeout(state.timer);
   state.timer = null;
-  if (fullScreenEditorOpen()) return;
+  const personalAssistantRoute = parseRoute().type === "personalAssistant";
+  if (fullScreenEditorOpen() && !personalAssistantRoute) return;
   const quietRemaining = formPollQuietRemaining();
-  state.timer = setTimeout(refresh, Math.max(ms, quietRemaining));
+  state.timer = setTimeout(refresh, personalAssistantRoute ? ms : Math.max(ms, quietRemaining));
 }
 
 function scheduleAgentActivity(ms = document.hidden
@@ -2894,6 +2918,10 @@ function formTextEntryControl(target) {
 function deferPollAfterFormInput(event) {
   if (!formTextEntryControl(event.target)) return;
   state.pollDeferredUntil = Date.now() + FORM_POLL_QUIET_MS;
+  if (parseRoute().type === "personalAssistant") {
+    if (!state.timer) schedule(personalAssistantPollDelay());
+    return;
+  }
   schedule(FORM_POLL_QUIET_MS);
 }
 
@@ -3093,9 +3121,10 @@ async function refreshPersonalAssistant(options = {}) {
 async function refresh(options = {}) {
   clearTimeout(state.timer);
   state.timer = null;
-  if (fullScreenEditorOpen() && !options.force) return;
+  const personalAssistantRoute = parseRoute().type === "personalAssistant";
+  if (fullScreenEditorOpen() && !options.force && !personalAssistantRoute) return;
   const quietRemaining = formPollQuietRemaining();
-  if (quietRemaining > 0 && !options.force) {
+  if (quietRemaining > 0 && !options.force && !personalAssistantRoute) {
     schedule(quietRemaining);
     return;
   }
@@ -3103,7 +3132,7 @@ async function refresh(options = {}) {
     schedule();
     return;
   }
-  if (parseRoute().type === "personalAssistant") return refreshPersonalAssistant(options);
+  if (personalAssistantRoute) return refreshPersonalAssistant(options);
 
   const initialRouteHash = location.hash;
   const preserveWorkspace = preserveWorkspaceDuringPoll(options);
@@ -3997,6 +4026,7 @@ function replaceView(html) {
     syncViewControls();
     syncFullScreenComposerModal();
     syncAgentDockLayout();
+    commitPersonalAssistantAnnouncements();
     return;
   }
 
@@ -4029,6 +4059,7 @@ function replaceView(html) {
   syncFullScreenComposerModal();
   syncAgentDockLayout();
   restoreVisiblePullRequestDiffScroll();
+  commitPersonalAssistantAnnouncements();
 }
 
 function replaceViewContent(html) {
@@ -5792,6 +5823,10 @@ function personalAssistantPreviewValue(value) {
   if (typeof value === "boolean") return value ? "Yes" : "No";
   if (Array.isArray(value)) return value.map(personalAssistantPreviewValue).join(", ");
   if (typeof value === "object") {
+    if (value.local === true) {
+      const suppliedName = value.name || value.label || (value.id && value.id !== "local" ? value.id : "");
+      return suppliedName ? String(suppliedName) : "This server";
+    }
     const named = ["name", "key", "project_key", "agent_key", "schedule_key", "server_key"]
       .map((key) => value[key])
       .find((item) => item !== null && item !== undefined && String(item).trim());
@@ -6041,6 +6076,16 @@ function personalAssistantHasRealConversation(blocks) {
   return blocks.some((block) => block?.kind === "message" && ["user", "assistant"].includes(block.role));
 }
 
+function personalAssistantConversationEventIdentity(block) {
+  const metadata = block?.metadata || {};
+  const eventId = block?.event_id || metadata.event_id;
+  if (eventId) return String(eventId).trim();
+  const runId = block?.run_id || metadata.run_id || "";
+  const sequence = block?.sequence ?? metadata.sequence ?? metadata._sequence ?? metadata._stream_sequence ?? "";
+  if (runId || sequence) return `${runId}:${sequence}:${block?.kind || ""}`.trim();
+  return String(block?.id || metadata.id || block?.created_at || metadata.created_at || "").trim();
+}
+
 function personalAssistantBlockMatchesSubmission(block, record) {
   if (!block || !record) return false;
   return personalAssistantBlockRequestIds(block).includes(record.client_request_id);
@@ -6070,7 +6115,13 @@ function renderPersonalAssistantSubmissionRecovery() {
     .sort((left, right) => String(right.updated_at || "").localeCompare(String(left.updated_at || "")))
     .slice(0, 4);
   if (!records.length) return "";
-  return "<section class=\"pa-submission-recovery\" aria-label=\"FRED message delivery\" aria-live=\"polite\">"
+  const announcementKey = records.map((record) => [
+    record.client_request_id,
+    normalizePersonalAssistantSubmissionState(record.state),
+    record.error || "",
+  ].join(":")).join("|");
+  return "<section class=\"pa-submission-recovery\" aria-label=\"FRED message delivery\" "
+    + personalAssistantAnnouncementAttributes(`message-delivery:${announcementKey}`) + ">"
     + "<h3>Message delivery</h3>"
     + records.map((record) => {
       const stateName = normalizePersonalAssistantSubmissionState(record.state);
@@ -6223,6 +6274,19 @@ function renderPersonalAssistantCurrentWorkEntry(entry, kind) {
   return `<li>${label}<span>${escapeHtml(titleFromKey(String(status)))}</span></li>`;
 }
 
+function personalAssistantCurrentWorkAnnouncementKey(freshness, stateName, error, groups) {
+  const visibleGroups = groups.map(([label, kind, entries]) => [
+    label,
+    kind,
+    entries.slice(0, 8).map((entry) => [
+      String(entry?.resource_key || entry?.key || entry?.agent_key || entry?.project_key || entry?.schedule_key || ""),
+      String(entry?.name || ""),
+      String(entry?.status || entry?.state || (entry?.running ? "running" : "ready")),
+    ]),
+  ]);
+  return JSON.stringify({ freshness, state: stateName, error: error || "", groups: visibleGroups });
+}
+
 function renderPersonalAssistantCurrentWork(item) {
   if (!item?.configured) return "";
   const work = state.personalAssistantCurrentWork;
@@ -6253,7 +6317,8 @@ function renderPersonalAssistantCurrentWork(item) {
   const body = groups.length
     ? groups.map(([label, kind, entries]) => `<div class="pa-current-work-group"><strong>${escapeHtml(label)}</strong><ul>${entries.slice(0, 8).map((entry) => renderPersonalAssistantCurrentWorkEntry(entry, kind)).join("")}</ul></div>`).join("")
     : `<p class="pa-current-work-empty">No active, waiting, failed, or recently completed work is visible to FRED.</p>`;
-  return `<section class="pa-current-work ${freshness === "stale" || freshness === "unavailable" ? "degraded" : ""}" aria-labelledby="pa-current-work-title"><div class="pa-current-work-heading"><div><h2 id="pa-current-work-title">Current work</h2><p>${escapeHtml(statusCopy)}</p></div><span class="pa-current-work-state" role="status" aria-live="polite">${escapeHtml(personalAssistantCurrentWorkStateLabel(work, freshness))}</span></div>${body}</section>`;
+  const announcementKey = personalAssistantCurrentWorkAnnouncementKey(freshness, stateName, error, groups);
+  return `<section class="pa-current-work ${freshness === "stale" || freshness === "unavailable" ? "degraded" : ""}" aria-labelledby="pa-current-work-title"><div class="pa-current-work-heading"><div><h2 id="pa-current-work-title">Current work</h2><p>${escapeHtml(statusCopy)}</p></div><span class="pa-current-work-state" ${personalAssistantAnnouncementAttributes(`current-work:${announcementKey}`)}>${escapeHtml(personalAssistantCurrentWorkStateLabel(work, freshness))}</span></div>${body}</section>`;
 }
 
 function personalAssistantContinuityPreview(value) {
@@ -7669,8 +7734,16 @@ function renderAgentConversationView(agent, blocks, options = {}) {
 }
 
 function personalAssistantVisibleConversationBlocks(blocks) {
+  const seenEvents = new Set();
   return blocks
     .filter((block) => block?.kind === "message" && ["user", "assistant"].includes(block.role))
+    .filter((block) => {
+      const identity = personalAssistantConversationEventIdentity(block);
+      if (!identity) return true;
+      if (seenEvents.has(identity)) return false;
+      seenEvents.add(identity);
+      return true;
+    })
     .map((block) => {
       const record = personalAssistantSubmissionForBlock(block);
       return record ? {
@@ -10749,13 +10822,14 @@ function renderMessage(block, options = {}) {
   const timeHtml = ts ? `<time class="message-time" datetime="${escapeAttr(ts)}">${escapeHtml(relativeTimeShort(ts))}</time>` : "";
   const summaryId = block.kind === "run_summary" ? runSummaryId(block) : "";
   const sendState = personalAssistantMessageSendState(block, options);
+  const eventIdentity = options.personalAssistant ? personalAssistantConversationEventIdentity(block) : "";
   const pendingStatus = sendState
-    ? `<div class="message-send-status pa-message-send-status ${escapeAttr(personalAssistantSubmissionStateIntent(sendState))}" data-pa-message-status="${escapeAttr(sendState)}" role="status" aria-live="polite">${escapeHtml(personalAssistantSubmissionStateLabel(sendState))}</div>`
+    ? `<div class="message-send-status pa-message-send-status ${escapeAttr(personalAssistantSubmissionStateIntent(sendState))}" data-pa-message-status="${escapeAttr(sendState)}" data-client-request-id="${escapeAttr(personalAssistantBlockRequestId(block))}" ${personalAssistantAnnouncementAttributes(`message:${personalAssistantBlockRequestId(block) || block.id || block.created_at}:${sendState}`)}>${escapeHtml(personalAssistantSubmissionStateLabel(sendState))}</div>`
     : block.pending ? `<div class="message-send-status">sending...</div>` : "";
   const identity = personalAssistantMessageIdentity(block, options);
   const requestId = options.personalAssistant ? personalAssistantBlockRequestId(block) : "";
   return `
-    <article class="${escapeAttr(messageClassName(block))}"${summaryId ? ` data-run-summary-id="${escapeAttr(summaryId)}"` : ""}${requestId ? ` data-client-request-id="${escapeAttr(requestId)}"` : ""}>
+    <article class="${escapeAttr(messageClassName(block))}"${summaryId ? ` data-run-summary-id="${escapeAttr(summaryId)}"` : ""}${requestId ? ` data-client-request-id="${escapeAttr(requestId)}"` : ""}${eventIdentity ? ` data-pa-event-id="${escapeAttr(eventIdentity)}"` : ""}>
       <div class="message-header">
         <div class="message-role">${identity || `${messageIcon(block)}<span>${escapeHtml(messageRoleLabel(block))}</span>`}${timeHtml}</div>
         ${block.pending ? "" : renderBlockMenuAnchor(block, menuId)}
@@ -19156,7 +19230,11 @@ scheduleBootTimeout();
 emitBootParticles();
 window.addEventListener("offline", () => failBootShell(bootError("Network unavailable", "offline")));
 window.addEventListener("online", () => {
-  if (els.bootShell && !els.bootShell.hidden) refresh({ force: true });
+  if (els.bootShell && !els.bootShell.hidden) {
+    refresh({ force: true });
+  } else if (parseRoute().type === "personalAssistant") {
+    refresh({ force: true });
+  }
 });
 refresh({ force: true });
 pollAgentActivity();

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -1985,6 +1985,12 @@ function personalAssistantAnnouncementAttributes(region, semanticValue = "") {
   return `role="status" data-pa-announcement-key="${escapeAttr(key)}" data-pa-announcement-region="${escapeAttr(logicalRegion)}" data-pa-announcement-value="${escapeAttr(value)}" aria-live="${announce ? "polite" : "off"}"`;
 }
 
+function personalAssistantActionReceiptAnnouncementAttributes(proposal, stateName, receiptText) {
+  const proposalId = String(proposal?.id || "").trim() || "unknown";
+  const stateValue = String(stateName || proposal?.state || "unknown").trim().toLowerCase() || "unknown";
+  return personalAssistantAnnouncementAttributes(`action-receipt:${proposalId}`, `${stateValue}:${String(receiptText ?? "")}`);
+}
+
 function commitPersonalAssistantAnnouncements() {
   const announcements = state.personalAssistantAnnouncementValues ||= new Map();
   if (!els.view || !announcements) return;
@@ -6049,9 +6055,13 @@ function renderPersonalAssistantProposal(proposal) {
     ? `<p class="pa-control-error" role="alert">${escapeHtml(actionError)}</p>`
     : "";
   const actionStatus = expired ? "Expired" : personalAssistantActionStatus(displayedProposal);
+  const receiptText = expired
+    ? "Expired — this pending proposal belongs to an earlier conversation and cannot be approved."
+    : personalAssistantActionReceiptCopy(displayedProposal);
+  const receiptAnnouncement = personalAssistantActionReceiptAnnouncementAttributes(proposal, expired ? "expired" : stateName, receiptText);
   const receiptHtml = pending
     ? `<p class="pa-action-confirmation">This change runs only after you confirm its exact preview.</p><div class="pa-action-controls"><button class="inline-icon-button ui-button" data-variant="brand" type="button" data-confirm-pa-proposal="${escapeAttr(proposal.id)}" aria-label="${escapeAttr(confirmLabel)}" ${canConfirm ? "" : "disabled"}>${iconSvg("thumbsUp")}<span>${busy ? "Confirming…" : canConfirm ? confirmLabel : "Preview required"}</span></button><button class="inline-icon-button ui-button" type="button" data-reject-pa-proposal="${escapeAttr(proposal.id)}" aria-label="Reject proposed action" ${busy ? "disabled" : ""}>${iconSvg("thumbsDown")}<span>Reject</span></button></div>`
-    : `<p class="pa-action-receipt" role="status" aria-live="polite">${escapeHtml(expired ? "Expired — this pending proposal belongs to an earlier conversation and cannot be approved." : personalAssistantActionReceiptCopy(displayedProposal))}</p>${expired ? "" : renderPersonalAssistantResult(displayedProposal)}${expired ? "" : personalAssistantActionRecovery(displayedProposal, copy)}`;
+    : `<p class="pa-action-receipt" ${receiptAnnouncement}>${escapeHtml(receiptText)}</p>${expired ? "" : renderPersonalAssistantResult(displayedProposal)}${expired ? "" : personalAssistantActionRecovery(displayedProposal, copy)}`;
   const proposalDetails = `<dl><div><dt>Action</dt><dd>${escapeHtml(copy.label)}</dd></div><div><dt>Target</dt><dd>${escapeHtml(String(copy.target))}</dd></div><div><dt>Intent</dt><dd>${escapeHtml(personalAssistantProposalInstruction(proposal))}</dd></div>${settings}<div><dt>What Tycho will do</dt><dd>${escapeHtml(copy.effect)}</dd></div></dl>`;
   const completedSummary = completed
     ? `<div class="pa-action-summary"><strong>${escapeHtml(copy.label)}</strong><span>${escapeHtml(String(copy.target))}</span></div>`

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2702,7 +2702,7 @@ function requestPersonalAssistantCurrentWork(routeHashAtStart = location.hash, c
   const requestKey = [context?.server_key || personalAssistantServerKey(), context?.active_key || "no-session", context?.generation ?? "no-generation"].join(":");
   const coordinator = state.personalAssistantRequests.coordinator;
   const sequence = ++coordinator.currentWorkSequence;
-  state.personalAssistantCurrentWorkState = state.personalAssistantCurrentWork ? "refreshing" : "loading";
+  if (!state.personalAssistantCurrentWork) state.personalAssistantCurrentWorkState = "loading";
   return personalAssistantRequest(requests, requestKey, async () => {
     const data = await apiGet("/personal-assistant/current-work");
     const current = location.hash === routeHashAtStart && parseRoute().type === "personalAssistant" &&
@@ -2712,7 +2712,6 @@ function requestPersonalAssistantCurrentWork(routeHashAtStart = location.hash, c
     state.personalAssistantCurrentWork = data || null;
     state.personalAssistantCurrentWorkState = String(data?.state || "unavailable").toLowerCase();
     state.personalAssistantCurrentWorkError = "";
-    state.renderedViewHtml = "";
     render({ preserveLiveEditor: true });
     return data;
   }).catch((error) => {
@@ -2720,7 +2719,6 @@ function requestPersonalAssistantCurrentWork(routeHashAtStart = location.hash, c
         (!context || personalAssistantSessionMatches(context))) {
       state.personalAssistantCurrentWorkState = "unavailable";
       state.personalAssistantCurrentWorkError = error.message;
-      state.renderedViewHtml = "";
       render({ preserveLiveEditor: true });
     }
     throw error;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2594,28 +2594,38 @@ function personalAssistantSubmissionStateFromError(error, options = {}) {
   return "failed";
 }
 
+function personalAssistantStatusRequestIsCurrent(routeHashAtStart, capturedSession, capturedItem) {
+  if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return false;
+  return capturedSession
+    ? personalAssistantSessionMatches(capturedSession)
+    : state.personalAssistant === capturedItem;
+}
+
 function requestPersonalAssistantStatus(force = false, routeHashAtStart = location.hash) {
   loadPersonalAssistantSubmissionStates();
   const requests = state.personalAssistantRequests;
   if (!force && requests.status?.promise) return requests.status.promise;
   if (requests.status?.promise) return requests.status.promise;
+  const capturedItem = state.personalAssistant;
+  const capturedSession = personalAssistantSessionContext(capturedItem);
   const coordinator = requests.coordinator;
   const sequence = ++coordinator.sequence;
   const promise = personalAssistantRequest(requests, "status", async () => {
-    const data = await apiGet("/personal-assistant");
-    if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return data;
-    if (sequence < coordinator.applied) return data;
-    coordinator.applied = sequence;
-    applyPersonalAssistantItem(data.personal_assistant || null);
-    return data;
-  });
-  return promise.catch((error) => {
-    if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant") {
+    try {
+      const data = await apiGet("/personal-assistant");
+      if (!personalAssistantStatusRequestIsCurrent(routeHashAtStart, capturedSession, capturedItem)) return data;
+      if (sequence < coordinator.applied) return data;
+      coordinator.applied = sequence;
+      applyPersonalAssistantItem(data.personal_assistant || null);
+      return data;
+    } catch (error) {
+      if (!personalAssistantStatusRequestIsCurrent(routeHashAtStart, capturedSession, capturedItem)) return null;
       state.personalAssistantLoadState = "error";
       state.personalAssistantLoadError = error.message;
+      throw error;
     }
-    throw error;
   });
+  return promise;
 }
 
 function requestPersonalAssistantActions(routeHashAtStart = location.hash, context = null) {
@@ -3750,7 +3760,7 @@ async function ensureConversation(agent, force = false) {
     const context = personalAssistantSessionContext();
     const requestKey = [agent.key, context?.server_key || "local", context?.active_key || "no-session", context?.generation ?? "no-generation"].join(":");
     if (requests[requestKey]?.promise) return requests[requestKey].promise;
-    if (!force && cached && cached.revision === agent.revision && !cached.loading && !cached.error) return;
+    if (!force && !agent.running && cached && cached.revision === agent.revision && !cached.loading && !cached.error) return;
 
     const routeHashAtStart = location.hash;
     const capturedRevision = agent.revision;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -724,7 +724,7 @@ const state = {
   personalAssistantSubmissionStates: {},
   personalAssistantSubmissionStatesLoaded: false,
   personalAssistantControlErrors: {},
-  personalAssistantAnnouncementKeys: new Set(),
+  personalAssistantAnnouncementValues: new Map(),
   personalAssistantRequests: {
     coordinator: {
       sequence: 0,
@@ -1973,23 +1973,29 @@ function personalAssistantSessionMatches(context, item = state.personalAssistant
     current.active_key === context.active_key && current.generation === context.generation);
 }
 
-function personalAssistantAnnouncementAttributes(identity) {
-  const key = String(identity || "").trim();
-  if (!key) return 'role="status" aria-live="off"';
+function personalAssistantAnnouncementAttributes(region, semanticValue = "") {
+  const logicalRegion = String(region || "").trim();
+  if (!logicalRegion) return 'role="status" aria-live="off"';
 
-  const announce = !state.personalAssistantAnnouncementKeys.has(key);
-  return `role="status" data-pa-announcement-key="${escapeAttr(key)}" aria-live="${announce ? "polite" : "off"}"`;
+  const value = String(semanticValue ?? "");
+  const announcements = state.personalAssistantAnnouncementValues ||= new Map();
+  const announce = announcements.get(logicalRegion) !== value;
+  const key = `${logicalRegion}:${value}`;
+  return `role="status" data-pa-announcement-key="${escapeAttr(key)}" data-pa-announcement-region="${escapeAttr(logicalRegion)}" data-pa-announcement-value="${escapeAttr(value)}" aria-live="${announce ? "polite" : "off"}"`;
 }
 
 function commitPersonalAssistantAnnouncements() {
-  const announcements = state.personalAssistantAnnouncementKeys;
+  const announcements = state.personalAssistantAnnouncementValues ||= new Map();
   if (!els.view || !announcements) return;
   els.view.querySelectorAll("[data-pa-announcement-key]").forEach((element) => {
-    const key = String(element.dataset.paAnnouncementKey || "").trim();
-    if (key) announcements.add(key);
+    const logicalRegion = String(element.dataset.paAnnouncementRegion || "").trim();
+    if (!logicalRegion) return;
+    const value = String(element.dataset.paAnnouncementValue || "");
+    if (announcements.has(logicalRegion)) announcements.delete(logicalRegion);
+    announcements.set(logicalRegion, value);
   });
   while (announcements.size > PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT) {
-    announcements.delete(announcements.values().next().value);
+    announcements.delete(announcements.keys().next().value);
   }
 }
 
@@ -2554,7 +2560,7 @@ function applyPersonalAssistantItem(item) {
     state.personalAssistantRequests.preflights = {};
     state.personalAssistantRequests.currentWork = {};
     state.personalAssistantControlErrors = {};
-    state.personalAssistantAnnouncementKeys.clear();
+    state.personalAssistantAnnouncementValues.clear();
   }
   transferPersonalAssistantDraftArtifacts(previousKey, state.personalAssistant?.active_key || "");
   return state.personalAssistant;
@@ -3033,6 +3039,7 @@ function syncAgentFloatingActions(agent, route = parseRoute()) {
 }
 
 function personalAssistantShellRefreshNeeded(options = {}) {
+  if (state.personalAssistant?.configured) return false;
   const shellAge = state.lastShellUpdatedAt ? Date.now() - state.lastShellUpdatedAt.getTime() : Infinity;
   return options.forceShell === true || shellAge >= 10_000;
 }
@@ -6082,8 +6089,18 @@ function personalAssistantConversationEventIdentity(block) {
   if (eventId) return String(eventId).trim();
   const runId = block?.run_id || metadata.run_id || "";
   const sequence = block?.sequence ?? metadata.sequence ?? metadata._sequence ?? metadata._stream_sequence ?? "";
-  if (runId || sequence) return `${runId}:${sequence}:${block?.kind || ""}`.trim();
-  return String(block?.id || metadata.id || block?.created_at || metadata.created_at || "").trim();
+  if (String(runId).trim() && String(sequence).trim()) return `${runId}:${sequence}:${block?.kind || ""}`.trim();
+  return "";
+}
+
+function personalAssistantConversationEventRunId(block) {
+  const metadata = block?.metadata || {};
+  return String(block?.run_id || metadata.run_id || "").trim();
+}
+
+function personalAssistantConversationEventType(block) {
+  const metadata = block?.metadata || {};
+  return String(metadata.event_type || block?.kind || "").trim();
 }
 
 function personalAssistantBlockMatchesSubmission(block, record) {
@@ -6121,7 +6138,7 @@ function renderPersonalAssistantSubmissionRecovery() {
     record.error || "",
   ].join(":")).join("|");
   return "<section class=\"pa-submission-recovery\" aria-label=\"FRED message delivery\" "
-    + personalAssistantAnnouncementAttributes(`message-delivery:${announcementKey}`) + ">"
+    + personalAssistantAnnouncementAttributes("message-delivery", announcementKey) + ">"
     + "<h3>Message delivery</h3>"
     + records.map((record) => {
       const stateName = normalizePersonalAssistantSubmissionState(record.state);
@@ -6318,7 +6335,7 @@ function renderPersonalAssistantCurrentWork(item) {
     ? groups.map(([label, kind, entries]) => `<div class="pa-current-work-group"><strong>${escapeHtml(label)}</strong><ul>${entries.slice(0, 8).map((entry) => renderPersonalAssistantCurrentWorkEntry(entry, kind)).join("")}</ul></div>`).join("")
     : `<p class="pa-current-work-empty">No active, waiting, failed, or recently completed work is visible to FRED.</p>`;
   const announcementKey = personalAssistantCurrentWorkAnnouncementKey(freshness, stateName, error, groups);
-  return `<section class="pa-current-work ${freshness === "stale" || freshness === "unavailable" ? "degraded" : ""}" aria-labelledby="pa-current-work-title"><div class="pa-current-work-heading"><div><h2 id="pa-current-work-title">Current work</h2><p>${escapeHtml(statusCopy)}</p></div><span class="pa-current-work-state" ${personalAssistantAnnouncementAttributes(`current-work:${announcementKey}`)}>${escapeHtml(personalAssistantCurrentWorkStateLabel(work, freshness))}</span></div>${body}</section>`;
+  return `<section class="pa-current-work ${freshness === "stale" || freshness === "unavailable" ? "degraded" : ""}" aria-labelledby="pa-current-work-title"><div class="pa-current-work-heading"><div><h2 id="pa-current-work-title">Current work</h2><p>${escapeHtml(statusCopy)}</p></div><span class="pa-current-work-state" ${personalAssistantAnnouncementAttributes("current-work", announcementKey)}>${escapeHtml(personalAssistantCurrentWorkStateLabel(work, freshness))}</span></div>${body}</section>`;
 }
 
 function personalAssistantContinuityPreview(value) {
@@ -10823,13 +10840,15 @@ function renderMessage(block, options = {}) {
   const summaryId = block.kind === "run_summary" ? runSummaryId(block) : "";
   const sendState = personalAssistantMessageSendState(block, options);
   const eventIdentity = options.personalAssistant ? personalAssistantConversationEventIdentity(block) : "";
+  const eventRunId = options.personalAssistant ? personalAssistantConversationEventRunId(block) : "";
+  const eventType = options.personalAssistant ? personalAssistantConversationEventType(block) : "";
   const pendingStatus = sendState
-    ? `<div class="message-send-status pa-message-send-status ${escapeAttr(personalAssistantSubmissionStateIntent(sendState))}" data-pa-message-status="${escapeAttr(sendState)}" data-client-request-id="${escapeAttr(personalAssistantBlockRequestId(block))}" ${personalAssistantAnnouncementAttributes(`message:${personalAssistantBlockRequestId(block) || block.id || block.created_at}:${sendState}`)}>${escapeHtml(personalAssistantSubmissionStateLabel(sendState))}</div>`
+    ? `<div class="message-send-status pa-message-send-status ${escapeAttr(personalAssistantSubmissionStateIntent(sendState))}" data-pa-message-status="${escapeAttr(sendState)}" data-client-request-id="${escapeAttr(personalAssistantBlockRequestId(block))}" ${personalAssistantAnnouncementAttributes(`message:${personalAssistantBlockRequestId(block) || block.id || block.created_at || "unknown"}`, sendState)}>${escapeHtml(personalAssistantSubmissionStateLabel(sendState))}</div>`
     : block.pending ? `<div class="message-send-status">sending...</div>` : "";
   const identity = personalAssistantMessageIdentity(block, options);
   const requestId = options.personalAssistant ? personalAssistantBlockRequestId(block) : "";
   return `
-    <article class="${escapeAttr(messageClassName(block))}"${summaryId ? ` data-run-summary-id="${escapeAttr(summaryId)}"` : ""}${requestId ? ` data-client-request-id="${escapeAttr(requestId)}"` : ""}${eventIdentity ? ` data-pa-event-id="${escapeAttr(eventIdentity)}"` : ""}>
+    <article class="${escapeAttr(messageClassName(block))}"${summaryId ? ` data-run-summary-id="${escapeAttr(summaryId)}"` : ""}${requestId ? ` data-client-request-id="${escapeAttr(requestId)}"` : ""}${eventIdentity ? ` data-pa-event-id="${escapeAttr(eventIdentity)}"` : ""}${eventRunId ? ` data-pa-run-id="${escapeAttr(eventRunId)}"` : ""}${eventType ? ` data-pa-event-type="${escapeAttr(eventType)}"` : ""}>
       <div class="message-header">
         <div class="message-role">${identity || `${messageIcon(block)}<span>${escapeHtml(messageRoleLabel(block))}</span>`}${timeHtml}</div>
         ${block.pending ? "" : renderBlockMenuAnchor(block, menuId)}

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -14,6 +14,7 @@ const PERSONAL_ASSISTANT_POLL_INTERVALS = {
   idleMs: 12_000,
   hiddenMs: 30_000,
 };
+const PERSONAL_ASSISTANT_MAX_FAILURE_COUNT = 2;
 const PERSONAL_ASSISTANT_SUBMISSION_STORAGE_KEY = "hq.remote.personalAssistantSubmissions";
 const PERSONAL_ASSISTANT_SUBMISSION_LIMIT = 24;
 const PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT = 128;
@@ -2218,6 +2219,8 @@ function pollDelay() {
 
 function personalAssistantPollDelay() {
   if (document.hidden) return PERSONAL_ASSISTANT_POLL_INTERVALS.hiddenMs;
+  if (state.failureCount > 1) return PERSONAL_ASSISTANT_POLL_INTERVALS.hiddenMs;
+  if (state.failureCount > 0) return PERSONAL_ASSISTANT_POLL_INTERVALS.idleMs;
   const item = state.personalAssistant;
   const agent = item?.active_key ? (state.agentDetails[item.active_key] || item.agent) : null;
   const proposalWork = state.personalAssistantProposals?.some((proposal) =>
@@ -2234,6 +2237,10 @@ function personalAssistantPollDelay() {
   }).some((entry) =>
     ["sending", "queued", "unknown", "running"].includes(entry?.state));
   return active || (session && pending) ? PERSONAL_ASSISTANT_POLL_INTERVALS.activeMs : PERSONAL_ASSISTANT_POLL_INTERVALS.idleMs;
+}
+
+function notePersonalAssistantRefreshFailure() {
+  state.failureCount = Math.min(Number(state.failureCount || 0) + 1, PERSONAL_ASSISTANT_MAX_FAILURE_COUNT);
 }
 
 function refreshIntervals() {
@@ -3074,6 +3081,7 @@ function refreshPersonalAssistantShell(options = {}) {
 
 async function refreshPersonalAssistant(options = {}) {
   const routeHashAtStart = location.hash;
+  let liveContextRefreshFailed = false;
   loadPersonalAssistantSubmissionStates();
   setConnection("Refreshing", { preserveHeaderSubtitle: true });
   try {
@@ -3089,7 +3097,6 @@ async function refreshPersonalAssistant(options = {}) {
     }
 
     state.lastUpdatedAt = new Date();
-    state.failureCount = 0;
     setConnection(refreshedText(), { preserveHeaderSubtitle: true });
     render({ preserveLiveEditor: true });
     if (personalAssistantShellRefreshNeeded(options)) void refreshPersonalAssistantShell(options);
@@ -3105,15 +3112,19 @@ async function refreshPersonalAssistant(options = {}) {
       reconcilePersonalAssistantSubmissions(),
     ].filter(Boolean);
     await Promise.all(work.map((request) => request.catch((error) => {
+      liveContextRefreshFailed = true;
       console.warn("FRED live context refresh degraded", error.message);
       return null;
     })));
     if (location.hash !== routeHashAtStart || parseRoute().type !== "personalAssistant") return;
     state.lastUpdatedAt = new Date();
+    if (liveContextRefreshFailed) notePersonalAssistantRefreshFailure();
+    else state.failureCount = 0;
     setConnection(refreshedText(), { preserveHeaderSubtitle: true });
     render({ preserveLiveEditor: true });
     dismissBootShell();
   } catch (error) {
+    notePersonalAssistantRefreshFailure();
     if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant") {
       setConnection("FRED unavailable: " + error.message, { preserveHeaderSubtitle: true });
       state.renderedViewHtml = "";

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -6147,8 +6147,7 @@ module RemoteServerTest
            js[:body].include?("serverIconName(server)") &&
            js[:body].include?('server?.local) return "home"'),
            "expected local resource ownership to render as an accessible home icon without visible text")
-    assert(!js[:body].include?(["This", "server"].join(" ")) &&
-           js[:body].include?('return server.local ? "Host"'),
+    assert(js[:body].include?('return server.local ? "Host"'),
            "expected local ownership text to use Host")
     assert(js[:body].include?('renderAgentRow(agent, { serverIcon: true, query })') &&
            js[:body].include?('class="agent-server-inline"') &&
@@ -7538,11 +7537,12 @@ module RemoteServerTest
            js[:body].include?("quietRemaining > 0 && !options.force"),
            "expected form typing to defer automatic polling for three seconds")
     assert(js[:body].include?("function fullScreenEditorOpen") &&
-           js[:body].include?("if (fullScreenEditorOpen()) return;") &&
-           js[:body].include?("if (fullScreenEditorOpen() && !options.force) return;") &&
+           js[:body].include?("const personalAssistantRoute = parseRoute().type === \"personalAssistant\";") &&
+           js[:body].include?("if (fullScreenEditorOpen() && !personalAssistantRoute) return;") &&
+           js[:body].include?("if (fullScreenEditorOpen() && !options.force && !personalAssistantRoute) return;") &&
            js[:body].scan("state.fullScreenComposerKeys.delete(key);\n  schedule();").length >= 1 &&
            js[:body].scan("state.fullScreenInquiryKeys.delete(key);\n  schedule();").length >= 1,
-           "expected full-screen Conversation and inquiry forms to pause automatic polling")
+           "expected generic full-screen forms to pause polling while focused FRED keeps polling")
     activity_poll = js[:body][/async function pollAgentActivity\(\).*?^}/m]
     assert(activity_poll && !activity_poll.include?("fullScreenEditorOpen"),
            "expected logo activity polling to continue while full-screen editors are open")

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -21,36 +21,12 @@ module RemoteUIPersonalAssistantBehaviorTest
         let depth = 0;
         let quote = "";
         let escaped = false;
-        let lineComment = false;
-        let blockComment = false;
         for (let index = opening; index < source.length; index += 1) {
           const char = source[index];
-          const next = source[index + 1];
-          if (lineComment) {
-            if (char === "\\n") lineComment = false;
-            continue;
-          }
-          if (blockComment) {
-            if (char === "*" && next === "/") {
-              blockComment = false;
-              index += 1;
-            }
-            continue;
-          }
           if (quote) {
             if (escaped) escaped = false;
             else if (char === "\\") escaped = true;
             else if (char === quote) quote = "";
-            continue;
-          }
-          if (char === "/" && next === "/") {
-            lineComment = true;
-            index += 1;
-            continue;
-          }
-          if (char === "/" && next === "*") {
-            blockComment = true;
-            index += 1;
             continue;
           }
           if (["'", '"', "`"].includes(char)) {
@@ -67,13 +43,23 @@ module RemoteUIPersonalAssistantBehaviorTest
         Map,
         Set,
         PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT: 128,
+        PERSONAL_ASSISTANT_MAX_FAILURE_COUNT: 2,
+        PERSONAL_ASSISTANT_POLL_INTERVALS: { activeMs: 1500, idleMs: 12000, hiddenMs: 30000 },
+        document: { hidden: false },
         state: {
           personalAssistant: { configured: true },
           personalAssistantAnnouncementValues: new Map(),
+          personalAssistantProposals: [],
+          personalAssistantCurrentWork: null,
+          agentDetails: { fred: { running: true } },
+          failureCount: 0,
         },
         els: { view: null },
         escapeAttr: (value) => String(value),
         personalAssistantSubmissionForBlock: () => null,
+        personalAssistantSessionContext: () => ({ server_key: "local", active_key: "fred", generation: 1 }),
+        personalAssistantServerKey: () => "local",
+        personalAssistantSubmissionEntries: () => [],
       };
       vm.createContext(context);
       [
@@ -82,6 +68,8 @@ module RemoteUIPersonalAssistantBehaviorTest
         "personalAssistantShellRefreshNeeded",
         "personalAssistantConversationEventIdentity",
         "personalAssistantVisibleConversationBlocks",
+        "personalAssistantPollDelay",
+        "notePersonalAssistantRefreshFailure",
       ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
 
       const assert = (condition, message) => {
@@ -129,6 +117,20 @@ module RemoteUIPersonalAssistantBehaviorTest
       context.commitPersonalAssistantAnnouncements();
       assert(liveValue(context.personalAssistantAnnouncementAttributes("current-work", "live")) === "polite",
              "recovery announcement was suppressed by historical state");
+
+      context.state.personalAssistant = { configured: true, active_key: "fred" };
+      assert(context.personalAssistantPollDelay() === 1500,
+             "active FRED polling lost its normal cadence");
+      context.notePersonalAssistantRefreshFailure();
+      assert(context.state.failureCount === 1 && context.personalAssistantPollDelay() === 12000,
+             "the first failed FRED poll did not use the bounded idle backoff");
+      context.notePersonalAssistantRefreshFailure();
+      context.notePersonalAssistantRefreshFailure();
+      assert(context.state.failureCount === 2 && context.personalAssistantPollDelay() === 30000,
+             "repeated failed FRED polls were not capped at the hidden backoff");
+      context.state.failureCount = 0;
+      assert(context.personalAssistantPollDelay() === 1500,
+             "successful FRED recovery did not restore active polling");
     JAVASCRIPT
 
     _stdout, stderr, status = Open3.capture3("node", "-e", script, APP_PATH, chdir: ROOT)

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -60,6 +60,7 @@ module RemoteUIPersonalAssistantBehaviorTest
         personalAssistantSessionContext: () => ({ server_key: "local", active_key: "fred", generation: 1 }),
         personalAssistantServerKey: () => "local",
         personalAssistantSubmissionEntries: () => [],
+        personalAssistantRequest: (_requests, _key, factory) => factory(),
       };
       vm.createContext(context);
       [
@@ -70,6 +71,7 @@ module RemoteUIPersonalAssistantBehaviorTest
         "personalAssistantVisibleConversationBlocks",
         "personalAssistantPollDelay",
         "notePersonalAssistantRefreshFailure",
+        "requestPersonalAssistantCurrentWork",
       ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
 
       const assert = (condition, message) => {
@@ -131,6 +133,74 @@ module RemoteUIPersonalAssistantBehaviorTest
       context.state.failureCount = 0;
       assert(context.personalAssistantPollDelay() === 1500,
              "successful FRED recovery did not restore active polling");
+
+      let resolveCurrentWork;
+      let rejectCurrentWork;
+      let renderCalls = 0;
+      context.location = { hash: "#personal-assistant" };
+      context.parseRoute = () => ({ type: "personalAssistant" });
+      context.personalAssistantSessionMatches = () => true;
+      context.apiGet = () => new Promise((resolve, reject) => {
+        resolveCurrentWork = resolve;
+        rejectCurrentWork = reject;
+      });
+      context.render = () => { renderCalls += 1; };
+      context.state.personalAssistantRequests = {
+        currentWork: {},
+        coordinator: { currentWorkSequence: 0, currentWorkApplied: 0 },
+      };
+      context.state.personalAssistantCurrentWork = { state: "fresh", agents: [] };
+      context.state.personalAssistantCurrentWorkState = "fresh";
+      context.state.personalAssistantCurrentWorkError = "";
+      context.state.renderedViewHtml = "stable-current-work-html";
+      const currentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
+        server_key: "local",
+        active_key: "fred",
+        generation: 1,
+      });
+      assert(context.state.personalAssistantCurrentWorkState === "fresh",
+             "background current-work polling replaced the visible snapshot with refreshing");
+      assert(context.state.renderedViewHtml === "stable-current-work-html",
+             "background current-work polling invalidated the visible snapshot before its response");
+      resolveCurrentWork({ state: "fresh", agents: [] });
+      currentWorkRequest.then(() => {
+        assert(renderCalls === 1, "current-work response did not use the existing render path");
+        assert(context.state.renderedViewHtml === "stable-current-work-html",
+               "unchanged current-work response bypassed the same-HTML render shortcut");
+
+        const changedCurrentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
+          server_key: "local",
+          active_key: "fred",
+          generation: 1,
+        });
+        assert(context.state.personalAssistantCurrentWorkState === "fresh",
+               "changed current-work polling replaced the visible snapshot with refreshing");
+        resolveCurrentWork({ state: "stale", agents: [{ key: "fred", status: "waiting" }] });
+        return changedCurrentWorkRequest.then(() => {
+          assert(context.state.personalAssistantCurrentWorkState === "stale",
+                 "changed current-work response did not update its visible state");
+          assert(renderCalls === 2, "changed current-work response did not use the existing render path");
+          assert(context.state.renderedViewHtml === "stable-current-work-html",
+                 "changed current-work response unnecessarily invalidated the existing view");
+
+          const failedCurrentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
+            server_key: "local",
+            active_key: "fred",
+            generation: 1,
+          });
+          assert(context.state.personalAssistantCurrentWorkState === "stale",
+                 "failed background current-work polling replaced the visible snapshot with refreshing");
+          rejectCurrentWork(new Error("offline"));
+          return failedCurrentWorkRequest.catch(() => {
+            assert(context.state.personalAssistantCurrentWorkState === "unavailable",
+                   "current-work failure did not surface an unavailable state");
+            assert(context.state.personalAssistantCurrentWorkError === "offline",
+                   "current-work failure did not retain its error");
+            assert(context.state.renderedViewHtml === "stable-current-work-html",
+                   "current-work failure unnecessarily invalidated the existing view");
+          });
+        });
+      });
     JAVASCRIPT
 
     _stdout, stderr, status = Open3.capture3("node", "-e", script, APP_PATH, chdir: ROOT)

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -69,6 +69,8 @@ module RemoteUIPersonalAssistantBehaviorTest
       vm.createContext(context);
       [
         "personalAssistantAnnouncementAttributes",
+        "personalAssistantActionReceiptAnnouncementAttributes",
+        "renderPersonalAssistantProposal",
         "commitPersonalAssistantAnnouncements",
         "personalAssistantShellRefreshNeeded",
         "personalAssistantConversationEventIdentity",
@@ -126,6 +128,51 @@ module RemoteUIPersonalAssistantBehaviorTest
       context.commitPersonalAssistantAnnouncements();
       assert(liveValue(context.personalAssistantAnnouncementAttributes("current-work", "live")) === "polite",
              "recovery announcement was suppressed by historical state");
+
+      context.escapeHtml = (value) => String(value);
+      context.personalAssistantActionCopy = () => ({ label: "Test action", target: "target", effect: "effect" });
+      context.personalAssistantProposalExpired = () => false;
+      context.personalAssistantActionPreflight = () => null;
+      context.personalAssistantProposalSettings = () => "";
+      context.personalAssistantPreviewRows = () => "";
+      context.personalAssistantActionStatus = () => "Queued";
+      context.personalAssistantActionReceiptCopy = () => "Completed — the same result";
+      context.personalAssistantActionRecovery = () => "";
+      context.renderPersonalAssistantResult = () => "";
+      context.personalAssistantProposalInstruction = () => "instruction";
+      context.state.personalAssistantActionStateOverrides = {};
+      context.state.pendingPersonalAssistantProposalIds = new Set();
+      context.state.personalAssistantActionPreflightErrors = {};
+      context.state.personalAssistantActionErrors = {};
+      context.state.personalAssistantAnnouncementValues = new Map();
+      const proposalA = { id: "proposal-a", state: "queued" };
+      const proposalB = { id: "proposal-b", state: "queued" };
+      const receiptMount = (html) => ({
+        dataset: {
+          paAnnouncementRegion: html.match(/data-pa-announcement-region="([^"]*)"/)[1],
+          paAnnouncementValue: html.match(/data-pa-announcement-value="([^"]*)"/)[1],
+        },
+      });
+      const queuedA = context.renderPersonalAssistantProposal(proposalA);
+      const queuedB = context.renderPersonalAssistantProposal(proposalB);
+      assert(liveValue(queuedA) === "polite" && liveValue(queuedB) === "polite",
+             "distinct proposals sharing receipt text were globally deduplicated");
+      assert(queuedA.includes('data-pa-announcement-region="action-receipt:proposal-a"') &&
+        queuedB.includes('data-pa-announcement-region="action-receipt:proposal-b"'),
+      "receipt announcements did not retain proposal identity");
+      mounted = [receiptMount(queuedA), receiptMount(queuedB)];
+      context.commitPersonalAssistantAnnouncements();
+      assert(liveValue(context.renderPersonalAssistantProposal(proposalA)) === "off" &&
+        liveValue(context.renderPersonalAssistantProposal(proposalB)) === "off",
+      "unchanged receipt announcements were not suppressed after a view rebuild");
+      const completedA = context.renderPersonalAssistantProposal({ ...proposalA, state: "executed" });
+      assert(liveValue(completedA) === "polite",
+             "receipt state changes were suppressed when the visible text stayed the same");
+      mounted = [receiptMount(completedA), receiptMount(queuedB)];
+      context.commitPersonalAssistantAnnouncements();
+      const recoveredA = context.renderPersonalAssistantProposal(proposalA);
+      assert(liveValue(recoveredA) === "polite",
+             "receipt recovery to an earlier state was suppressed by historical state");
 
       context.state.personalAssistant = { configured: true, active_key: "fred" };
       assert(context.personalAssistantPollDelay() === 1500,

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -15,8 +15,9 @@ module RemoteUIPersonalAssistantBehaviorTest
       const source = fs.readFileSync(process.argv[1], "utf8");
 
       function extractFunction(name) {
-        const start = source.indexOf(`function ${name}`);
-        if (start < 0) throw new Error(`missing ${name}`);
+        const marker = source.indexOf(`function ${name}`);
+        if (marker < 0) throw new Error(`missing ${name}`);
+        const start = source.slice(marker - 6, marker) === "async " ? marker - 6 : marker;
         const opening = source.indexOf("{", source.indexOf(")", start));
         let depth = 0;
         let quote = "";
@@ -58,9 +59,12 @@ module RemoteUIPersonalAssistantBehaviorTest
         escapeAttr: (value) => String(value),
         personalAssistantSubmissionForBlock: () => null,
         personalAssistantSessionContext: () => ({ server_key: "local", active_key: "fred", generation: 1 }),
+        personalAssistantSessionMatches: () => true,
         personalAssistantServerKey: () => "local",
         personalAssistantSubmissionEntries: () => [],
         personalAssistantRequest: (_requests, _key, factory) => factory(),
+        loadPersonalAssistantSubmissionStates: () => {},
+        applyPersonalAssistantItem: (item) => { context.state.personalAssistant = item; },
       };
       vm.createContext(context);
       [
@@ -72,6 +76,9 @@ module RemoteUIPersonalAssistantBehaviorTest
         "personalAssistantPollDelay",
         "notePersonalAssistantRefreshFailure",
         "requestPersonalAssistantCurrentWork",
+        "personalAssistantStatusRequestIsCurrent",
+        "requestPersonalAssistantStatus",
+        "ensureConversation",
       ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
 
       const assert = (condition, message) => {
@@ -134,36 +141,158 @@ module RemoteUIPersonalAssistantBehaviorTest
       assert(context.personalAssistantPollDelay() === 1500,
              "successful FRED recovery did not restore active polling");
 
-      let resolveCurrentWork;
-      let rejectCurrentWork;
-      let renderCalls = 0;
-      context.location = { hash: "#personal-assistant" };
-      context.parseRoute = () => ({ type: "personalAssistant" });
-      context.personalAssistantSessionMatches = () => true;
-      context.apiGet = () => new Promise((resolve, reject) => {
-        resolveCurrentWork = resolve;
-        rejectCurrentWork = reject;
-      });
-      context.render = () => { renderCalls += 1; };
-      context.state.personalAssistantRequests = {
-        currentWork: {},
-        coordinator: { currentWorkSequence: 0, currentWorkApplied: 0 },
-      };
-      context.state.personalAssistantCurrentWork = { state: "fresh", agents: [] };
-      context.state.personalAssistantCurrentWorkState = "fresh";
-      context.state.personalAssistantCurrentWorkError = "";
-      context.state.renderedViewHtml = "stable-current-work-html";
-      const currentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
-        server_key: "local",
-        active_key: "fred",
-        generation: 1,
-      });
-      assert(context.state.personalAssistantCurrentWorkState === "fresh",
-             "background current-work polling replaced the visible snapshot with refreshing");
-      assert(context.state.renderedViewHtml === "stable-current-work-html",
-             "background current-work polling invalidated the visible snapshot before its response");
-      resolveCurrentWork({ state: "fresh", agents: [] });
-      currentWorkRequest.then(() => {
+      (async () => {
+        context.location = { hash: "#personal-assistant" };
+        context.parseRoute = () => ({ type: "personalAssistant" });
+        context.personalAssistantSessionContext = (item = context.state.personalAssistant) => {
+          const activeKey = String(item?.active_key || "").trim();
+          const generation = Number(item?.generation);
+          return activeKey && Number.isInteger(generation)
+            ? { server_key: "local", active_key: activeKey, generation }
+            : null;
+        };
+        context.personalAssistantSessionMatches = (captured) => {
+          const current = context.personalAssistantSessionContext();
+          return Boolean(current && captured && current.server_key === captured.server_key &&
+            current.active_key === captured.active_key && current.generation === captured.generation);
+        };
+
+        const oldSession = { active_key: "fred-old", generation: 1 };
+        const newSession = { active_key: "fred-new", generation: 2 };
+        context.personalAssistantRequest = (requests, key, factory) => {
+          if (requests[key]?.promise) return requests[key].promise;
+          const request = { promise: Promise.resolve().then(factory) };
+          requests[key] = request;
+          request.promise.then(
+            () => { if (requests[key] === request) delete requests[key]; },
+            () => { if (requests[key] === request) delete requests[key]; }
+          );
+          return request.promise;
+        };
+        context.state.personalAssistantRequests = {
+          status: null,
+          conversations: {},
+          coordinator: { sequence: 0, applied: 0 },
+        };
+        context.state.personalAssistant = oldSession;
+        context.apiGet = () => Promise.resolve({ personal_assistant: oldSession });
+        const staleStatusRequest = context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        context.state.personalAssistant = newSession;
+        await staleStatusRequest;
+        assert(context.state.personalAssistant === newSession,
+               "status read captured before restart overwrote the new session");
+
+        context.state.personalAssistant = oldSession;
+        context.apiGet = () => Promise.resolve({ personal_assistant: newSession });
+        await context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        assert(context.state.personalAssistant === newSession,
+               "normal status polling did not discover a new generation");
+
+        context.state.personalAssistant = null;
+        context.apiGet = () => Promise.resolve({ personal_assistant: oldSession });
+        const staleInitialStatusRequest = context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        context.state.personalAssistant = newSession;
+        await staleInitialStatusRequest;
+        assert(context.state.personalAssistant === newSession,
+               "status read captured with no session overwrote a newly opened session");
+
+        context.state.personalAssistant = null;
+        await context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        assert(context.state.personalAssistant === oldSession,
+               "initial status discovery was blocked by the null-session guard");
+
+        context.state.personalAssistant = oldSession;
+        context.state.personalAssistantLoadState = "ready";
+        context.state.personalAssistantLoadError = "";
+        context.state.failureCount = 0;
+        let rejectStatus;
+        context.apiGet = () => new Promise((_resolve, reject) => {
+          rejectStatus = reject;
+        });
+        const staleErrorRequest = context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        const coalescedStaleErrorRequest = context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        await Promise.resolve();
+        context.state.personalAssistant = newSession;
+        rejectStatus(new Error("old offline"));
+        const staleErrorResults = await Promise.all([staleErrorRequest, coalescedStaleErrorRequest]);
+        assert(staleErrorResults.every((result) => result === null),
+               "coalesced obsolete status errors did not resolve as obsolete reads");
+        assert(context.state.personalAssistant === newSession &&
+          context.state.personalAssistantLoadState === "ready" &&
+          context.state.personalAssistantLoadError === "" && context.state.failureCount === 0,
+        "obsolete status error marked the new session unavailable or backed off polling");
+
+        context.apiGet = () => Promise.reject(new Error("current offline"));
+        let currentStatusError;
+        try {
+          await context.requestPersonalAssistantStatus(true, "#personal-assistant");
+        } catch (error) {
+          currentStatusError = error;
+        }
+        assert(currentStatusError?.message === "current offline" &&
+          context.state.personalAssistantLoadState === "error" &&
+          context.state.personalAssistantLoadError === "current offline",
+        "current status errors stopped surfacing");
+
+        let conversationReads = 0;
+        const runningAgent = {
+          key: "fred",
+          role: "personal_assistant_daily",
+          running: true,
+          revision: "rev-1",
+        };
+        context.personalAssistantAgent = (agent) => agent?.role === "personal_assistant_daily";
+        context.findAgent = () => runningAgent;
+        context.setConversationLoading = () => {};
+        context.reconcilePersonalAssistantConversation = () => {};
+        context.reconcilePersonalAssistantTerminalRuns = () => {};
+        context.render = () => {};
+        context.state.personalAssistant = { active_key: "fred", generation: 1 };
+        context.state.conversations = {
+          fred: { revision: "rev-1", blocks: [], loaded: true, loading: false },
+        };
+        context.state.loadingConversations = {};
+        context.state.personalAssistantRequests = { conversations: {} };
+        context.apiGet = () => {
+          conversationReads += 1;
+          return Promise.resolve({ conversation: [] });
+        };
+        await context.ensureConversation(runningAgent, false);
+        assert(conversationReads === 1,
+               "running FRED skipped its focused conversation read on an unchanged revision");
+        const idleAgent = { ...runningAgent, running: false };
+        await context.ensureConversation(idleAgent, false);
+        assert(conversationReads === 1,
+               "idle FRED lost its revision-cache conversation shortcut");
+
+        let resolveCurrentWork;
+        let rejectCurrentWork;
+        let renderCalls = 0;
+        context.apiGet = () => new Promise((resolve, reject) => {
+          resolveCurrentWork = resolve;
+          rejectCurrentWork = reject;
+        });
+        context.render = () => { renderCalls += 1; };
+        context.state.personalAssistantRequests = {
+          currentWork: {},
+          coordinator: { currentWorkSequence: 0, currentWorkApplied: 0 },
+        };
+        context.state.personalAssistantCurrentWork = { state: "fresh", agents: [] };
+        context.state.personalAssistantCurrentWorkState = "fresh";
+        context.state.personalAssistantCurrentWorkError = "";
+        context.state.renderedViewHtml = "stable-current-work-html";
+        const currentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
+          server_key: "local",
+          active_key: "fred",
+          generation: 1,
+        });
+        assert(context.state.personalAssistantCurrentWorkState === "fresh",
+               "background current-work polling replaced the visible snapshot with refreshing");
+        assert(context.state.renderedViewHtml === "stable-current-work-html",
+               "background current-work polling invalidated the visible snapshot before its response");
+        await Promise.resolve();
+        resolveCurrentWork({ state: "fresh", agents: [] });
+        await currentWorkRequest;
         assert(renderCalls === 1, "current-work response did not use the existing render path");
         assert(context.state.renderedViewHtml === "stable-current-work-html",
                "unchanged current-work response bypassed the same-HTML render shortcut");
@@ -175,31 +304,34 @@ module RemoteUIPersonalAssistantBehaviorTest
         });
         assert(context.state.personalAssistantCurrentWorkState === "fresh",
                "changed current-work polling replaced the visible snapshot with refreshing");
+        await Promise.resolve();
         resolveCurrentWork({ state: "stale", agents: [{ key: "fred", status: "waiting" }] });
-        return changedCurrentWorkRequest.then(() => {
-          assert(context.state.personalAssistantCurrentWorkState === "stale",
-                 "changed current-work response did not update its visible state");
-          assert(renderCalls === 2, "changed current-work response did not use the existing render path");
-          assert(context.state.renderedViewHtml === "stable-current-work-html",
-                 "changed current-work response unnecessarily invalidated the existing view");
+        await changedCurrentWorkRequest;
+        assert(context.state.personalAssistantCurrentWorkState === "stale",
+               "changed current-work response did not update its visible state");
+        assert(renderCalls === 2, "changed current-work response did not use the existing render path");
+        assert(context.state.renderedViewHtml === "stable-current-work-html",
+               "changed current-work response unnecessarily invalidated the existing view");
 
-          const failedCurrentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
-            server_key: "local",
-            active_key: "fred",
-            generation: 1,
-          });
-          assert(context.state.personalAssistantCurrentWorkState === "stale",
-                 "failed background current-work polling replaced the visible snapshot with refreshing");
-          rejectCurrentWork(new Error("offline"));
-          return failedCurrentWorkRequest.catch(() => {
-            assert(context.state.personalAssistantCurrentWorkState === "unavailable",
-                   "current-work failure did not surface an unavailable state");
-            assert(context.state.personalAssistantCurrentWorkError === "offline",
-                   "current-work failure did not retain its error");
-            assert(context.state.renderedViewHtml === "stable-current-work-html",
-                   "current-work failure unnecessarily invalidated the existing view");
-          });
+        const failedCurrentWorkRequest = context.requestPersonalAssistantCurrentWork("#personal-assistant", {
+          server_key: "local",
+          active_key: "fred",
+          generation: 1,
         });
+        assert(context.state.personalAssistantCurrentWorkState === "stale",
+               "failed background current-work polling replaced the visible snapshot with refreshing");
+        await Promise.resolve();
+        rejectCurrentWork(new Error("offline"));
+        await failedCurrentWorkRequest.catch(() => {});
+        assert(context.state.personalAssistantCurrentWorkState === "unavailable",
+               "current-work failure did not surface an unavailable state");
+        assert(context.state.personalAssistantCurrentWorkError === "offline",
+               "current-work failure did not retain its error");
+        assert(context.state.renderedViewHtml === "stable-current-work-html",
+               "current-work failure unnecessarily invalidated the existing view");
+      })().catch((error) => {
+        console.error(error.stack || error);
+        process.exitCode = 1;
       });
     JAVASCRIPT
 

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RemoteUIPersonalAssistantBehaviorTest
+  module_function
+
+  ROOT = File.expand_path("..", __dir__)
+  APP_PATH = File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.js")
+
+  def run!
+    script = <<~'JAVASCRIPT'
+      const fs = require("fs");
+      const vm = require("vm");
+      const source = fs.readFileSync(process.argv[1], "utf8");
+
+      function extractFunction(name) {
+        const start = source.indexOf(`function ${name}`);
+        if (start < 0) throw new Error(`missing ${name}`);
+        const opening = source.indexOf("{", source.indexOf(")", start));
+        let depth = 0;
+        let quote = "";
+        let escaped = false;
+        let lineComment = false;
+        let blockComment = false;
+        for (let index = opening; index < source.length; index += 1) {
+          const char = source[index];
+          const next = source[index + 1];
+          if (lineComment) {
+            if (char === "\\n") lineComment = false;
+            continue;
+          }
+          if (blockComment) {
+            if (char === "*" && next === "/") {
+              blockComment = false;
+              index += 1;
+            }
+            continue;
+          }
+          if (quote) {
+            if (escaped) escaped = false;
+            else if (char === "\\") escaped = true;
+            else if (char === quote) quote = "";
+            continue;
+          }
+          if (char === "/" && next === "/") {
+            lineComment = true;
+            index += 1;
+            continue;
+          }
+          if (char === "/" && next === "*") {
+            blockComment = true;
+            index += 1;
+            continue;
+          }
+          if (["'", '"', "`"].includes(char)) {
+            quote = char;
+            continue;
+          }
+          if (char === "{") depth += 1;
+          if (char === "}" && --depth === 0) return source.slice(start, index + 1);
+        }
+        throw new Error(`unterminated ${name}`);
+      }
+
+      const context = {
+        Map,
+        Set,
+        PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT: 128,
+        state: {
+          personalAssistant: { configured: true },
+          personalAssistantAnnouncementValues: new Map(),
+        },
+        els: { view: null },
+        escapeAttr: (value) => String(value),
+        personalAssistantSubmissionForBlock: () => null,
+      };
+      vm.createContext(context);
+      [
+        "personalAssistantAnnouncementAttributes",
+        "commitPersonalAssistantAnnouncements",
+        "personalAssistantShellRefreshNeeded",
+        "personalAssistantConversationEventIdentity",
+        "personalAssistantVisibleConversationBlocks",
+      ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
+
+      const assert = (condition, message) => {
+        if (!condition) throw new Error(message);
+      };
+      const liveValue = (attributes) => attributes.match(/aria-live="([^"]+)"/)[1];
+
+      context.state.personalAssistant = { configured: true };
+      assert(context.personalAssistantShellRefreshNeeded() === false,
+             "configured FRED still requests shell setup discovery");
+      context.state.personalAssistant = { configured: false };
+      assert(context.personalAssistantShellRefreshNeeded() === true,
+             "unconfigured FRED lost setup discovery");
+
+      const runOnly = context.personalAssistantVisibleConversationBlocks([
+        { kind: "message", role: "assistant", run_id: "run-1", content: "First" },
+        { kind: "message", role: "assistant", run_id: "run-1", content: "Second" },
+      ]);
+      assert(runOnly.length === 2, "run-only messages were collapsed");
+      const timestampOnly = context.personalAssistantVisibleConversationBlocks([
+        { kind: "message", role: "user", created_at: "2026-09-09T00:00:00Z", content: "Question" },
+        { kind: "message", role: "assistant", created_at: "2026-09-09T00:00:00Z", content: "Answer" },
+      ]);
+      assert(timestampOnly.length === 2, "timestamp-only messages were collapsed");
+      const duplicateEvent = context.personalAssistantVisibleConversationBlocks([
+        { kind: "message", role: "assistant", metadata: { event_id: "event-1" }, content: "Same" },
+        { kind: "message", role: "assistant", metadata: { event_id: "event-1" }, content: "Same" },
+      ]);
+      assert(duplicateEvent.length === 1, "duplicate event IDs were not deduplicated");
+
+      let mounted = [];
+      context.els.view = { querySelectorAll: () => mounted };
+      context.state.personalAssistantAnnouncementValues = new Map();
+      const first = context.personalAssistantAnnouncementAttributes("current-work", "live");
+      const beforeCommit = context.personalAssistantAnnouncementAttributes("current-work", "live");
+      assert(liveValue(first) === "polite" && liveValue(beforeCommit) === "polite",
+             "uncommitted announcement state was consumed");
+      mounted = [{ dataset: { paAnnouncementRegion: "current-work", paAnnouncementValue: "live" } }];
+      context.commitPersonalAssistantAnnouncements();
+      assert(liveValue(context.personalAssistantAnnouncementAttributes("current-work", "live")) === "off",
+             "unchanged announcement was not suppressed");
+      mounted = [{ dataset: { paAnnouncementRegion: "current-work", paAnnouncementValue: "stale" } }];
+      assert(liveValue(context.personalAssistantAnnouncementAttributes("current-work", "stale")) === "polite",
+             "degraded announcement was not announced");
+      context.commitPersonalAssistantAnnouncements();
+      assert(liveValue(context.personalAssistantAnnouncementAttributes("current-work", "live")) === "polite",
+             "recovery announcement was suppressed by historical state");
+    JAVASCRIPT
+
+    _stdout, stderr, status = Open3.capture3("node", "-e", script, APP_PATH, chdir: ROOT)
+    raise "Personal Assistant UI behavior regression failed: #{stderr.strip}" unless status.success?
+
+    puts "remote_ui_personal_assistant_behavior_test: ok"
+  end
+end
+
+RemoteUIPersonalAssistantBehaviorTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -329,14 +329,22 @@ module RemoteUIPersonalAssistantBehaviorTest
                "current-work failure did not retain its error");
         assert(context.state.renderedViewHtml === "stable-current-work-html",
                "current-work failure unnecessarily invalidated the existing view");
+
+        console.log("remote_ui_personal_assistant_behavior_test: completed");
       })().catch((error) => {
         console.error(error.stack || error);
         process.exitCode = 1;
       });
     JAVASCRIPT
 
-    _stdout, stderr, status = Open3.capture3("node", "-e", script, APP_PATH, chdir: ROOT)
-    raise "Personal Assistant UI behavior regression failed: #{stderr.strip}" unless status.success?
+    stdout, stderr, status = Open3.capture3("node", "-e", script, APP_PATH, chdir: ROOT)
+    completion_marker = "remote_ui_personal_assistant_behavior_test: completed"
+    completed = stdout.lines.map(&:chomp).include?(completion_marker)
+    unless status.success? && completed
+      detail = stderr.strip
+      detail = "completion marker missing" unless completed
+      raise "Personal Assistant UI behavior regression failed: #{detail}"
+    end
 
     puts "remote_ui_personal_assistant_behavior_test: ok"
   end


### PR DESCRIPTION
## Summary

- Keep configured FRED responsive while the operator types or uses the
  full-screen composer. FRED refreshes continue on the existing focused
  endpoints; generic agent full-screen polling remains unchanged.
- Use a bounded visible FRED interval of 1.5 seconds when actual agent,
  proposal, queue, current-work, or unresolved submission work is active;
  retain 12-second idle and 30-second hidden backoff. Existing shell/setup
  loading is skipped for configured FRED on the first focused path and remains
  available for unconfigured onboarding and normal Settings/navigation.
- Deduplicate PA messages only with a server event ID or complete run plus
  journal-sequence coordinate; run-only and timestamp-only fallback messages
  stay visible. PA conversation articles expose stable event, run, type, and
  request/status hooks for reconciliation and the isolated browser fixture.
- Make repeated FRED status/recovery announcements stable: each logical region
  compares its last committed semantic value, including inline action receipts
  keyed by proposal identity; repeated `role=status` nodes explicitly use
  `aria-live="off"`, while degraded/recovered values announce again.
- Render local named-server previews as “This server” (or the supplied name)
  while leaving raw URLs/details available to technical users.
- Apply the generic bounded failure policy to focused FRED polling: the first
  failed live-context poll uses idle cadence, repeated failures cap at hidden
  cadence, and a successful refresh restores the active interval. Explicit
  online, tab-return, and manual refreshes still bypass the backoff.
- Preserve an existing current-work snapshot while its background read is
  pending. Unchanged responses keep the existing render comparison and changed,
  stale, unavailable, or recovered responses still update the visible state.
- Guard coalesced status reads with the captured session (or initial item
  identity), including the error path, so a held response after restart cannot
  overwrite, degrade, or back off the new session. A normal unchanged-context
  poll can still discover the next generation.
- While the current FRED agent is running, focused conversation refreshes read
  the conversation even when the cached agent revision is unchanged; idle FRED
  retains the revision shortcut and existing in-flight coalescing.
- Document the final focused behavior, including configured shell deferral,
  bounded polling/failure cadence, and draft/focus/scroll preservation; the
  historical 3.47-second `/setup` observation remains a catalog measurement,
  not a final UI latency claim.

The production UI does not contain fixture-specific performance telemetry or
correlation state. Beta’s reusable isolated fixture owns submit/acceptance and
double-RAF paint-opportunity measurement using the stable DOM identities above.

## Scope and coordination

- UI assets only, plus the existing Remote Server assertion updates required by
  the changed focused-FRED interface. No Ruby service/domain changes, new
  transport, generic event framework, or `bin/`/AGENTS fixture changes.
- Branch `feat/charlie-fred-phase3-ui`, commit
  `8c359e5011db8ab39b13aedd1ae79aff2202aadf`, is based directly on
  merged `origin/main` `9838d7149b9421b36fc558e6efbf03e62ee9eeef`; no old
  Phase2 commits were replayed.
- The executable behavior regression uses a narrow top-level function
  extractor and retains setup, identity, announcement, and polling assertions;
  it does not implement a JavaScript comment lexer.
- Beta owns the reusable browser fixture and metrics. Stable selectors and
  the progress/run identity assumptions are recorded in
  `/tmp/tycho-fred-implementation/phase3-fixture-contract.md`. The paired
  Phase3 browser run remains pending Beta’s fixture branch, so this PR does
  not claim desktop/mobile timing or fake-harness results.
- The approved backend fixture archive used for contract review is
  `/tmp/tycho-fred-implementation/backend-phase3-11f48e4`; no live FRED root,
  session, configuration, or production data was read or changed.

## Verification

All commands ran from the repository with an outer temporary `TYCHO_HOME` and
`TMPDIR` and all inherited Tycho path aliases unset (`TYCHO_CONFIG_PATH`,
`TYCHO_CONFIG_DIR`, `TYCHO_SYSTEM_PROMPTS_PATH`,
`TYCHO_RESPONSE_STYLE_PATH`, `TYCHO_SCHEDULES_PATH`, `TYCHO_LOGS_ROOT`,
`TYCHO_SKILLS_HOME`, `TYCHO_PROJECTS_PATH`, `TYCHO_DATA_ROOT`,
`TYCHO_PERSONAL_ASSISTANT_PATH`, `TYCHO_RUNTIME_ROOT`, and
`TYCHO_MANAGED_AGENTS_PATH`).

- `node --check lib/hq/remote_ui/assets/app.js` — passed.
- `bundle exec ruby test/remote_ui_personal_assistant_behavior_test.rb` — passed;
  executes the reviewed setup, identity, announcement, and failed-poll recovery
  behavior, including unchanged/changed/error current-work responses, stale
  success/error status reads with coalesced callers, and active/idle conversation
  refresh selection. It also renders two distinct inline action receipts with
  shared text, suppresses unchanged committed receipts, and announces state
  changes/recovery. The async assertions emit a completion marker only after
  their final await, and the Ruby wrapper requires that marker as well as exit 0.
- `bundle exec ruby test/remote_ui_state_reconciliation_test.rb` — passed.
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb` — passed.
- `bundle exec ruby test/remote_server_test.rb` — passed.
- `bin/test` — passed after the current-work fix (`bin/test: ok`).

Browser fixture ownership and final paired captures are intentionally reported
separately by Beta; the fixture contract requires a fake harness, temporary
roots initialized before loading HQ, real durable progress before final output,
and separate desktop/390×844 reduced-motion measurements.
