### PR TITLE
Add scheduled session execution overrides

### DIFF
--- a/config/schedules.yml.example
+++ b/config/schedules.yml.example
@@ -13,6 +13,9 @@
 #       project_key: tycho
 #       name: Tycho scheduled maintenance
 #       agent_key: existing-agent-key # optional; adopts an existing session
+#       agent: codex # optional; defaults to the project harness
+#       model: gpt-5.4 # optional; defaults to the project model
+#       reasoning_effort: high # optional; defaults to the project effort
 #       message_source: file
 #       message_file: schedules/weekday-maintenance.md
 #     policy:

--- a/lib/hq/cli_command.rb
+++ b/lib/hq/cli_command.rb
@@ -425,6 +425,49 @@ module HQ
         end
       end
 
+      module ScheduleOptions
+        def schedule_options(create:)
+          option :name, desc: "Schedule display name"
+          option :cron, desc: "Five-field cron expression"
+          option :timezone, desc: "local or UTC"
+          option :project_key, desc: "Target project key"
+          option :agent_name, desc: "Scheduled session name"
+          option :agent_key, desc: "Existing session to adopt"
+          option :agent, desc: "Optional harness override"
+          option :model, desc: "Optional model override"
+          option :reasoning_effort, desc: "Optional reasoning effort override"
+          option :system_message, desc: "Stable system context"
+          option :message, desc: "Run message"
+          option :ends_at, desc: "Optional ISO 8601 end timestamp"
+        end
+      end
+
+      class ScheduleCreate < Dry::CLI::Command
+        extend CommandMetadata
+        extend ScheduleOptions
+        desc "Create a schedule"
+        argument :schedule_key, required: true, desc: "Schedule key"
+        schedule_options(create: true)
+        usage_template "schedule create %{schedule_key} --cron CRON --project-key PROJECT --message MESSAGE [options]"
+
+        def call(schedule_key:, **opts)
+          exit CLICommand.create_schedule(schedule_key, opts, out: out, err: err)
+        end
+      end
+
+      class ScheduleUpdate < Dry::CLI::Command
+        extend CommandMetadata
+        extend ScheduleOptions
+        desc "Update a schedule"
+        argument :schedule_key, required: true, desc: "Schedule key"
+        schedule_options(create: false)
+        usage_template "schedule update %{schedule_key} [options]"
+
+        def call(schedule_key:, **opts)
+          exit CLICommand.update_schedule(schedule_key, opts, out: out, err: err)
+        end
+      end
+
       class ScheduleValidate < Dry::CLI::Command
         extend CommandMetadata
 
@@ -495,6 +538,8 @@ module HQ
       end
 
       register "schedule", Schedule do |prefix|
+        prefix.register "create", ScheduleCreate
+        prefix.register "update", ScheduleUpdate
         prefix.register "validate", ScheduleValidate
         prefix.register "list", ScheduleList
         prefix.register "run", ScheduleRun
@@ -2190,6 +2235,23 @@ module HQ
       failure(e.message, err:)
     end
 
+    def create_schedule(key, opts, out: $stdout, err: $stderr)
+      attrs = schedule_attrs(opts).merge("key" => key)
+      schedule = schedule_registry.create(attrs)
+      out.puts "Created schedule #{schedule.key}."
+      0
+    rescue ScheduleRegistry::Error => e
+      failure(e.message, err:)
+    end
+
+    def update_schedule(key, opts, out: $stdout, err: $stderr)
+      schedule = schedule_registry.update(key, schedule_attrs(opts))
+      out.puts "Updated schedule #{schedule.key}."
+      0
+    rescue ScheduleRegistry::Error => e
+      failure(e.message, err:)
+    end
+
     def schedule_list_table(rows)
       headers = %w[Key Project Status Next Last Agent Runs Skips]
       table_rows = rows.map do |row|
@@ -2221,6 +2283,19 @@ module HQ
 
     def scheduler
       Scheduler.new
