### PR TITLE
Auto-resume schedules after user replies

### DIFF
--- a/lib/hq/app.rb
+++ b/lib/hq/app.rb
@@ -2238,6 +2238,7 @@ def selected_screen_items
       end
       @agent_chat_form.composer.clear unless @agent_chat_form.inquiry_active?
       save_agents!
+      Scheduler.new(registry: @registry).resume_after_user_message(agent.key) if agent.scheduled?
       unless agent.running?
         replacement = @agent_store.start_agent!(agent.key)
         @agents[@agents.index { |item| item.key == agent.key }] = replacement

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -1557,6 +1557,7 @@ module HQ
       store.accept_prompt_from!(agent, actor: opts.fetch(:actor), agents: agents)
       agent.add_user_message!(message, metadata: agent.message_author_metadata(opts.fetch(:actor)))
       store.save(agents)
+      scheduler.resume_after_user_message(agent.key) if opts.fetch(:actor).user? && agent.scheduled?
       agent = store.start_agent!(agent.key)
       if agent.running?
         print_sent_agent(agent_cli_payload(agent), json: opts[:json], out: out)

--- a/lib/hq/domain/schedule_store.rb
+++ b/lib/hq/domain/schedule_store.rb
@@ -35,7 +35,7 @@ module HQ
     :key, :status, :enabled, :paused_at, :last_due_at, :last_started_at, :last_finished_at,
     :last_status, :last_error, :last_target_kind, :last_target_key, :previous_target_key,
     :next_due_at, :run_count, :skip_count, :first_success_notified_at, :failure_started_at,
-    :recovery_notified_at, :resumed_at,
+    :recovery_notified_at, :resumed_at, :stopped_reason, :last_resume_reason,
     keyword_init: true
   ) do
     OPERATOR_STATUSES = %w[scheduled paused stopped].freeze
@@ -70,7 +70,9 @@ module HQ
         first_success_notified_at: parse_time(hash["first_success_notified_at"]),
         failure_started_at: parse_time(hash["failure_started_at"]),
         recovery_notified_at: parse_time(hash["recovery_notified_at"]),
-        resumed_at: parse_time(hash["resumed_at"])
+        resumed_at: parse_time(hash["resumed_at"]),
+        stopped_reason: hash["stopped_reason"],
+        last_resume_reason: hash["last_resume_reason"]
       )
     end
 
@@ -120,7 +122,9 @@ module HQ
         "first_success_notified_at" => first_success_notified_at&.iso8601,
         "failure_started_at" => failure_started_at&.iso8601,
         "recovery_notified_at" => recovery_notified_at&.iso8601,
-        "resumed_at" => resumed_at&.iso8601
+        "resumed_at" => resumed_at&.iso8601,
+        "stopped_reason" => stopped_reason,
+        "last_resume_reason" => last_resume_reason
       }.compact
     end
 
@@ -153,18 +157,27 @@ module HQ
       self.status = "scheduled"
       self.enabled = true
       self.paused_at = nil
+      self.stopped_reason = nil
     end
 
     def mark_paused!(now: Time.now)
       self.status = "paused"
       self.enabled = false
       self.paused_at ||= now
+      self.stopped_reason = nil
+      self.last_resume_reason = nil
     end
 
-    def mark_stopped!(now: Time.now)
+    def mark_stopped!(now: Time.now, reason: nil)
       self.status = "stopped"
       self.enabled = false
       self.paused_at ||= now
+      self.stopped_reason = reason
+      self.last_resume_reason = nil
+    end
+
+    def stopped_for_awaiting_input?
+      stopped? && stopped_reason == "awaiting_input"
     end
   end
 

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -80,6 +80,29 @@ module HQ
       { status: :resumed, schedule: schedule_payload(schedule, state) }
     end
 
+    # Re-enable only schedules that this scheduler explicitly stopped while their
+    # own managed session awaited a user's reply. Manual pauses and all other
+    # stopped conditions intentionally remain unchanged.
+    def resume_after_user_message(agent_key, now: Time.now)
+      key = agent_key.to_s
+      return [] if key.empty?
+
+      states = store.load
+      resumed = schedule_registry.schedules.filter_map do |schedule|
+        state = states[schedule.key]
+        next unless state&.stopped_for_awaiting_input?
+        next unless state.last_target_key.to_s == key
+
+        resume_state!(schedule, state, now:, reason: "user_message")
+        schedule_payload(schedule, state)
+      end
+      store.save(states) if resumed.any?
+      resumed
+    rescue ScheduleRegistry::Error => e
+      HQ.logger.warn("Scheduler") { "Skipped auto-resume after user message: #{e.message}" }
+      []
+    end
+
     def resume_and_run_now(key, now: Time.now, dry_run: false)
       schedule, states, state = schedule_state_for(key)
       ensure_not_expired!(schedule, state, states, now:)
