### PR TITLE
Add FRED unread notifications

### DIFF
--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -493,6 +493,7 @@ module HQ
         bundle = personal_assistant_snapshot(service)
         return ok(proposals: bundle.fetch(:actions))
       end
+      return ok(agent: service.mark_personal_assistant_read(body)) if method == "PUT" && parts == ["personal-assistant", "reading"]
       if method == "GET" && parts.length == 3 && parts[0, 2] == ["personal-assistant", "actions"]
         return ok(proposal: service.personal_assistant_action(parts[2]))
       end
@@ -3781,9 +3782,10 @@ module HQ
     def dispatch_agent_push_notifications!
       agents, events = load_agents_with_events
       visible = visible_agents(agents)
+      notification_candidates = notification_agents(agents)
       @agent_activity_snapshot.replace!(visible)
-      visible_keys = visible.map(&:key)
-      dispatch_agent_push_events(events.select { |event| visible_keys.include?(event.agent_key) }, agents: visible)
+      notification_keys = notification_candidates.map(&:key)
+      dispatch_agent_push_events(events.select { |event| notification_keys.include?(event.agent_key) }, agents: notification_candidates)
     end
 
     def metrics_query(filters = {})
@@ -3854,6 +3856,17 @@ module HQ
         save_agent(target)
       end
       agent_payload(target)
+    end
+
+    def mark_personal_assistant_read(attrs)
+      with_personal_assistant_session!(attrs) do |context|
+        target = personal_assistant_target_for_context!(context)
+        if target.unread?
+          target.mark_read!
+          save_agent(target)
+        end
+        agent_payload(target)
+      end
     end
 
     def submit_prompt(key, attrs = {}, actor: nil, personal_assistant_lifecycle: false, acceptance_id: nil, message_metadata: nil, session_context: nil, **attribute_keywords)
@@ -4704,6 +4717,12 @@ module HQ
       HQ::Visibility.visible_agents(agents, @projects).reject(&:personal_assistant?)
     end
 
+    # FRED is deliberately outside the generic agent catalog, yet its finished
+    # work still deserves the same unread and push reconciliation.
+    def notification_agents(agents)
+      visible_agents(agents) + agents.select(&:personal_assistant?)
+    end
+
     def hidden_setting_value(attrs)
       raise Error.new("Missing hidden value") unless attrs.key?("hidden")
 
@@ -4849,9 +4868,10 @@ module HQ
     def load_all_agents
       agents, events = load_agents_with_events
       visible = visible_agents(agents)
+      notification_candidates = notification_agents(agents)
       @agent_activity_snapshot.replace!(visible)
-      visible_keys = visible.map(&:key)
-      dispatch_agent_push_events(events.select { |event| visible_keys.include?(event.agent_key) }, agents: visible)
+      notification_keys = notification_candidates.map(&:key)
+      dispatch_agent_push_events(events.select { |event| notification_keys.include?(event.agent_key) }, agents: notification_candidates)
       agents
     end
 
@@ -5178,16 +5198,17 @@ module HQ
       status = agent.status
       if status == "awaiting-input"
         event = "input_required"
-        title = "Agent requires response"
+        title = agent.personal_assistant? ? "FRED requires response" : "Agent requires response"
       elsif %w[succeeded failed stopped blocked].include?(status)
         event = "finished"
-        title = status == "succeeded" ? "Agent finished" : "Agent finished: #{status}"
+        prefix = agent.personal_assistant? ? "FRED finished" : "Agent finished"
+        title = status == "succeeded" ? prefix : "#{prefix}: #{status}"
       else
         return nil
       end
 
       group_count = [unread_count.to_i, 1].max
-      body = "#{agent.display_name}: #{truncate(agent.last_summary, 120)}"
+      body = "#{agent.personal_assistant? ? "FRED" : agent.display_name}: #{truncate(agent.last_summary, 120)}"
       body = "#{body} (#{group_count} unread agents)" if group_count > 1
 
       {
@@ -5199,7 +5220,7 @@ module HQ
           renotify: event == "input_required",
           silent: event != "input_required",
           badge_count: group_count,
-          url: "/#agent/#{agent.key}"
+          url: agent.personal_assistant? ? "/#personal-assistant" : "/#agent/#{agent.key}"
         }
       }
     end
@@ -5275,6 +5296,13 @@ module HQ
         summary: agent.last_summary,
         updated_at: agent.last_activity_at&.iso8601
       }
+    end
+
+    def personal_assistant_quick_switch_summary(agent)
+      request = agent.messages.reverse.find do |message|
+        message.role == "user" && !message.metadata&.fetch("personal_assistant_summary", false)
+      end
+      truncate(request&.content.to_s.strip.empty? ? agent.last_summary : request.content, 120)
     end
 
     def archived_project_count
@@ -5677,6 +5705,8 @@ module HQ
         last_exit_code: agent.last_exit_code,
         last_result: agent.last_result_label,
         summary: agent.last_summary,
