### PR TITLE
Load new conversation messages manually

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5413,6 +5413,49 @@ Saved safely.
         if (value !== draft) throw new Error(`Composer draft was not preserved: ${JSON.stringify(value)}`);
         await assertEditorExcludedFromRefresh("#composer:not(.composer-full-screen)", "Inline conversation form", "#prompt-input");
 
+        // Polling may observe a server snapshot while the user is composing.
+        // The browser must retain the rendered history and scroll position until
+        // the explicit accessible control is activated.
+        const stagedConversation = await page.evaluate((key) => {
+          const baseline = Array.from({ length: 28 }, (_item, index) => ({
+            id: `manual-load-${index}`,
+            kind: "message",
+            role: index % 2 ? "assistant" : "user",
+            content: `Existing message ${index}`,
+            created_at: new Date(1_700_000_000_000 + index * 1000).toISOString(),
+          }));
+          state.conversations[key] = { revision: "manual-load-baseline", blocks: baseline, loaded: true, loading: false };
+          delete state.pendingConversationUpdates[key];
+          render({ preserveLiveEditor: true });
+          const root = document.querySelector("[data-agent-conversation-scroll]");
+          root.scrollTop = Math.max(0, root.scrollHeight - root.clientHeight - 120);
+          const before = root.scrollTop;
+          receiveConversationSnapshot(key, [...baseline, {
+            id: "manual-load-new",
+            kind: "message",
+            role: "assistant",
+            content: "Server message staged for manual loading",
+            created_at: new Date().toISOString(),
+          }], "manual-load-next");
+          render({ preserveLiveEditor: true });
+          return {
+            before,
+            after: document.querySelector("[data-agent-conversation-scroll]").scrollTop,
+            draft: document.querySelector("#prompt-input")?.value,
+            button: document.querySelector("[data-load-pending-conversation]")?.getAttribute("aria-label"),
+            stagedVisible: document.body.textContent.includes("Server message staged for manual loading"),
+          };
+        }, agentKey);
+        if (stagedConversation.button !== "Load 1 new message" || stagedConversation.stagedVisible ||
+            stagedConversation.draft !== draft || Math.abs(stagedConversation.after - stagedConversation.before) > 8) {
+          throw new Error(`Manual conversation loading changed the visible snapshot before activation: ${JSON.stringify(stagedConversation)}`);
+        }
+        await page.click("[data-load-pending-conversation]");
+        await page.waitForFunction(() => document.body.textContent.includes("Server message staged for manual loading"), { timeout: 10_000 });
+        if (await page.locator("[data-load-pending-conversation]").count() || (await page.locator("#prompt-input").inputValue()) !== draft) {
+          throw new Error("Manual conversation loading did not apply the staged snapshot while preserving the composer");
+        }
+
         const expandButtonGeometry = await page.locator(".composer-full-screen-button").evaluate((button) => {
           const control = button.getBoundingClientRect();
           const icon = button.querySelector(".ui-icon").getBoundingClientRect();

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -6105,6 +6105,21 @@ select {
   white-space: nowrap;
 }
 
+.new-conversation-messages {
+  position: sticky;
+  bottom: 12px;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+  max-width: calc(100% - 24px);
+  margin: 12px auto;
+}
+
+.new-conversation-messages .ui-button {
+  box-shadow: 0 3px 14px color-mix(in srgb, #000 24%, transparent);
+}
+
 .composer {
   position: relative;
   display: grid;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -761,6 +761,7 @@ const state = {
   onboardingGuide: "",
   settingsSection: "connection",
   conversations: {},
+  pendingConversationUpdates: {},
   loadingConversations: {},
   pendingConversationMessages: {},
   pendingComposerKeys: new Set(),
@@ -3793,14 +3794,9 @@ async function ensureConversation(agent, force = false) {
           personalAssistantSessionMatches(context) &&
           revisionMatches;
         if (!current) return null;
-        state.conversations[agent.key] = {
-          revision: capturedRevision,
-          blocks: data.conversation || [],
-          loaded: true,
-          loading: false,
-        };
-        reconcilePersonalAssistantConversation(agent.key, state.conversations[agent.key].blocks);
-        reconcilePersonalAssistantTerminalRuns(agent.key, state.conversations[agent.key].blocks);
+        receiveConversationSnapshot(agent.key, data.conversation || [], capturedRevision, { initial: !cached?.loaded });
+        reconcilePersonalAssistantConversation(agent.key, data.conversation || []);
+        reconcilePersonalAssistantTerminalRuns(agent.key, data.conversation || []);
         return data;
       } catch (error) {
         if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant" &&
@@ -3827,12 +3823,7 @@ async function ensureConversation(agent, force = false) {
   render();
   try {
     const data = await apiGet(`/agents/${encodeURIComponent(agent.key)}/conversation`);
-    state.conversations[agent.key] = {
-      revision: agent.revision,
-      blocks: data.conversation || [],
-      loaded: true,
-      loading: false,
-    };
+    receiveConversationSnapshot(agent.key, data.conversation || [], agent.revision, { initial: !cached?.loaded });
   } finally {
     setConversationLoading(agent.key, false);
   }
@@ -7783,6 +7774,7 @@ function renderAgentConversationView(agent, blocks, options = {}) {
       ${renderAgentRelationshipContext(agent)}
       ${conversationBlocks.length ? renderConversationBlocks(conversationBlocks, { ...options, agent }) : emptyHtml}
     </div>
+    ${renderPendingConversationControl(agent)}
     <div data-conversation-recent aria-hidden="true"></div>
     ${options.floatingActions === false ? "" : renderAgentFloatingActions(agent, { recent: true })}
   `;
@@ -7958,10 +7950,66 @@ function tychoLoadingState(label, options = {}) {
 }
 
 function conversationBlocksForAgent(agent, blocks) {
-  const pending = state.pendingConversationMessages[agent?.key] || [];
+  const pending = (state.pendingConversationMessages[agent?.key] || []).filter((block) =>
+    !REMOTE_HELPERS.pendingConversationBlockAcknowledged(block, blocks));
   if (!pending.length) return blocks;
 
   return blocks.concat(pending);
+}
+
+function pendingConversationUpdate(agentKey) {
+  return (state.pendingConversationUpdates || {})[String(agentKey || "")] || null;
+}
+
+function receiveConversationSnapshot(agentKey, blocks, revision, options = {}) {
+  const key = String(agentKey || "");
+  if (!key) return { applied: false, unseen: [] };
+
+  state.pendingConversationUpdates ||= {};
+  const incoming = Array.isArray(blocks) ? blocks : [];
+  const current = state.conversations[key];
+  const shouldApply = options.initial === true || !current?.loaded;
+  if (shouldApply) {
+    state.conversations[key] = { revision, blocks: incoming, loaded: true, loading: false };
+    delete state.pendingConversationUpdates[key];
+    return { applied: true, unseen: [] };
+  }
+
+  if (REMOTE_HELPERS.conversationBlocksMatch(current.blocks, incoming)) {
+    delete state.pendingConversationUpdates[key];
+    return { applied: false, unseen: [] };
+  }
+
+  const unseen = REMOTE_HELPERS.unseenConversationBlocks(current.blocks, incoming);
+  state.pendingConversationUpdates[key] = { revision, blocks: incoming, unseen };
+  return { applied: false, unseen };
+}
+
+function loadPendingConversationMessages(agentKey) {
+  const key = String(agentKey || "");
+  const pending = pendingConversationUpdate(key);
+  if (!pending) return;
+
+  state.conversations[key] = {
+    ...(state.conversations[key] || {}),
+    revision: pending.revision,
+    blocks: pending.blocks,
+    loaded: true,
+    loading: false,
+  };
+  delete state.pendingConversationUpdates[key];
+  state.renderedViewHtml = "";
+  render({ preserveLiveEditor: true });
+  window.requestAnimationFrame(scrollAgentConversationToBottom);
+}
+
+function renderPendingConversationControl(agent) {
+  const pending = pendingConversationUpdate(agent?.key);
+  const count = pending?.unseen?.length || 0;
+  if (!pending) return "";
+
+  const label = count ? `${count} new message${count === 1 ? "" : "s"}` : "Conversation updated";
+  return `<div class="new-conversation-messages" role="status" aria-live="polite" aria-atomic="true"><button class="ui-button" type="button" data-load-pending-conversation="${escapeAttr(agent.key)}" aria-label="Load ${escapeAttr(label)}">Load ${escapeHtml(label)}</button></div>`;
 }
 
 function renderAgentAttachmentView(agent, attachmentId, options = {}) {
@@ -11556,12 +11604,7 @@ async function submitComposerPrompt(options) {
     if (!currentPersonalAssistantRequest()) return record;
     if (response.agent) upsertAgent(response.agent);
     if (responseConversation.length) {
-      state.conversations[key] = {
-        revision: response.agent?.revision || state.conversations[key]?.revision,
-        blocks: responseConversation,
-        loaded: true,
-        loading: false,
-      };
+      receiveConversationSnapshot(key, responseConversation, response.agent?.revision || state.conversations[key]?.revision);
       reconcilePersonalAssistantConversation(key, responseConversation);
       reconcilePersonalAssistantTerminalRuns(key, responseConversation);
     }
@@ -11594,12 +11637,7 @@ async function submitComposerPrompt(options) {
       persistOptimisticPromptQueue(key, optimisticPromptQueueEntries(key));
     }
     if (!isPersonalAssistant && Array.isArray(response.conversation)) {
-      state.conversations[key] = {
-        revision: response.agent?.revision,
-        blocks: response.conversation,
-        loaded: true,
-        loading: false,
-      };
+      receiveConversationSnapshot(key, response.conversation, response.agent?.revision);
     }
     if (response.queued || responseState === "queued") showGrowl("Prompt queued", "done");
     if (!isPersonalAssistant && Array.isArray(response.resumed_schedules) && response.resumed_schedules.length) {
@@ -16035,12 +16073,7 @@ async function runInquiryLifecycleAction(button) {
     if (!currentRequest()) return;
     if (response.agent) upsertAgent(response.agent);
     if (Array.isArray(response.conversation)) {
-      state.conversations[key] = {
-        revision: response.agent?.revision,
-        blocks: response.conversation,
-        loaded: true,
-        loading: false,
-      };
+      receiveConversationSnapshot(key, response.conversation, response.agent?.revision);
     }
     clearPersonalAssistantControlError(
       key,
@@ -16212,6 +16245,12 @@ async function checkPersonalAssistantActionReceipt(id) {
 }
 
 function handleViewClick(event) {
+  const loadConversationButton = event.target.closest("[data-load-pending-conversation]");
+  if (loadConversationButton) {
+    loadPendingConversationMessages(loadConversationButton.dataset.loadPendingConversation);
+    return;
+  }
+
   if (event.target.closest("[data-open-settings]")) {
     navigate({ type: "tab", tab: "settings" });
     return;

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -548,6 +548,66 @@
     return !conversation?.loaded || conversation.loading === true || fetching === true;
   }
 
+  // A server conversation is append-oriented, but a run can amend its last
+  // progress block. Keep a stable identity when available and otherwise use
+  // the user-visible content. The latter deliberately treats exact repeated
+  // messages as separate occurrences below.
+  function conversationBlockIdentity(block) {
+    const metadata = block?.metadata || {};
+    const id = block?.id || block?.event_id || metadata.id || metadata.event_id;
+    if (id) return `id:${id}`;
+
+    return JSON.stringify([
+      block?.kind || "",
+      block?.role || "",
+      block?.tool_name || "",
+      block?.created_at || metadata.created_at || "",
+      block?.content || "",
+    ]);
+  }
+
+  function conversationBlocksMatch(left, right) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+    return left.every((block, index) => conversationBlockIdentity(block) === conversationBlockIdentity(right[index]));
+  }
+
+  function unseenConversationBlocks(rendered, incoming) {
+    const seen = new Map();
+    (Array.isArray(rendered) ? rendered : []).forEach((block) => {
+      const identity = conversationBlockIdentity(block);
+      seen.set(identity, (seen.get(identity) || 0) + 1);
+    });
+    return (Array.isArray(incoming) ? incoming : []).filter((block) => {
+      const identity = conversationBlockIdentity(block);
+      const remaining = seen.get(identity) || 0;
+      if (remaining > 0) {
+        seen.set(identity, remaining - 1);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  function pendingConversationBlockAcknowledged(pending, serverBlocks) {
+    const pendingId = String(pending?.client_request_id || pending?.metadata?.personal_assistant_client_request_id || "");
+    return (Array.isArray(serverBlocks) ? serverBlocks : []).some((block) => {
+      const metadata = block?.metadata || {};
+      const serverIds = [block?.client_request_id, metadata.client_request_id, metadata.personal_assistant_client_request_id]
+        .filter(Boolean)
+        .map(String);
+      if (pendingId && serverIds.includes(pendingId)) return true;
+      if (String(pending?.kind || "") !== String(block?.kind || "") ||
+          String(pending?.role || "") !== String(block?.role || "") ||
+          String(pending?.content || "") !== String(block?.content || "")) return false;
+
+      const pendingTime = Date.parse(String(pending?.created_at || ""));
+      const serverTime = Date.parse(String(block?.created_at || metadata.created_at || ""));
+      // Legacy agent sends do not have a request ID. A nearby equal message is
+      // the server acknowledgement; an older repeated prompt remains distinct.
+      return Number.isFinite(pendingTime) && Number.isFinite(serverTime) && Math.abs(pendingTime - serverTime) <= 120_000;
+    });
+  }
+
   function agentComposerState(agent) {
     if (agent?.latest_inquiry) return "inquiry";
     if (agent?.suspended_inquiry) return "composer";
@@ -645,6 +705,8 @@
     compareAgentsBySort,
     compareDisplayText,
     compareQuickSwitchAgents,
+    conversationBlockIdentity,
+    conversationBlocksMatch,
     conversationLoading,
     controlState,
     currentAgentSortOption,
@@ -658,6 +720,7 @@
     normalizeAttachmentTargetForMatch,
     normalizeDiffScope,
     normalizeAgentSort,
+    pendingConversationBlockAcknowledged,
     parseRoute,
     projectSearchMatch,
     rankMatchingAgents,
@@ -672,5 +735,6 @@
     shouldPreserveControl,
     shouldPollServerActivity,
     textSelectionFor,
+    unseenConversationBlocks,
   });
 })(window);

--- a/test/remote_ui_conversation_loading_test.rb
+++ b/test/remote_ui_conversation_loading_test.rb
@@ -18,6 +18,9 @@ module RemoteUIConversationLoadingTest
 
       const conversationLoading = context.window.TychoRemoteHelpers.conversationLoading;
       const agentComposerState = context.window.TychoRemoteHelpers.agentComposerState;
+      const conversationBlocksMatch = context.window.TychoRemoteHelpers.conversationBlocksMatch;
+      const unseenConversationBlocks = context.window.TychoRemoteHelpers.unseenConversationBlocks;
+      const pendingConversationBlockAcknowledged = context.window.TychoRemoteHelpers.pendingConversationBlockAcknowledged;
       const conversations = {
         alpha: { blocks: [], loaded: true, loading: false },
       };
@@ -47,6 +50,33 @@ module RemoteUIConversationLoadingTest
       if (failedComposerCheck) {
         const [label, actual, expected] = failedComposerCheck;
         throw new Error(`${label}: expected ${expected}, got ${actual}`);
+      }
+
+      const rendered = [
+        { id: "one", kind: "message", role: "user", content: "Keep this visible" },
+        { id: "two", kind: "message", role: "assistant", content: "Existing reply" },
+      ];
+      const incoming = [...rendered, { id: "three", kind: "message", role: "assistant", content: "Arrived while composing" }];
+      const unseen = unseenConversationBlocks(rendered, incoming);
+      if (unseen.length !== 1 || unseen[0].id !== "three") {
+        throw new Error(`new server message was not staged exactly once: ${JSON.stringify(unseen)}`);
+      }
+      if (conversationBlocksMatch(rendered, incoming) || !conversationBlocksMatch(rendered, [...rendered])) {
+        throw new Error("conversation snapshot comparison did not preserve the rendered baseline");
+      }
+
+      const optimistic = { id: "local", kind: "message", role: "user", content: "Optimistic prompt", client_request_id: "request-1" };
+      const acknowledged = { id: "server", kind: "message", role: "user", content: "Optimistic prompt", metadata: { personal_assistant_client_request_id: "request-1" } };
+      if (!pendingConversationBlockAcknowledged(optimistic, [acknowledged])) {
+        throw new Error("server acknowledgement did not suppress the duplicate optimistic message");
+      }
+      if (pendingConversationBlockAcknowledged(optimistic, rendered)) {
+        throw new Error("unrelated server history acknowledged an optimistic message");
+      }
+      const legacyPending = { id: "local-legacy", kind: "message", role: "user", content: "Same legacy prompt", created_at: "2026-09-10T00:00:00Z" };
+      const legacyAcknowledged = { id: "server-legacy", kind: "message", role: "user", content: "Same legacy prompt", created_at: "2026-09-10T00:00:02Z" };
+      if (!pendingConversationBlockAcknowledged(legacyPending, [legacyAcknowledged])) {
+        throw new Error("nearby legacy acknowledgement did not suppress a duplicate optimistic message");
       }
     JAVASCRIPT
 

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -43,6 +43,10 @@ module RemoteUIPersonalAssistantBehaviorTest
       const context = {
         Map,
         Set,
+        REMOTE_HELPERS: {
+          conversationBlocksMatch: (left, right) => JSON.stringify(left) === JSON.stringify(right),
+          unseenConversationBlocks: (_left, right) => right,
+        },
         PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT: 128,
         PERSONAL_ASSISTANT_MAX_FAILURE_COUNT: 2,
         PERSONAL_ASSISTANT_POLL_INTERVALS: { activeMs: 1500, idleMs: 12000, hiddenMs: 30000 },
@@ -80,6 +84,7 @@ module RemoteUIPersonalAssistantBehaviorTest
         "requestPersonalAssistantCurrentWork",
         "personalAssistantStatusRequestIsCurrent",
         "requestPersonalAssistantStatus",
+        "receiveConversationSnapshot",
         "ensureConversation",
       ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
 


### PR DESCRIPTION
## Summary
- Stage refreshed server conversations until the user explicitly loads them.
- Preserve drafts, scroll state, inquiry/FRED state, and optimistic message reconciliation.
- Add focused snapshot tests and a browser smoke scenario.

## Verification
- bin/test
- bundle exec ruby test/remote_server_test.rb
- bin/remote-ui-smoke (stops at the pre-existing Settings context-menu assertion before the new scenario)

Closes #172