@@ -270,7 +293,10 @@ module HQ
         last_target_key: state.last_target_key,
         run_count: state.run_count.to_i,
         session_run_count: agent ? agent.run_count.to_i : state.run_count.to_i,
-        skip_count: state.skip_count.to_i
+        skip_count: state.skip_count.to_i,
+        stopped_reason: state.stopped_reason,
+        last_resume_reason: state.last_resume_reason,
+        resumed_at: state.resumed_at&.iso8601
       }
     end
 
@@ -316,7 +342,7 @@ module HQ
       return false unless schedule.expired?(now)
       return false if state.stopped? && state.last_status.to_s == "expired"
 
-      state.mark_stopped!(now:)
+      state.mark_stopped!(now:, reason: "expired")
       state.next_due_at = nil
       state.last_status = "expired"
       state.last_error = nil
@@ -369,6 +395,7 @@ module HQ
       state.last_target_key = agent.key
       state.next_due_at = schedule.next_due_after(now)
       state.resumed_at = nil
+      state.last_resume_reason = nil
       state.run_count = state.run_count.to_i + 1
       publish("schedule.started", schedule, state, agent_key: agent.key)
 
@@ -384,7 +411,7 @@ module HQ
       end
       state.last_status = "failed"
       state.last_error = e.message
-      state.mark_stopped!(now:)
+      state.mark_stopped!(now:, reason: "failure")
       notify_schedule_failure(schedule, state, now:, error: e.message)
       publish("schedule.failed", schedule, state, error: e.message)
       publish("schedule.stopped", schedule, state, reason: "failure")
@@ -409,7 +436,7 @@ module HQ
       state.last_status = agent.status
       state.last_error = agent.last_summary
       state.last_finished_at ||= agent.finished_at || now
-      state.mark_stopped!(now:)
+      state.mark_stopped!(now:, reason: "awaiting_input")
       notify_schedule_input_required(schedule, state, agent, now:)
       publish("schedule.stopped", schedule, state, agent_key: agent.key, reason: "input_required")
       { status: :skipped, schedule: schedule_payload(schedule, state) }
@@ -420,7 +447,7 @@ module HQ
       state.last_error = reason
       state.skip_count = state.skip_count.to_i + 1
       state.next_due_at = schedule.next_due_after(now)
-      state.mark_stopped!(now:) if reason.to_s == "interactive"
+      state.mark_stopped!(now:, reason: "interactive") if reason.to_s == "interactive"
       publish("schedule.skipped", schedule, state, reason:)
     end
 
@@ -465,14 +492,15 @@ module HQ
       agents.find { |agent| agent.key == key }
     end
 
-    def resume_state!(schedule, state, now:)
+    def resume_state!(schedule, state, now:, reason: nil)
       was_stopped = state.stopped?
       was_paused = state.paused?
       state.mark_scheduled!
       state.next_due_at = schedule.next_due_after(now)
       state.resumed_at = now if was_stopped || was_paused
-      reason = was_stopped ? "stopped" : (was_paused ? "paused" : "manual")
-      publish("schedule.resumed", schedule, state, reason: reason)
+      state.last_resume_reason = reason if was_stopped || was_paused
+      event_reason = reason || (was_stopped ? "stopped" : (was_paused ? "paused" : "manual"))
+      publish("schedule.resumed", schedule, state, reason: event_reason)
     end
 
     def ensure_not_expired!(schedule, state, states, now:)
@@ -552,7 +580,7 @@ module HQ
       state.last_status = agent.status
       state.last_error = agent.last_summary
       state.failure_started_at ||= now
-      state.mark_stopped!(now:)
+      state.mark_stopped!(now:, reason: "awaiting_input")
       notify_schedule_input_required(schedule, state, agent, now:)
       publish("schedule.stopped", schedule, state, agent_key: agent.key, reason: "input_required")
     end
@@ -561,7 +589,7 @@ module HQ
       state.last_status = agent.status
       state.last_error = agent.last_summary
       state.failure_started_at ||= now