+        role: agent.personal_assistant? ? "personal_assistant_daily" : nil,
+        quick_switch_summary: agent.personal_assistant? ? personal_assistant_quick_switch_summary(agent) : nil,
         cost_snapshot: agent.cost_snapshot,
         latest_inquiry: inquiry,
         suspended_inquiry: suspended_inquiry_payload(agent),

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -916,6 +916,18 @@ h3 {
   box-shadow: none;
 }
 
+.switcher-fred-row {
+  border-left: 3px solid var(--accent);
+}
+
+.fred-switcher-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+
 .unread-agents-panel .switcher-agent-row.selected {
   border-color: var(--accent);
   background: color-mix(in srgb, var(--accent) 18%, var(--panel-soft));

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3863,6 +3863,19 @@ async function markAgentReading(agent) {
   }
 }
 
+async function markPersonalAssistantReading() {
+  const item = state.personalAssistant;
+  const context = personalAssistantSessionContext(item);
+  if (!context || !item?.agent?.unread || document.hidden) return;
+
+  const data = await apiPut("/personal-assistant/reading", context);
+  if (!data.agent) return;
+  const agent = normalizeAgentResource(data.agent, resourceServer(context.server_key));
+  state.personalAssistant = { ...item, agent };
+  state.agentDetails[agent.key] = agent;
+  syncUnreadAlert();
+}
+
 async function ensureSkillsForProject(projectKey, harness, options = {}) {
   const key = skillKey(projectKey, harness);
   if (!options.force && state.skills[key]) return;
@@ -6548,6 +6561,9 @@ function renderPersonalAssistant() {
     overlayHtml: composerPlacement.overlay,
     attributes: `data-personal-assistant-state="${escapeAttr(item.state)}"`,
   }));
