### PR TITLE
Use folder icons for archive actions

### DIFF
--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -162,11 +162,20 @@ const ICONS = {
       <path d="m4.9 4.9 14.2 14.2"></path>
     </svg>
   `,
-  archive: `
+  folderDown: `
     <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
-      <rect width="20" height="5" x="2" y="3" rx="1"></rect>
-      <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"></path>
-      <path d="M10 12h4"></path>
+      <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path>
+      <path d="M12 10v6"></path>
+      <path d="m15 13-3 3-3-3"></path>
+    </svg>
+  `,
+  folderSync: `
+    <svg class="ui-icon" aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M9 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v.5"></path>
+      <path d="M12 10v4h4"></path>
+      <path d="m12 14 1.535-1.605a5 5 0 0 1 8 1.5"></path>
+      <path d="M22 22v-4h-4"></path>
+      <path d="m22 18-1.535 1.605a5 5 0 0 1-8-1.5"></path>
     </svg>
   `,
   activity: `
@@ -5054,7 +5063,7 @@ function renderScheduleActionsMenu(schedule) {
     moreMenuButton({
       label: "Refresh session",
       sublabel: "Archive this session and run a fresh one",
-      icon: "refreshCw",
+      icon: "folderSync",
       attrs: `data-schedule-action="refresh-session" data-schedule-key="${escapeAttr(schedule.key)}"`,
     }),
     moreMenuButton({
@@ -5436,7 +5445,7 @@ function agentBulkActionMenuHtml() {
       ${moreMenuButton({
         label: "Archive agents",
         sublabel: selectedLabel,
-        icon: "archive",
+        icon: "folderDown",
         attrs: "data-run-bulk-archive",
         danger: true,
         disabled: selected.length === 0,
@@ -5479,7 +5488,7 @@ function agentMobileToolbarMenuHtml() {
         moreMenuButton({
           label: "Archive agents",
           sublabel: `${selectedBulkArchiveKeys().length} selected`,
-          icon: "archive",
+          icon: "folderDown",
           attrs: "data-run-bulk-archive",
           danger: true,
           disabled: selectedBulkArchiveKeys().length === 0,
@@ -7064,7 +7073,7 @@ function renderServerActionsMenu(server) {
       }),
       moreMenuButton({
         label: "Forget cached data",
-        icon: "archive",
+        icon: "folderDown",
         attrs: `data-forget-server-resources="${key}"`,
       }),
       moreMenuSeparator(),
@@ -9452,7 +9461,7 @@ function renderAgentArchive(key) {
         ${kv("Runs", agent.run_count)}
       </div>
       <div class="button-row form-actions ui-form-actions archive-actions">
-        <button class="danger inline-icon-button ui-button" data-variant="danger" type="button" data-agent-action="archive" data-agent-key="${escapeAttr(agent.key)}">${iconSvg("archive")}<span>Archive</span></button>
+        <button class="danger inline-icon-button ui-button" data-variant="danger" type="button" data-agent-action="archive" data-agent-key="${escapeAttr(agent.key)}">${iconSvg("folderDown")}<span>Archive</span></button>
         <button class="inline-icon-button ui-button" type="button" data-clone-agent="${escapeAttr(agent.key)}">${iconSvg("copyPlus")}<span>Clone instead</span></button>
         <button type="button" data-open-agent="${escapeAttr(agent.key)}">Cancel</button>
       </div>
@@ -14058,7 +14067,7 @@ function agentMoreMenuHtml(agent) {
     moreMenuButton({
       label: "Archive agent",
       sublabel: lifecycleSublabel,
-      icon: "archive",
+      icon: "folderDown",
       attrs: `data-archive-agent="${escapeAttr(agent.key)}"`,
       danger: true,
       disabled: running,

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -6436,8 +6436,17 @@ module RemoteServerTest
            js[:body].include?("Runs in current session"),
            "expected schedule rows to show current-session run counts with threshold colors")
     assert(js[:body].include?('label: "Refresh session"') &&
-           js[:body].include?('data-schedule-action="refresh-session"'),
-           "expected schedule actions to refresh the current session")
+           js[:body].include?('data-schedule-action="refresh-session"') &&
+           js[:body].include?('sublabel: "Archive this session and run a fresh one"') &&
+           js[:body].include?('icon: "folderSync"'),
+           "expected Schedule refresh-session action to use folder-sync for archive-and-run")
+    assert(js[:body].include?('folderDown: `') &&
+           js[:body].include?('M12 10v6') &&
+           js[:body].include?('iconSvg("folderDown")') &&
+           js[:body].scan('icon: "folderDown"').length >= 3 &&
+           !js[:body].include?('icon: "archive"') &&
+           !js[:body].include?('iconSvg("archive")'),
+           "expected every Remote UI archive control to use the Lucide folder-down icon")
     assert(js[:body].include?('label: "Run now"') &&
            js[:body].include?('attrs: `data-schedule-action="run" data-schedule-key="${escapeAttr(schedule.key)}"`') &&
            !js[:body].include?("schedule-run-button"),


### PR DESCRIPTION
Summary: replace all Remote UI archive icon uses with Lucide folder-down; use Lucide folder-sync only for Schedule Refresh session, which archives then runs a fresh session; and cover the icon selection while preserving labels and behavior.

Verification: bin/test passed. bin/remote-ui-smoke exercised the Schedule menu but has a pre-existing Settings context-menu failure.