-      state.mark_stopped!(now:)
+      state.mark_stopped!(now:, reason: "failure")
       notify_schedule_failure(schedule, state, now:, agent:)
       publish("schedule.failed", schedule, state, agent_key: agent.key, status: agent.status)
       publish("schedule.stopped", schedule, state, agent_key: agent.key, reason: "failure")

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -84,7 +84,7 @@ module HQ
                    restart_command: nil, token: HQ.env("REMOTE_TOKEN"), logger: HQ.logger, output: $stdout,
                    daemonize_after_startup: false, daemon_log_path: REMOTE_DAEMON_LOG_FILE, daemonizer: nil,
                    resource_catalog: nil, resource_snapshot_path: nil, agent_activity_snapshot: nil,
-                   personal_assistant_action_worker: nil)
+                   personal_assistant_action_worker: nil, registry: nil, clock: -> { Time.now })
       @host = host.to_s.empty? ? DEFAULT_HOST : host.to_s
       @port = port.to_i.positive? ? port.to_i : DEFAULT_PORT
       @public_url = public_url.to_s
@@ -98,6 +98,8 @@ module HQ
       @daemonizer = daemonizer
       @resource_catalog = resource_catalog || RemoteResourceCatalog.new(snapshot_path: resource_snapshot_path)
       @agent_activity_snapshot = agent_activity_snapshot || AgentActivitySnapshot.new
+      @registry = registry
+      @clock = clock
       @personal_assistant_actions = personal_assistant_action_worker&.respond_to?(:actions) ? personal_assistant_action_worker.actions : build_personal_assistant_action_store
       @personal_assistant_action_worker = personal_assistant_action_worker || build_personal_assistant_action_worker
       @personal_assistant_timezone_cache = PersonalAssistantLifecycle::TimezoneSnapshotCache.new
@@ -204,6 +206,8 @@ module HQ
 
     def background_personal_assistant_service
       RemoteService.new(
+        registry: @registry || Registry.new,
+        clock: @clock,
         server_url: "http://#{@host}:#{@port}",
         public_url: @public_url,
         auth_required: !@token.empty?,
@@ -314,6 +318,8 @@ module HQ
       end
 
       service = RemoteService.new(
+        registry: @registry || Registry.new,
+        clock: @clock,
         server_url: "http://#{@host}:#{@port}",
         public_url: @public_url,
         auth_required: !@token.empty?,
@@ -3903,8 +3909,9 @@ module HQ
         )
       end
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"]) && !target.running?
+      resumed_schedules = actor.user? && target.scheduled? ? scheduler.resume_after_user_message(target.key) : []
       @agent_activity_snapshot.upsert!(target)
-      { agent: agent_payload(target), conversation: conversation(target.key) }
+      { agent: agent_payload(target), conversation: conversation(target.key), resumed_schedules: resumed_schedules }
     rescue DelegationStore::Error => e
       raise Error.new(e.message, status: actor&.parent? ? 403 : 409)
     rescue ArgumentError => e
@@ -3960,8 +3967,9 @@ module HQ
         feedback_embedded:
       )
       target = @agent_store.start_agent!(target.key) if truthy?(attrs["start"]) && !target.running?
+      resumed_schedules = target.scheduled? ? scheduler.resume_after_user_message(target.key) : []
       @agent_activity_snapshot.upsert!(target)
-      { agent: agent_payload(target), conversation: conversation(target.key) }
+      { agent: agent_payload(target), conversation: conversation(target.key), resumed_schedules: resumed_schedules }
     rescue ArgumentError => e
       raise Error.new(e.message, status: e.message.start_with?("Unknown agent") ? 404 : 409)
     end

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -11593,6 +11593,10 @@ async function submitComposerPrompt(options) {
       };
     }
     if (response.queued || responseState === "queued") showGrowl("Prompt queued", "done");
+    if (!isPersonalAssistant && Array.isArray(response.resumed_schedules) && response.resumed_schedules.length) {
+      const names = response.resumed_schedules.map((schedule) => schedule.name || schedule.key).join(", ");
+      showGrowl(`Schedule resumed after your reply: ${names}`, "done");
+    }
     submittedAttachments.forEach(revokePendingAttachment);
     if (!queueing) setComposerSending(form, false);
     if (!isPersonalAssistant) removePendingConversationMessage(key, pendingMessageId, { render: false });
