### PR TITLE
Fix inquiry tab order

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5873,6 +5873,17 @@ Saved safely.
         }
         await page.click("[data-toggle-inquiry-full-screen]");
         await page.waitForSelector("#inquiry-form.inquiry-form-full-screen", { state: "visible", timeout: 10_000 });
+        await page.locator("#inquiry-feedback").press("Tab");
+        const inquiryTabTarget = await page.evaluate(() => {
+          const active = document.activeElement;
+          return {
+            uploadButton: active?.matches("[data-add-prompt-attachment]"),
+            hiddenFileInput: active?.matches("[data-prompt-attachment-input]"),
+          };
+        });
+        if (!inquiryTabTarget.uploadButton || inquiryTabTarget.hiddenFileInput) {
+          throw new Error(`Inquiry feedback Tab must skip the hidden file input: ${JSON.stringify(inquiryTabTarget)}`);
+        }
         const inquiryModalBox = await page.locator("#inquiry-form.inquiry-form-full-screen").boundingBox();
         const inquiryModalRole = await page.locator("#inquiry-form").getAttribute("role");
         const inquiryBackgroundInert = await page.locator("[data-agent-workspace]").evaluate((element) => element.inert);

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -11480,6 +11480,7 @@ function renderPromptAttachmentInput(agent) {
       type="file"
       data-prompt-attachment-input
       data-agent-key="${escapeAttr(agent.key)}"
+      tabindex="-1"
       multiple
       ${agentIsRunning(agent) ? "disabled" : ""}
     >

--- a/test/delegation_runner_test.rb
+++ b/test/delegation_runner_test.rb
@@ -120,7 +120,7 @@ module DelegationRunnerTest
       raise "missing detached callback message" unless callback
       raise "callback did not name child" unless callback.dig("metadata", "agent_reference", "agent_key") == child_key
 
-      child_record = JSON.parse(File.read(agents_path)).find { |agent| agent["key"] == child_key }
+      child_record = wait_for_agent(agents_path, child_key, minimum_runs: 1)
       child_memory_path = child_record.fetch("log_path").sub(/\.raw\.log\z/, ".memory.jsonl")
       child_events = File.readlines(child_memory_path).map { |line| JSON.parse(line) }
       signed_prompt = child_events.find { |event| event["content"] == "Execute the delegated work" }

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -6014,6 +6014,10 @@ module RemoteServerTest
     assert(js[:body].include?("data-agent-dock"), "expected Agent detail composer to live in a dock")
     assert(js[:body].include?("function renderInquiryForm"),
            "expected Agent detail to render structured inquiry forms")
+    prompt_attachment_input = js[:body][/function renderPromptAttachmentInput\(agent\).*?^}/m]
+    assert(prompt_attachment_input&.include?('data-prompt-attachment-input') &&
+           prompt_attachment_input.include?('tabindex="-1"'),
+           "expected inquiry attachment inputs to stay out of the keyboard tab order")
     assert(js[:body].include?("function renderInquiryLoadingSkeleton") &&
            js[:body].include?('composerState === "inquiry-loading"') &&
            js[:body].include?('class="inquiry-loading-tools"') &&


### PR DESCRIPTION
## Summary
- remove the visually hidden inquiry attachment input from sequential keyboard navigation
- move focus from optional feedback directly to the visible Upload file control
- add focused Remote UI browser and asset-contract regression coverage

## Verification
- `bundle exec ruby test/remote_server_test.rb` ✅
- `bin/remote-ui-smoke` ⚠️ stops before the inquiry case on an existing Settings menu fixture mismatch: expected route-specific actions but saw `["Settings", "Push notifications", "Hidden projects", "Refresh harness catalogs", "Recheck status", "Restart server"]`.
- `bin/test` ⚠️ stops after earlier passing suites on an existing `personal_assistant_phase2_test` HTTP preflight assertion (`409`, expected success).

Closes #181