### PR TITLE
Guard FRED notification lifecycle

### DIFF
--- a/lib/hq/domain/personal_assistant.rb
+++ b/lib/hq/domain/personal_assistant.rb
@@ -130,6 +130,19 @@ module HQ
       synchronize { |state| snapshot_finalized_proposals!(state); reconcile!(state); state["phase"] == "active" && state["active_key"] == key.to_s }
     end
 
+    # Notification polling observes the current daily generation without
+    # dispatching queued work or advancing a closing session.
+    def active_notification_session
+      synchronize do |state|
+        reconcile!(state, dispatch_prompt_queues: false)
+        return nil unless state["phase"] == "active"
+
+        key = state["active_key"].to_s
+        generation = state["generation"].to_i
+        key.empty? || generation <= 0 ? nil : { "active_key" => key, "generation" => generation }
+      end
+    end
+
     def with_active_session!(active_key:, generation:)
       key = active_key.to_s.strip
       supplied_generation = normalize_generation(generation)

--- a/lib/hq/domain/personal_assistant.rb
+++ b/lib/hq/domain/personal_assistant.rb
@@ -130,12 +130,15 @@ module HQ
       synchronize { |state| snapshot_finalized_proposals!(state); reconcile!(state); state["phase"] == "active" && state["active_key"] == key.to_s }
     end
 
-    # Notification polling observes the current daily generation without
-    # dispatching queued work or advancing a closing session.
+    # Notification polling is observational: it must neither dispatch queued
+    # work nor advance/modify a closing session.
     def active_notification_session
       synchronize do |state|
-        reconcile!(state, dispatch_prompt_queues: false)
+        return nil unless @registry.personal_assistant["enabled"] == true
         return nil unless state["phase"] == "active"
+
+        timezone = state["active_timezone"] || @registry.personal_assistant["timezone"]
+        return nil if timezone.to_s.empty? || state["active_date"] != local_date(@clock.call, timezone)
 
         key = state["active_key"].to_s
         generation = state["generation"].to_i

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -4720,7 +4720,19 @@ module HQ
     # FRED is deliberately outside the generic agent catalog, yet its finished
     # work still deserves the same unread and push reconciliation.
     def notification_agents(agents)
-      visible_agents(agents) + agents.select(&:personal_assistant?)
+      visible_agents(agents) + active_personal_assistant_notification_agents(agents)
+    end
+
+    def active_personal_assistant_notification_agents(agents)
+      session = @personal_assistant.active_notification_session
+      return [] unless session
+
+      active_key = session["active_key"].to_s
+      return [] if active_key.empty?
+
+      agents.select { |agent| agent.personal_assistant? && agent.key == active_key }
+    rescue ArgumentError
+      []
     end
 
     def hidden_setting_value(attrs)

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -370,7 +370,9 @@ module HQ
       return if now - @last_agent_push_poll < AGENT_PUSH_POLL_INTERVAL
 
       @last_agent_push_poll = now