+    end
+
+    def schedule_registry
+      registry = Registry.new
+      ScheduleRegistry.new(projects: registry.projects.map { |config| Project.new(config) }, harness_catalogs: registry.harness_catalogs)
+    end
+
+    def schedule_attrs(opts)
+      opts.each_with_object({}) do |(key, value), attrs|
+        next if value.nil?
+
+        attrs[key.to_s] = value
+      end
     end
 
     def darwin_amd64?

--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -222,7 +222,7 @@ module HQ
       end
     end
 
-    def create_scheduled(project, schedule_key:, name:, system_message: nil, existing_agents: load)
+    def create_scheduled(project, schedule_key:, name:, system_message: nil, execution_overrides: {}, existing_agents: load)
       now = Time.now
       key = next_agent_key(project.key, existing_agents, now:)
       prompt = scheduled_system_prompt(schedule_key:, name:, system_message:)
@@ -236,9 +236,9 @@ module HQ
         workspace: project.path,
         prompt: prompt,
         sandbox_mode: "danger-full-access",
-        agent: project.respond_to?(:agent) ? project.agent : project.config.agent,
-        model: project.respond_to?(:model) ? project.model : project.config.model,
-        reasoning_effort: project.respond_to?(:reasoning_effort) ? project.reasoning_effort : project.config.reasoning_effort,
+        agent: execution_overrides[:agent] || (project.respond_to?(:agent) ? project.agent : project.config.agent),
+        model: execution_overrides[:model] || (project.respond_to?(:model) ? project.model : project.config.model),
+        reasoning_effort: execution_overrides[:reasoning_effort] || (project.respond_to?(:reasoning_effort) ? project.reasoning_effort : project.config.reasoning_effort),
         response_style: project.respond_to?(:response_style) ? project.response_style : project.config.response_style,
         messages: system_messages,
         created_at: now,

--- a/lib/hq/domain/schedule_registry.rb
+++ b/lib/hq/domain/schedule_registry.rb
@@ -5,6 +5,7 @@ require "yaml"
 
 require_relative "constants"
 require_relative "file_store"
+require_relative "../harness_registry"
 
 module HQ
   class CronExpression
@@ -107,7 +108,7 @@ module HQ
   ScheduleDefinition = Struct.new(
     :key, :name, :enabled, :cron, :timezone, :project_key, :agent_name,
     :agent_key, :system_message, :message_source, :message, :message_file, :message_path,
-    :ends_at, :policy,
+    :ends_at, :policy, :agent, :model, :reasoning_effort,
     keyword_init: true
   ) do
     def cron_expression
@@ -147,6 +148,10 @@ module HQ
     def expired?(time = Time.now)
       ends_at && time >= ends_at
     end
+
+    def execution_overrides
+      { agent:, model:, reasoning_effort: }.compact
+    end
   end
 
   class ScheduleRegistry
@@ -154,10 +159,11 @@ module HQ
 
     attr_reader :path, :projects, :schedules_root
 
-    def initialize(path: SCHEDULES_FILE, projects:, schedules_root: nil)
+    def initialize(path: SCHEDULES_FILE, projects:, schedules_root: nil, harness_catalogs: {})
       @path = File.expand_path(path)
       @projects = projects
       @schedules_root = File.expand_path(schedules_root || USER_SCHEDULES_DIR)
+      @harness_catalogs = harness_catalogs || {}
     end
 
     def schedules
@@ -291,6 +297,9 @@ module HQ
       assign_clean_string(target, "name", values, source_key: "agent_name", fallback: target["name"])
       assign_clean_string(target, "agent_key", values, fallback: target["agent_key"])
       assign_clean_string(target, "system_message", values, fallback: target["system_message"])
