### PR TITLE
Prevent delegation resume during parent inquiry

### DIFF
--- a/lib/hq/domain/delegation_coordinator.rb
+++ b/lib/hq/domain/delegation_coordinator.rb
@@ -157,6 +157,13 @@ module HQ
           next
         end
 
+        if parent.latest_inquiry
+          reports.each do |report|
+            delegation_store.update_report!(report.fetch("id"), resume_state: "awaiting_parent_input")
+          end
+          next
+        end
+
         parent_workspace = canonical_workspace(parent.workspace)
         conflicts = agents.any? do |agent|
           agent.key != parent.key && canonical_workspace(agent.workspace) == parent_workspace && agent.running?

--- a/test/delegation_test.rb
+++ b/test/delegation_test.rb
@@ -54,7 +54,7 @@ class DelegationTest
       @running = false
     end
 
-    def finish_run!(suffix, owner: "parent", generation: 1)
+    def finish_run!(suffix, owner: "parent", generation: 1, status: @status)
       @run_count += 1
       @last_run = FakeRun.new(
         run_id: "run-#{@key}-#{suffix}",
@@ -63,6 +63,8 @@ class DelegationTest
         delegation_generation: generation
       )
       @session_id = @last_run.session_id
+      @status = status
+      @structured_result["status"] = status
       @running = false
     end
 
@@ -238,6 +240,23 @@ class DelegationTest
       callback_events = events.select { |event| event.dig("metadata", "delegation_callback") }
       assert(callback_events.length == 1, "expected callback message deduplication")
       assert(events.any? { |event| event["type"] == "delegation_event" }, "expected contextual creation event")
+
+      waiting_parent = FakeAgent.new(key: "waiting-parent", root: dir, running: true,
+                                     workspace: File.join(dir, "waiting-parent-workspace"))
+      waiting_child = FakeAgent.new(key: "waiting-child", root: dir,
+                                    workspace: File.join(dir, "waiting-child-workspace"))
+      waiting_agents = [waiting_parent, waiting_child]
+      coordinator.attach!(agents: waiting_agents, child: waiting_child, parent_key: waiting_parent.key)
+      coordinator.process!(waiting_agents)
+      waiting_report = store.reports.find { |item| item["child_run_id"] == "run-waiting-child" }
+      assert(waiting_report["resume_state"] == "parent_running",
+             "expected child callback to wait for its running parent")
+      waiting_parent.finish_run!("asked-user", status: "input_required")
+      coordinator.process!(waiting_agents)
+      waiting_report = store.reports.find { |item| item["child_run_id"] == "run-waiting-child" }
+      assert(!waiting_parent.running?, "expected parent inquiry to block automatic callback resume")
+      assert(waiting_report["resume_state"] == "awaiting_parent_input",
+             "expected callback to remain pending until explicit parent input")
 
       quiet_parent = FakeAgent.new(key: "quiet-parent", root: dir,
                                    workspace: File.join(dir, "quiet-parent-workspace"))


### PR DESCRIPTION
## Summary
- Prevent a delivered child callback from automatically restarting a parent while that parent has an unanswered inquiry.
- Keep the callback in the delegation ledger with an awaiting-parent-input state.
- Stabilize the real-HTTP Personal Assistant action fixture so it uses the same FRED session as its proposal.

## Root cause
The delegation loop came from a callback deferred as parent-running remaining resumable after the parent finished with input-required.

The failed push CI run exposed a separate real failure in the Phase 2 HTTP fixture. Its listener built a different RemoteService and FRED session than the one that created the action proposal, so preflight intermittently rejected the proposal as belonging to an earlier conversation. The listener now supports an injected service factory for this test seam.

## Verification
- 10 consecutive bundle exec ruby test/personal_assistant_phase2_test.rb runs
- bundle exec ruby test/delegation_test.rb
- bundle exec ruby test/remote_server_test.rb
- bin/test reaches the unrelated local-environment tycho_updater_test failure because a real local Remote server is running; CI runs in an isolated environment.