-      service = RemoteService.new(server_url: "http://#{@host}:#{@port}",
+      service = RemoteService.new(registry: @registry || Registry.new,
+                                  clock: @clock,
+                                  server_url: "http://#{@host}:#{@port}",
                                   public_url: @public_url,
                                   auth_required: !@token.empty?,
                                   agent_activity_snapshot: @agent_activity_snapshot,

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -853,6 +853,8 @@ const state = {
   unreadPanelLinkedAgentKey: "",
   shortcutModifierActive: false,
   readMarkTimer: null,
+  personalAssistantReadMarkTimer: null,
+  personalAssistantReadingContext: "",
   lastAppBadgeCount: null,
   growlTimer: null,
   pendingSummaryScrollId: null,
@@ -3863,17 +3865,29 @@ async function markAgentReading(agent) {
   }
 }
 
-async function markPersonalAssistantReading() {
-  const item = state.personalAssistant;
-  const context = personalAssistantSessionContext(item);
-  if (!context || !item?.agent?.unread || document.hidden) return;
+async function markPersonalAssistantReading(context = personalAssistantSessionContext()) {
+  const contextId = personalAssistantReadContextId(context);
+  if (!contextId || state.personalAssistantReadingContext === contextId) return;
+  if (parseRoute().type !== "personalAssistant" || !personalAssistantSessionMatches(context) || document.hidden) return;
 
-  const data = await apiPut("/personal-assistant/reading", context);
-  if (!data.agent) return;
-  const agent = normalizeAgentResource(data.agent, resourceServer(context.server_key));
-  state.personalAssistant = { ...item, agent };
-  state.agentDetails[agent.key] = agent;
-  syncUnreadAlert();
+  const item = state.personalAssistant;
+  if (!item?.agent?.unread || !document.querySelector("[data-conversation-recent]")) return;
+  state.personalAssistantReadingContext = contextId;
+  try {
+    const data = await apiPut("/personal-assistant/reading", context);
+    if (!data.agent || !personalAssistantSessionMatches(context)) return;
+    const agent = normalizeAgentResource(data.agent, resourceServer(context.server_key));
+    state.personalAssistant = { ...state.personalAssistant, agent };
+    state.agentDetails[agent.key] = agent;
+    syncUnreadAlert();
+  } finally {
+    if (state.personalAssistantReadingContext === contextId) state.personalAssistantReadingContext = "";
+  }
+}
+
+function personalAssistantReadContextId(context) {
+  if (!context?.active_key || !Number.isInteger(context.generation)) return "";
+  return [context.server_key || "local", context.active_key, context.generation].join(":");
 }
 
 async function ensureSkillsForProject(projectKey, harness, options = {}) {
@@ -3975,6 +3989,7 @@ function renderCurrentView() {
   document.body.dataset.routeType = route.type || "tab";
   document.body.dataset.routeTab = currentTopTab(route);
   if (route.type !== "agent" && !workspaceRoute) cancelAgentReading();
+  if (route.type !== "personalAssistant") cancelPersonalAssistantReading();
   els.back.classList.toggle("hidden", !subpage);
   els.header.classList.toggle("hidden", onboarding);
   els.nav.classList.toggle("hidden", onboarding);
@@ -6561,9 +6576,7 @@ function renderPersonalAssistant() {
     overlayHtml: composerPlacement.overlay,
     attributes: `data-personal-assistant-state="${escapeAttr(item.state)}"`,
   }));
-  if (agent && item.state === "active" && state.conversations[agent.key] && document.querySelector("[data-conversation-recent]")) {
-    window.setTimeout(() => markPersonalAssistantReading().catch((error) => setConnection(error.message)), 1200);
-  }
+  schedulePersonalAssistantReading(item, agent);
 }
 
 function personalAssistantHeaderTitleHtml() {
@@ -8960,6 +8973,20 @@ function scheduleAgentReading(agent) {
   }, 1200);
 }
 
+function schedulePersonalAssistantReading(item, agent) {
+  cancelPersonalAssistantReading();
+  const context = personalAssistantSessionContext(item);
+  if (!context || item?.state !== "active" || !agent?.unread || !state.conversations[agent.key] || document.hidden) return;
+  if (!document.querySelector("[data-conversation-recent]")) return;
+
+  state.personalAssistantReadMarkTimer = window.setTimeout(() => {
+    state.personalAssistantReadMarkTimer = null;
+    if (parseRoute().type !== "personalAssistant" || !personalAssistantSessionMatches(context) || document.hidden) return;
+    if (!document.querySelector("[data-conversation-recent]")) return;
+    markPersonalAssistantReading(context).catch((error) => setConnection(error.message));
+  }, 1200);
+}
+
 function agentComposerAction(agent, sending = false) {
   if (agentComposerRunning(agent)) {
     return `
@@ -9317,6 +9344,13 @@ function cancelAgentReading() {
 
   window.clearTimeout(state.readMarkTimer);
   state.readMarkTimer = null;
+}
+
+function cancelPersonalAssistantReading() {
+  if (!state.personalAssistantReadMarkTimer) return;
+
+  window.clearTimeout(state.personalAssistantReadMarkTimer);
+  state.personalAssistantReadMarkTimer = null;
 }
 
 function renderAgentForm(route) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5035,6 +5035,7 @@ module RemoteServerTest
       write_project_workspace(workspace)
       notifier = RecordingPushNotifier.new
       service = HQ::RemoteService.new(registry: registry_for_project(dir, workspace), web_push_notifier: notifier)
+      service.setup_personal_assistant("confirmed" => true, "model" => "gpt-5.6-sol", "reasoning_effort" => "medium", "timezone" => "UTC")
       finished_at = Time.now - 60
       fred = HQ::ManagedAgent.new(
         key: "personal-assistant-test-1", name: "Personal Assistant · today", project_key: "__personal_assistant__",
@@ -5042,7 +5043,20 @@ module RemoteServerTest
         started_at: finished_at, finished_at: finished_at, last_exit_code: 0, summary: "Prepared the release request.", unread: true,
         runs: [HQ::ManagedAgent::AgentRun.new(started_at: finished_at, finished_at: finished_at, exit_code: 0, status: "succeeded")]
       )
-      HQ::AgentStore.new([]).save([fred])
+      historical_fred = HQ::ManagedAgent.new(
+        key: "personal-assistant-yesterday-0", name: "Personal Assistant · yesterday", project_key: "__personal_assistant__",
+        template_key: "personal_assistant_daily", workspace: workspace, prompt: "Assist.", role: "personal_assistant_daily",
+        started_at: finished_at, finished_at: finished_at, last_exit_code: 0, summary: "Old work.", unread: true,
+        runs: [HQ::ManagedAgent::AgentRun.new(started_at: finished_at, finished_at: finished_at, exit_code: 0, status: "succeeded")]
+      )
+      HQ::AgentStore.new([]).save([fred, historical_fred])
+      HQ::FileStore.write_json(File.join(HQ::PERSONAL_ASSISTANT_DIR, "state.json"), {
+                                 "active_key" => fred.key, "active_date" => Time.now.utc.strftime("%F"),
+                                 "active_timezone" => "UTC", "generation" => 1, "phase" => "active"
+                               })
+
+      active_notification_keys = service.send(:notification_agents, HQ::AgentStore.new([]).load).select(&:personal_assistant?).map(&:key)
+      assert(active_notification_keys == [fred.key], "expected only the active FRED generation to join notification reconciliation")
 
       result = service.dispatch_agent_push_notifications!
       assert(result[:events] == 1, "expected a protected FRED session to dispatch one notification")
@@ -5054,6 +5068,12 @@ module RemoteServerTest
       assert(service.agents.empty?, "expected FRED to remain outside the generic agent catalog")
       service.dispatch_agent_push_notifications!
       assert(notifier.payloads.length == 1, "expected FRED notification deduplication to survive polling")
+      HQ::FileStore.write_json(File.join(HQ::PERSONAL_ASSISTANT_DIR, "state.json"), {
+                                 "active_key" => fred.key, "active_date" => Time.now.utc.strftime("%F"),
+                                 "active_timezone" => "UTC", "generation" => 1, "phase" => "closing"
+                               })
+      assert(service.send(:notification_agents, HQ::AgentStore.new([]).load).none?(&:personal_assistant?),
+             "expected a closing FRED generation to be excluded from unread and push reconciliation")
     end
   end
 
@@ -7034,6 +7054,13 @@ module RemoteServerTest
            "expected Agent detail to mark read from visible render state rather than data fetch")
     assert(js[:body].include?("readMarkTimer"),
            "expected Agent detail read marking to use a guarded dwell timer")
+    assert(js[:body].include?("function schedulePersonalAssistantReading") &&
+           js[:body].include?("personalAssistantReadMarkTimer") &&
+           js[:body].include?("route.type !== \"personalAssistant\"") &&
+           js[:body].include?("personalAssistantSessionMatches(context)"),
+           "expected FRED unread clearing to cancel on navigation and reject stale daily generations")
+    assert(js[:body].include?("personalAssistantReadingContext === contextId"),
+           "expected repeated FRED renders to coalesce an in-flight read mutation")
     assert(js[:body].include?("/reading"),
            "expected Agent detail read state to use the reading endpoint")
     assert(js[:body].include?('if (agent.unread) return "Unread";'),


### PR DESCRIPTION
## Summary
- cancel and session-guard FRED unread dwell timers; coalesce concurrent read mutations
- limit FRED notification reconciliation to the active lifecycle generation and exclude closing sessions
- add lifecycle regression coverage

## Verification
- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/managed_agent_test.rb`
- `bin/remote-ui-phase2-smoke`