@@ -14860,7 +14864,8 @@ function scheduleSubtext(schedule) {
   const project = schedule.project_key || "unknown project";
   const next = schedule.next_due_at ? `next ${timeShort(schedule.next_due_at)}` : "next n/a";
   const ends = schedule.ends_at ? ` / ends ${timeShort(schedule.ends_at)}` : "";
-  return `${project} / ${next}${ends} / ${humanizeCron(schedule.cron)}`;
+  const resumed = schedule.last_resume_reason === "user_message" ? " / resumed after your reply" : "";
+  return `${project} / ${next}${ends}${resumed} / ${humanizeCron(schedule.cron)}`;
 }
 
 function scheduleDaemonHeaderPills(daemon) {

--- a/test/personal_assistant_phase2_test.rb
+++ b/test/personal_assistant_phase2_test.rb
@@ -249,19 +249,24 @@ class PersonalAssistantPhase2Test
         executor: ->(*) { started << true; release.pop; { "ok" => true } }
       )
       fixture.open!(service, _direct_server)
-      FileUtils.cp(fixture.registry.path, HQ::Registry::DEFAULT_PATH)
       target = service.create_agent(
         "project_key" => "web", "name" => "HTTP Target", "prompt" => "HTTP target prompt", "agent" => "codex"
       )
+      assert(service.instance_variable_get(:@personal_assistant).status[:state] == "active",
+             "expected fixture FRED session to remain active before HTTP server startup")
       proposal = fixture.register(actions, "start_agent", { "agent_key" => target[:key] }, "http-start-1")
       port = fixture.free_port
       service.instance_variable_set(:@server_url, "http://127.0.0.1:#{port}")
-      server = HQ::RemoteServer.new(host: "127.0.0.1", port:, personal_assistant_action_worker: worker)
+      server = HQ::RemoteServer.new(
+        host: "127.0.0.1", port:, personal_assistant_action_worker: worker,
+        registry: fixture.registry,
+        clock: -> { Time.utc(2026, 9, 9, 12) }
+      )
       thread = Thread.new { server.start }
       begin
         fixture.wait_for_http!(port)
         preflight_status, preflight = fixture.http_request(port, "GET", "/personal-assistant/actions/#{proposal["id"]}/preflight")