+  if (agent && item.state === "active" && state.conversations[agent.key] && document.querySelector("[data-conversation-recent]")) {
+    window.setTimeout(() => markPersonalAssistantReading().catch((error) => setConnection(error.message)), 1200);
+  }
 }
 
 function personalAssistantHeaderTitleHtml() {
@@ -12925,13 +12941,28 @@ function copyableKv(label, value) {
 }
 
 function unreadAgents() {
-  return currentAgents()
+  return quickSwitchAgents()
     .filter((agent) => agent.unread)
     .sort(compareUnreadAgents);
 }
 
 function quickSwitchAgents() {
-  return currentAgents().sort(compareQuickSwitchAgents);
+  return [...currentAgents(), ...personalAssistantQuickSwitchAgents()].sort(compareQuickSwitchAgents);
+}
+
+function personalAssistantQuickSwitchAgents() {
+  const item = state.personalAssistant;
+  const agent = item?.agent;
+  if (!item?.configured || !item?.active_key || !agent?.key || agent.archived) return [];
+  const normalized = normalizeAgentResource(agent, resourceServer(personalAssistantServerKey(item)));
+  if (!normalized) return [];
+  return [{
+    ...normalized,
+    name: "FRED",
+    personal_assistant: true,
+    role: "personal_assistant_daily",
+    quick_switch_summary: agent.quick_switch_summary || agent.summary || "Personal assistant",
+  }];
 }
 
 function quickSwitchPanelAgent() {
@@ -13814,16 +13845,23 @@ function renderSwitcherAgentRow(agent, index) {
     ? `<span class="switcher-linked-symbol" data-show-linked-agents="${escapeAttr(agent.key)}" aria-label="Show linked agents" title="Show linked agents">${iconSvg("link")}</span>`
     : "";
 
+  const isFred = agent.personal_assistant === true;
   return `
-    <button class="agent-row switcher-agent-row ${selected ? "selected" : ""}" type="button" data-open-agent="${escapeAttr(agent.key)}" data-switcher-index="${index}" ${selected ? "aria-selected=\"true\"" : ""}>
-      ${statusIcon || agentIdentityIcon(agent)}
+    <button class="agent-row switcher-agent-row ${isFred ? "switcher-fred-row" : ""} ${selected ? "selected" : ""}" type="button" data-open-agent="${escapeAttr(agent.key)}" data-switcher-index="${index}" ${selected ? "aria-selected=\"true\"" : ""}>
+      ${isFred ? fredSwitcherAvatar() : (statusIcon || agentIdentityIcon(agent))}
       <div class="row-title">
         <strong class="switcher-agent-title-line">${agentNameHtml(agent, state.unreadPanelQuery)}${linkedSymbol}</strong>
-        <span>${agentListSubtextHtml(agent, { query: state.unreadPanelQuery })}</span>
+        <span>${isFred ? highlightSearchText(agent.quick_switch_summary || "Personal assistant", state.unreadPanelQuery) : agentListSubtextHtml(agent, { query: state.unreadPanelQuery })}</span>
       </div>
       <span class="switcher-agent-tools">${statusText}</span>
     </button>
   `;
+}
+
+function fredSwitcherAvatar() {
+  const version = document.documentElement.dataset.assetVersion || "";
+  const suffix = version ? `?v=${encodeURIComponent(version)}` : "";
+  return `<img class="fred-switcher-avatar" src="/fred-avatar.png${suffix}" alt="" aria-hidden="true">`;
 }
 
 function agentListStatusIcon(agent) {
@@ -13896,7 +13934,11 @@ function openSelectedSwitcherAgent() {
   if (!agent) return;
 
   closeUnreadPanel();
-  navigate({ type: "agent", key: agent.key });
+  navigateSwitcherAgent(agent);
+}
+
+function navigateSwitcherAgent(agent) {
+  navigate(agent?.personal_assistant ? { type: "personalAssistant" } : { type: "agent", key: agent.key });
 }
 
 function scrollSelectedSwitcherAgentIntoView() {
@@ -15868,7 +15910,7 @@ els.unreadPanel.addEventListener("click", (event) => {
     const index = Number.parseInt(agentButton.dataset.switcherIndex, 10);
     if (Number.isFinite(index)) state.unreadPanelSelectedIndex = index;
     closeUnreadPanel();
-    navigate({ type: "agent", key: agentButton.dataset.openAgent });
+    navigateSwitcherAgent(findAgent(agentButton.dataset.openAgent) || quickSwitchAgents().find((agent) => agent.key === agentButton.dataset.openAgent));
     return;
   }
 

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -77,6 +77,7 @@ module RemoteServerTest
     assert_serve_command_accepts_daemon_mode
     assert_remote_push_subscription_lifecycle
     assert_remote_agent_push_notifications
+    assert_remote_fred_push_notifications
     assert_remote_search_index_includes_agents_and_projects
     assert_remote_skills_payload_uses_discovery
     assert_remote_ui_routes_load_without_auth
@@ -499,6 +500,14 @@ module RemoteServerTest
       personal_status = server.send(:route, service, "GET", "/personal-assistant", {}, nil)
       assert(personal_status.dig(:body, :personal_assistant, :agent, :key) == key,
              "expected dedicated FRED status API to retain the protected conversation detail")
+      fred = service.send(:find_agent!, key)
+      fred.mark_unread!
+      service.send(:save_agent, fred)
+      read = server.send(:route, service, "PUT", "/personal-assistant/reading", {
+                           "active_key" => key,
+                           "generation" => opened.dig(:body, :personal_assistant, :generation)
+                         }, nil)
+      assert(!read.dig(:body, :agent, :unread), "expected the active FRED session to clear unread through its protected route")
       proposals_path = File.join(HQ::PERSONAL_ASSISTANT_DIR, "proposals.json")
       HQ::FileStore.write_json(proposals_path, {
                                  "proposals" => [
@@ -5017,6 +5026,34 @@ module RemoteServerTest
 
       service.dispatch_agent_push_notifications!
       assert(notifier.payloads.length == 2, "expected duplicate agent push events to be suppressed")
+    end
+  end
+
+  def assert_remote_fred_push_notifications
+    with_remote_temp_store do |dir|
+      workspace = File.join(dir, "workspace")
+      write_project_workspace(workspace)
+      notifier = RecordingPushNotifier.new
+      service = HQ::RemoteService.new(registry: registry_for_project(dir, workspace), web_push_notifier: notifier)
+      finished_at = Time.now - 60
+      fred = HQ::ManagedAgent.new(
+        key: "personal-assistant-test-1", name: "Personal Assistant · today", project_key: "__personal_assistant__",
+        template_key: "personal_assistant_daily", workspace: workspace, prompt: "Assist.", role: "personal_assistant_daily",
+        started_at: finished_at, finished_at: finished_at, last_exit_code: 0, summary: "Prepared the release request.", unread: true,
+        runs: [HQ::ManagedAgent::AgentRun.new(started_at: finished_at, finished_at: finished_at, exit_code: 0, status: "succeeded")]
+      )
+      HQ::AgentStore.new([]).save([fred])
+
+      result = service.dispatch_agent_push_notifications!
+      assert(result[:events] == 1, "expected a protected FRED session to dispatch one notification")
+      payload = notifier.payloads.first
+      assert(payload[:title] == "FRED finished" && payload[:url] == "/#personal-assistant",
+             "expected FRED push to use distinct copy and its dedicated route")
+      assert(payload[:badge_count] == 1 && payload[:body].start_with?("FRED:"),
+             "expected FRED push to participate in the shared unread badge")
+      assert(service.agents.empty?, "expected FRED to remain outside the generic agent catalog")
+      service.dispatch_agent_push_notifications!
+      assert(notifier.payloads.length == 1, "expected FRED notification deduplication to survive polling")
     end
   end
 


### PR DESCRIPTION
## Summary
- reconcile protected FRED sessions into unread badges and deduplicated Web Push without exposing them in the generic catalog
- add a distinct FRED quick-switch row with avatar, concise latest request, unread state, and dedicated navigation
- clear FRED unread state through a generation-validated lifecycle route

## Verification
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test` (started; focused suite passes)
- `bin/capture-personal-assistant`