+      assign_clean_string(target, "agent", values, fallback: target["agent"])
+      assign_clean_string(target, "model", values, fallback: target["model"])
+      assign_clean_string(target, "reasoning_effort", values, fallback: target["reasoning_effort"])
       source = clean_string(values["message_source"], fallback: target["message_source"])
       source = target["message_file"].to_s.empty? ? "inline" : "file" if source.to_s.empty?
       target["message_source"] = source
@@ -356,9 +365,13 @@ module HQ
       ends_at = optional_time!(entry["ends_at"], label: "schedule #{key.inspect} ends_at")
 
       project_key = required_string(target, "project_key", label: "schedule #{key.inspect} target")
-      project_for!(key, project_key)
+      project = project_for!(key, project_key)
       source, message, message_file, message_path = message_fields!(key, target)
       policy = normalize_policy!(key, entry["policy"])
+      agent = optional_nil_string(target["agent"]&.to_s&.downcase)
+      model = optional_nil_string(target["model"])
+      reasoning_effort = optional_nil_string(target["reasoning_effort"]&.to_s&.downcase)
+      validate_execution_overrides!(key, project, agent:, model:, reasoning_effort:)
 
       ScheduleDefinition.new(
         key: key,
@@ -375,7 +388,10 @@ module HQ
         message_file: message_file,
         message_path: message_path,
         ends_at: ends_at,
-        policy: policy
+        policy: policy,
+        agent: agent,
+        model: model,
+        reasoning_effort: reasoning_effort
       )
     end
 
@@ -447,6 +463,31 @@ module HQ
     def optional_string(value, fallback:)
       text = value.to_s.strip
       text.empty? ? fallback.to_s : text
+    end
+
+    def optional_nil_string(value)
+      text = value.to_s.strip
+      text.empty? ? nil : text
+    end
+
+    def validate_execution_overrides!(key, project, agent:, model:, reasoning_effort:)
+      harness = agent || project.config.agent
+      unless HQ.supported_harness?(harness)
+        raise Error, "Schedule #{key.inspect} has unsupported harness #{harness.inspect}. Supported: #{HQ.harness_keys.join(", ")}"
+      end
+
+      catalog = @harness_catalogs[harness.to_s]
+      return unless catalog
+
+      configured_models = Array(catalog.models).map(&:to_s).reject(&:empty?)
+      if model && configured_models.any? && !configured_models.include?(model)
+        raise Error, "Schedule #{key.inspect} model #{model.inspect} is not allowed for harness #{harness.inspect}"
+      end
+
+      configured_efforts = Array(catalog.reasoning_efforts).map { |value| value.to_s.downcase }.reject(&:empty?)
+      if reasoning_effort && configured_efforts.any? && !configured_efforts.include?(reasoning_effort)
+        raise Error, "Schedule #{key.inspect} reasoning_effort #{reasoning_effort.inspect} is not allowed for harness #{harness.inspect}"
+      end
     end
 
     def optional_time!(value, label:)

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -28,7 +28,7 @@ module HQ
       @projects = registry.projects.map { |config| Project.new(config) }
       @agent_store = AgentStore.new(@projects)
       @personal_assistant = PersonalAssistantLifecycle.new(registry:, agent_store: @agent_store)
-      @schedule_registry = schedule_registry || ScheduleRegistry.new(projects: @projects)
+      @schedule_registry = schedule_registry || ScheduleRegistry.new(projects: @projects, harness_catalogs: registry.harness_catalogs)
       @store = store
       @push_notification_store = push_notification_store
       @web_push_notifier = web_push_notifier || WebPushNotifier.new
@@ -277,6 +277,9 @@ module HQ
         paused: state.paused?,
         stopped: state.stopped?,
         project_key: schedule.project_key,
+        agent: schedule.agent,
+        model: schedule.model,
+        reasoning_effort: schedule.reasoning_effort,
         agent_name: schedule.agent_name,
         target_agent_key: schedule.agent_key,
         system_message: schedule.system_message,
