### PR TITLE
Fix staged conversation update detection

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5417,6 +5417,8 @@ Saved safely.
         // The browser must retain the rendered history and scroll position until
         // the explicit accessible control is activated.
         const stagedConversation = await page.evaluate((key) => {
+          clearTimeout(state.timer);
+          state.timer = null;
           const baseline = Array.from({ length: 28 }, (_item, index) => ({
             id: `manual-load-${index}`,
             kind: "message",
@@ -5428,9 +5430,26 @@ Saved safely.
           delete state.pendingConversationUpdates[key];
           render({ preserveLiveEditor: true });
           const root = document.querySelector("[data-agent-conversation-scroll]");
-          root.scrollTop = Math.max(0, root.scrollHeight - root.clientHeight - 120);
+          root.scrollTop = 0;
           const before = root.scrollTop;
+          const pending = {
+            id: "pending-fred-manual-load",
+            kind: "message",
+            role: "user",
+            content: "FRED optimistic message remains visible",
+            created_at: new Date().toISOString(),
+            client_request_id: "fred-manual-load",
+            metadata: { personal_assistant_client_request_id: "fred-manual-load" },
+          };
+          state.pendingConversationMessages[key] = [pending];
           receiveConversationSnapshot(key, [...baseline, {
+            id: "fred-manual-load-server",
+            kind: "message",
+            role: "user",
+            content: pending.content,
+            created_at: pending.created_at,
+            metadata: { personal_assistant_client_request_id: "fred-manual-load" },
+          }, {
             id: "manual-load-new",
             kind: "message",
             role: "assistant",
@@ -5438,21 +5457,33 @@ Saved safely.
             created_at: new Date().toISOString(),
           }], "manual-load-next");
           render({ preserveLiveEditor: true });
+          const button = document.querySelector("[data-load-pending-conversation]");
+          const rootRect = root.getBoundingClientRect();
+          const buttonRect = button?.getBoundingClientRect();
           return {
             before,
             after: document.querySelector("[data-agent-conversation-scroll]").scrollTop,
             draft: document.querySelector("#prompt-input")?.value,
-            button: document.querySelector("[data-load-pending-conversation]")?.getAttribute("aria-label"),
+            button: button?.getAttribute("aria-label"),
+            buttonIntersectsViewport: Boolean(buttonRect && buttonRect.bottom > rootRect.top && buttonRect.top < rootRect.bottom),
             stagedVisible: document.body.textContent.includes("Server message staged for manual loading"),
+            optimisticCount: document.body.textContent.split(pending.content).length - 1,
           };
         }, agentKey);
-        if (stagedConversation.button !== "Load 1 new message" || stagedConversation.stagedVisible ||
+        if (stagedConversation.button !== "Load 2 new messages" || !stagedConversation.buttonIntersectsViewport ||
+            stagedConversation.stagedVisible || stagedConversation.optimisticCount !== 1 ||
             stagedConversation.draft !== draft || Math.abs(stagedConversation.after - stagedConversation.before) > 8) {
           throw new Error(`Manual conversation loading changed the visible snapshot before activation: ${JSON.stringify(stagedConversation)}`);
         }
         await page.click("[data-load-pending-conversation]");
-        await page.waitForFunction(() => document.body.textContent.includes("Server message staged for manual loading"), { timeout: 10_000 });
-        if (await page.locator("[data-load-pending-conversation]").count() || (await page.locator("#prompt-input").inputValue()) !== draft) {
+        const loadedConversation = await page.evaluate((key) => ({
+          contentLoaded: state.conversations[key]?.blocks?.some((block) => block.content === "Server message staged for manual loading"),
+          pendingCleared: !state.pendingConversationUpdates[key],
+          visibleFreds: document.body.textContent.split("FRED optimistic message remains visible").length - 1,
+        }), agentKey);
+        if (!loadedConversation.contentLoaded || !loadedConversation.pendingCleared ||
+            await page.locator("[data-load-pending-conversation]").count() || loadedConversation.visibleFreds !== 1 ||
+            (await page.locator("#prompt-input").inputValue()) !== draft) {
           throw new Error("Manual conversation loading did not apply the staged snapshot while preserving the composer");
         }
 

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -6107,7 +6107,7 @@ select {
 
 .new-conversation-messages {
   position: sticky;
-  bottom: 12px;
+  top: 12px;
   z-index: 3;
   display: flex;
   justify-content: center;

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -7770,11 +7770,11 @@ function renderAgentConversationView(agent, blocks, options = {}) {
       agent.summary || agent.last_summary || agent.last_result || "Review the latest agent activity and resolve the blocker before continuing.",
       { intent: "warning", className: "agent-recovery-banner" }
     ) : ""}
+    ${renderPendingConversationControl(agent)}
     <div class="message-list">
       ${renderAgentRelationshipContext(agent)}
       ${conversationBlocks.length ? renderConversationBlocks(conversationBlocks, { ...options, agent }) : emptyHtml}
     </div>
-    ${renderPendingConversationControl(agent)}
     <div data-conversation-recent aria-hidden="true"></div>
     ${options.floatingActions === false ? "" : renderAgentFloatingActions(agent, { recent: true })}
   `;

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -548,21 +548,29 @@
     return !conversation?.loaded || conversation.loading === true || fetching === true;
   }
 
-  // A server conversation is append-oriented, but a run can amend its last
-  // progress block. Keep a stable identity when available and otherwise use
-  // the user-visible content. The latter deliberately treats exact repeated
-  // messages as separate occurrences below.
+  function stableConversationValue(value) {
+    if (Array.isArray(value)) return value.map(stableConversationValue);
+    if (!value || typeof value !== "object") return value;
+    return Object.keys(value).sort().reduce((result, key) => {
+      result[key] = stableConversationValue(value[key]);
+      return result;
+    }, {});
+  }
+
+  // A run can amend an existing block without assigning it a new ID. Include
+  // the stable ID and rendered fields in the snapshot identity so amendments
+  // are staged instead of being mistaken for an unchanged conversation.
   function conversationBlockIdentity(block) {
     const metadata = block?.metadata || {};
     const id = block?.id || block?.event_id || metadata.id || metadata.event_id;
-    if (id) return `id:${id}`;
-
     return JSON.stringify([
+      id || "",
       block?.kind || "",
       block?.role || "",
       block?.tool_name || "",
       block?.created_at || metadata.created_at || "",
       block?.content || "",
+      stableConversationValue(metadata),
     ]);
   }
 
@@ -734,6 +742,7 @@
     safeLocalStorageSet,
     shouldPreserveControl,
     shouldPollServerActivity,
+    stableConversationValue,
     textSelectionFor,
     unseenConversationBlocks,
   });

--- a/test/remote_ui_conversation_loading_test.rb
+++ b/test/remote_ui_conversation_loading_test.rb
@@ -64,6 +64,11 @@ module RemoteUIConversationLoadingTest
       if (conversationBlocksMatch(rendered, incoming) || !conversationBlocksMatch(rendered, [...rendered])) {
         throw new Error("conversation snapshot comparison did not preserve the rendered baseline");
       }
+      const amended = [{ id: "two", kind: "message", role: "assistant", content: "Existing reply amended", metadata: { progress: "complete" } }];
+      const original = [{ id: "two", kind: "message", role: "assistant", content: "Existing reply", metadata: { progress: "running" } }];
+      if (conversationBlocksMatch(original, amended) || unseenConversationBlocks(original, amended).length !== 1) {
+        throw new Error("same-ID content or metadata amendments were not staged");
+      }
 
       const optimistic = { id: "local", kind: "message", role: "user", content: "Optimistic prompt", client_request_id: "request-1" };
       const acknowledged = { id: "server", kind: "message", role: "user", content: "Optimistic prompt", metadata: { personal_assistant_client_request_id: "request-1" } };


### PR DESCRIPTION
## Summary
- detect same-ID conversation content and metadata amendments
- pin the manual-load control at the visible edge of the conversation pane
- extend browser coverage for viewport visibility and staged FRED optimistic-send reconciliation

## Verification
- bin/test
- bundle exec ruby test/remote_server_test.rb
- focused browser fixture run advanced past the known Settings-menu baseline gate with that gate temporarily bypassed; it later stopped at a separate existing wait timeout after the new scenario ran

Follow-up to #123 and Fizzy #172.