-        assert(preflight_status == 200, "expected HTTP preflight to succeed")
+        assert(preflight_status == 200, "expected HTTP preflight to succeed: #{preflight.inspect}")
         token = preflight.dig("preflight", "precondition_token")
         confirm_status, confirmed = fixture.http_request(
           port, "POST", "/personal-assistant/actions/#{proposal["id"]}/confirm",

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -17,6 +17,7 @@ module RemoteServerTest
   def run!
     assert_remote_agent_lifecycle
     assert_remote_agent_delegation_lifecycle
+    assert_remote_user_message_auto_resumes_awaiting_schedule
     assert_remote_agent_response_style_selection_is_independent
     assert_remote_archive_reconciles_scheduled_agent_state
     assert_remote_agent_bulk_archive
@@ -86,6 +87,53 @@ module RemoteServerTest
     assert_server_daemonizes_after_startup_to_log
     assert_server_prints_request_logs
     puts "remote_server_test: ok"
+  end
+
+  def assert_remote_user_message_auto_resumes_awaiting_schedule
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      registry = registry_for_project(dir, workspace)
+      File.write(HQ::SCHEDULES_FILE, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              agent_key: scheduled-agent
+              message: "Run maintenance."
+      YAML
+      service = HQ::RemoteService.new(registry: registry)
+      agent = service.create_agent(
+        "project_key" => "web", "name" => "Scheduled agent", "prompt" => "Maintain", "agent" => "codex"
+      )
+      stored = service.send(:load_all_agents).find { |item| item.key == agent[:key] }
+      stored.associate_schedule!("weekday")
+      service.send(:save_agent, stored)
+
+      state = HQ::ScheduleStore.new.state_for({}, "weekday")
+      state.last_target_key = agent[:key]
+      state.mark_stopped!(reason: "awaiting_input")
+      HQ::ScheduleStore.new.save("weekday" => state)
+
+      response = service.submit_prompt(agent[:key], "prompt" => "Use main.", "start" => false)
+      assert(response.dig(:resumed_schedules, 0, :key) == "weekday",
+             "expected a user message to report the resumed schedule")
+      resumed = HQ::ScheduleStore.new.load.fetch("weekday")
+      assert(resumed.scheduled? && resumed.last_resume_reason == "user_message",
+             "expected user message to resume only the recorded awaiting-input stop")
+
+      resumed.mark_paused!
+      HQ::ScheduleStore.new.save("weekday" => resumed)
+      parent = service.create_agent(
+        "project_key" => "web", "name" => "Parent", "prompt" => "Coordinate", "agent" => "codex"
+      )
+      service.submit_prompt(agent[:key], "prompt" => "Parent follow-up", "parent_agent_key" => parent[:key], "start" => false)
+      assert(HQ::ScheduleStore.new.load.fetch("weekday").paused?,
+             "expected delegated parent messages not to override a deliberate manual pause")
+    end
   end
 
   def assert_remote_agent_delegation_lifecycle
@@ -6496,8 +6544,9 @@ module RemoteServerTest
            js[:body].include?('statusBadge(titleFromKey(scheduleStatusLabel(schedule)), className)'),
            "expected Remote UI schedule status labels to render inline with the title")
     assert(js[:body].include?("const ends = schedule.ends_at") &&
-           js[:body].include?("return `${project} / ${next}${ends} / ${humanizeCron(schedule.cron)}`;"),
-           "expected Remote UI schedule rows to show optional loop expiry without last outcome")
+           js[:body].include?("schedule.last_resume_reason === \"user_message\"") &&
+           js[:body].include?("resumed after your reply"),
+           "expected Remote UI schedule rows to show optional loop expiry and user-message auto-resume state")
     assert(!js[:body].include?("last ${schedule.last_status}"),
            "expected Remote UI schedule rows not to render last status text")
     assert(js[:body].include?("MagicDNS push requires Tailscale HTTPS"),

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -29,6 +29,7 @@ module SchedulerTest
       assert_refresh_failure_keeps_replacement_recoverable
       assert_expired_refresh_preserves_current_session
       assert_schedule_waits_for_human_input
+      assert_schedule_auto_resumes_only_after_awaiting_input_reply
     end
     assert_schedule_daemon_supervisor_spawns_external_daemon
     assert_bin_schedule_list_lists_configured_schedules
@@ -556,6 +557,42 @@ module SchedulerTest
       assert(state.last_status == "awaiting-input", "expected schedule to preserve the agent attention status")
       assert(state.last_target_key == agent.key, "expected schedule to keep the input-required session linked")
       assert(read_agents.map(&:key) == [agent.key], "expected input-required session to remain active")
+    end
+  end
+
+  def assert_schedule_auto_resumes_only_after_awaiting_input_reply
+    with_temp_runtime do |dir|
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: weekday
+            cron: "0 9 * * 1-5"
+            target:
+              type: agent
+              project_key: web
+              name: Weekday maintenance
+              message: "Run maintenance."
+      YAML
+      scheduler = build_scheduler(registry, schedule_path)
+      started = scheduler.run_now("weekday")
+      agent = started.fetch(:agent)
+      state = HQ::ScheduleStore.new.load.fetch("weekday")
+      state.mark_stopped!(reason: "awaiting_input")
+      HQ::ScheduleStore.new.save("weekday" => state)
+
+      resumed = scheduler.resume_after_user_message(agent.key)
+      state = HQ::ScheduleStore.new.load.fetch("weekday")
+      assert(resumed.map { |item| item[:key] } == ["weekday"], "expected the awaiting-input schedule to resume")
+      assert(state.scheduled? && state.last_resume_reason == "user_message",
+             "expected auto-resume provenance to be visible in schedule state")
+
+      state.mark_paused!
+      HQ::ScheduleStore.new.save("weekday" => state)
+      assert(scheduler.resume_after_user_message(agent.key).empty?, "expected manual pause to remain paused")
+
+      state = HQ::ScheduleStore.new.load.fetch("weekday")
+      state.mark_stopped!(reason: "failure")
+      HQ::ScheduleStore.new.save("weekday" => state)
+      assert(scheduler.resume_after_user_message(agent.key).empty?, "expected unrelated stopped state to remain stopped")
     end
   end
 


### PR DESCRIPTION
Resume only schedules explicitly stopped for awaiting user input. Covers CLI, TUI, Remote message and inquiry replies; preserves delegation/takeover behavior; surfaces the automatic resume in Remote UI.\n\nValidated: scheduler_test, remote_server_test, rendering_test. Remote UI smoke is blocked by an existing Settings-menu assertion before this path.