@@ -458,6 +461,7 @@ module HQ
         schedule_key: schedule.key,
         name: schedule.agent_name,
         system_message: schedule.system_message,
+        execution_overrides: schedule.execution_overrides,
         existing_agents: agents
       )
     end

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -4805,7 +4805,7 @@ module HQ
     end
 
     def schedule_registry
-      ScheduleRegistry.new(projects: @projects)
+      ScheduleRegistry.new(projects: @projects, harness_catalogs: @registry.harness_catalogs)
     end
 
     def schedule_definition!(key)

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -5197,6 +5197,9 @@ function renderScheduleForm(route) {
     endsAt: editing ? dateTimeLocalValue(schedule.ends_at) : "",
     projectKey,
     agentName,
+    agent: editing ? (schedule.agent || "") : "",
+    model: editing ? (schedule.model || "") : "",
+    reasoningEffort: editing ? (schedule.reasoning_effort || "") : "",
     systemMessage,
     message: editing ? (schedule.message_source === "file" ? (loadedFileMessage?.content || "") : (schedule.message || "")) : "",
   };
@@ -5242,6 +5245,26 @@ function renderScheduleForm(route) {
       <section class="field-card ui-field ui-surface">
         <label class="field-label ui-field__label" for="schedule-agent-name">Agent name</label>
         <input class="ui-input" id="schedule-agent-name" name="agent_name" type="text" value="${escapeAttr(values.agentName)}" autocomplete="off" placeholder="Defaults to schedule name">
+      </section>
+      <section class="field-card ui-field ui-surface">
+        <label class="field-label ui-field__label" for="schedule-harness">Harness</label>
+        <select class="ui-input" id="schedule-harness" name="agent" data-schedule-harness-select aria-describedby="schedule-harness-help">
+          <option value="" ${values.agent ? "" : "selected"}>Project default</option>
+          ${agentHarnessOptions().map((option) => `<option value="${escapeAttr(option)}" ${option === values.agent ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}
+        </select>
+        <span class="field-hint ui-field__description" id="schedule-harness-help">Optional override for new or refreshed schedule sessions.</span>
+      </section>
+      <section class="field-card ui-field ui-surface">
+        <label class="field-label ui-field__label" for="schedule-model">Model</label>
+        <select class="ui-input" id="schedule-model" name="model" data-schedule-model-select>
+          ${scheduleModelChoiceOptions(values.agent || projectDefaultHarness(values.projectKey), values.model)}
+        </select>
+      </section>
+      <section class="field-card ui-field ui-surface">
+        <label class="field-label ui-field__label" for="schedule-reasoning-effort">Reasoning effort</label>
+        <select class="ui-input" id="schedule-reasoning-effort" name="reasoning_effort" data-schedule-reasoning-effort-select>
+          ${scheduleReasoningEffortChoiceOptions(values.agent || projectDefaultHarness(values.projectKey), values.model, values.reasoningEffort)}
+        </select>
       </section>
       <div class="form-section-heading ui-form-section-heading"><strong>Recurring messages</strong><span>Stable context and per-run request</span></div>
       <section class="field-card ui-field ui-surface">
@@ -17637,6 +17660,18 @@ els.view.addEventListener("change", (event) => {
     return;
   }
 
+  const scheduleModelChoice = event.target.closest("[data-schedule-model-select]");
+  if (scheduleModelChoice) {
+    applyScheduleModelChoice(scheduleModelChoice);
+    return;
+  }
+
+  const scheduleHarnessChoice = event.target.closest("[data-schedule-harness-select]");
+  if (scheduleHarnessChoice) {
+    applyScheduleHarnessSelection(scheduleHarnessChoice);
+    return;
+  }
+
   const reasoningEffortChoice = event.target.closest("[data-agent-reasoning-effort-select]");
   if (reasoningEffortChoice) {
     applyAgentReasoningEffortChoice(reasoningEffortChoice);
@@ -18651,6 +18686,42 @@ function projectFormPayload(form) {
   };
 }
 
+function projectDefaultHarness(projectKey) {
+  return normalizeAgentHarness(findProject(projectKey)?.agent || "");
+}
+
+function scheduleModelChoiceOptions(harness, selectedModel = "") {
+  return modelChoiceOptions(harness, selectedModel).replace(">Default<", ">Project default<");
+}
+
+function scheduleReasoningEffortChoiceOptions(harness, model = "", selectedEffort = "") {
+  return reasoningEffortChoiceOptions(harness, model, selectedEffort).replace(">Default<", ">Project default<");
+}
+
+function updateScheduleModelChoices(form, harness) {
+  const modelSelect = form.querySelector("#schedule-model");
+  const model = modelSelect?.value || "";
+  if (modelSelect) modelSelect.innerHTML = scheduleModelChoiceOptions(harness, model);
+  const effortSelect = form.querySelector("#schedule-reasoning-effort");
+  if (effortSelect) effortSelect.innerHTML = scheduleReasoningEffortChoiceOptions(harness, model, effortSelect.value || "");
+}
+
+function applyScheduleHarnessSelection(select) {
+  const form = select.closest("#schedule-form");
+  if (!form) return;
+  updateScheduleModelChoices(form, select.value || projectDefaultHarness(form.querySelector("#schedule-project")?.value));
+  saveFormDraft(form);
+}
+
+function applyScheduleModelChoice(select) {
+  const form = select.closest("#schedule-form");
+  if (!form) return;
+  const harness = form.querySelector("#schedule-harness")?.value || projectDefaultHarness(form.querySelector("#schedule-project")?.value);
+  const effortSelect = form.querySelector("#schedule-reasoning-effort");
+  if (effortSelect) effortSelect.innerHTML = scheduleReasoningEffortChoiceOptions(harness, select.value, effortSelect.value || "");
+  saveFormDraft(form);
+}
+
 function scheduleFormPayload(form) {
   const formData = form instanceof FormData ? form : new FormData(form);
   const localEnd = String(formData.get("ends_at") || "").trim();
@@ -18663,6 +18734,9 @@ function scheduleFormPayload(form) {
     ends_at: localEnd && !Number.isNaN(endDate.getTime()) ? endDate.toISOString() : "",
     project_key: String(formData.get("project_key") || "").trim(),
     agent_name: String(formData.get("agent_name") || "").trim(),
+    agent: String(formData.get("agent") || "").trim().toLowerCase(),
+    model: String(formData.get("model") || "").trim(),
+    reasoning_effort: String(formData.get("reasoning_effort") || "").trim().toLowerCase(),
     system_message: String(formData.get("system_message") || "").trim(),
     message_source: "inline",
     message: String(formData.get("message") || "").trim(),

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -3501,6 +3501,9 @@ module RemoteServerTest
                               "timezone" => "UTC",
                               "project_key" => "web",
                               "agent_name" => "Daily Agent",
+                              "agent" => "claude",
+                              "model" => "claude-opus-5",
+                              "reasoning_effort" => "high",
                               "system_message" => "Daily system context.",
                               "message_source" => "inline",
                               "message" => "Check the project.",
@@ -3515,6 +3518,10 @@ module RemoteServerTest
       assert(created.dig(:body, :schedule, :project_key) == "web", "expected created schedule project")
       assert(created.dig(:body, :schedule, :system_message) == "Daily system context.",
              "expected created schedule system message")
+      assert(created.dig(:body, :schedule, :agent) == "claude" &&
+             created.dig(:body, :schedule, :model) == "claude-opus-5" &&
+             created.dig(:body, :schedule, :reasoning_effort) == "high",
+             "expected API schedule creation to return execution overrides")
       assert(created.dig(:body, :schedule, :policy, "overlap") == "skip",
              "expected schedule policy to use the fixed overlap default")
 
@@ -3524,6 +3531,9 @@ module RemoteServerTest
                               "cron" => "30 11 * * 1-5",
                               "timezone" => "local",
                               "project_key" => "web",
+                              "agent" => "",
+                              "model" => "",
+                              "reasoning_effort" => "",
                               "system_message" => "Updated system context.",
                               "message_source" => "inline",
                               "message" => "Check weekdays.",
@@ -3537,6 +3547,9 @@ module RemoteServerTest
       assert(updated.dig(:body, :schedule, :cron) == "30 11 * * 1-5", "expected updated schedule cron")
       assert(updated.dig(:body, :schedule, :system_message) == "Updated system context.",
              "expected updated schedule system message")
+      assert(updated.dig(:body, :schedule, :agent).nil? && updated.dig(:body, :schedule, :model).nil? &&
+             updated.dig(:body, :schedule, :reasoning_effort).nil?,
+             "expected empty API values to clear execution overrides")
       assert(updated.dig(:body, :schedule, :policy) == {
         "overlap" => "skip",
         "missed" => "run_once_on_start",

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -18,6 +18,7 @@ module SchedulerTest
   def run!
     with_stubbed_agent_start do
       assert_schedule_registry_validates_scope_and_prompt_paths
+      assert_schedule_execution_overrides_round_trip_and_apply
       assert_schedule_store_tracks_daemon_state
       assert_scheduler_run_reuses_schedule_agent_session
       assert_scheduler_adopts_existing_session_and_expires_loop
@@ -140,6 +141,43 @@ module SchedulerTest
       YAML
       assert_raises(HQ::ScheduleRegistry::Error, "expected message_file outside schedules/ to be rejected") do
         HQ::ScheduleRegistry.new(path: invalid_file, projects: registry.projects.map { |config| HQ::Project.new(config) }).schedules
+      end
+    end
+  end
+
+  def assert_schedule_execution_overrides_round_trip_and_apply
+    with_temp_runtime do |dir|
+      registry, schedule_path = write_registry_and_schedule(dir, <<~YAML)
+        schedules:
+          - key: override
+            cron: "0 9 * * *"
+            target:
+              type: agent
+              project_key: web
+              agent: claude
+              model: claude-opus-5
+              reasoning_effort: high
+              message: "Run with overrides."
+      YAML
+      projects = registry.projects.map { |config| HQ::Project.new(config) }
+      schedules = HQ::ScheduleRegistry.new(path: schedule_path, projects: projects).schedules
+      schedule = schedules.fetch(0)
+      assert(schedule.execution_overrides == { agent: "claude", model: "claude-opus-5", reasoning_effort: "high" },
+             "expected schedule execution override round trip")
+
+      scheduler = build_scheduler(registry, schedule_path)
+      started = scheduler.run_now("override", now: Time.new(2026, 7, 16, 9, 0, 0, "+07:00"))
+      agent = started.fetch(:agent)
+      assert(agent.agent == "claude" && agent.model == "claude-opus-5" && agent.reasoning_effort == "high",
+             "expected scheduled session to use target execution overrides")
+
+      invalid = HQ::ScheduleRegistry.new(
+        path: schedule_path,
+        projects: projects,
+        harness_catalogs: { "claude" => HQ::HarnessCatalogConfig.new(key: "claude", models: ["claude-opus-5"], reasoning_efforts: ["high"]) }
+      )
+      assert_raises(HQ::ScheduleRegistry::Error, "expected configured harness catalog to reject an invalid override") do
+        invalid.update("override", "model" => "not-in-catalog")
       end
     end
   end


### PR DESCRIPTION
Adds optional per-schedule harness, model, and reasoning-effort overrides with project-default fallback. Validates configured catalog values, preserves round trips through CLI/API/Remote UI, and applies overrides to new and refreshed scheduled sessions.\n\nVerified with scheduler, Remote API/UI asset tests and the Phase 2 browser smoke.