### PR TITLE
Preserve conversation scroll during polling

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -5413,9 +5413,9 @@ Saved safely.
         if (value !== draft) throw new Error(`Composer draft was not preserved: ${JSON.stringify(value)}`);
         await assertEditorExcludedFromRefresh("#composer:not(.composer-full-screen)", "Inline conversation form", "#prompt-input");
 
-        // Polling may observe a server snapshot while the user is composing.
-        // The browser must retain the rendered history and scroll position until
-        // the explicit accessible control is activated.
+        // Polling may observe newer conversation metadata while the user is
+        // composing. The browser must not fetch or render the full snapshot
+        // until the explicit accessible control is activated.
         const stagedConversation = await page.evaluate((key) => {
           clearTimeout(state.timer);
           state.timer = null;
@@ -5442,7 +5442,7 @@ Saved safely.
             metadata: { personal_assistant_client_request_id: "fred-manual-load" },
           };
           state.pendingConversationMessages[key] = [pending];
-          receiveConversationSnapshot(key, [...baseline, {
+          const incoming = [...baseline, {
             id: "fred-manual-load-server",
             kind: "message",
             role: "user",
@@ -5455,7 +5455,25 @@ Saved safely.
             role: "assistant",
             content: "Server message staged for manual loading",
             created_at: new Date().toISOString(),
-          }], "manual-load-next");
+          }];
+          receiveConversationMetadata(key, {
+            revision: "manual-load-next",
+            block_count: incoming.length,
+            digest: "manual-load-next-digest",
+          });
+          const originalApiGet = apiGet;
+          apiGet = async (path) => {
+            if (String(path).endsWith(`/agents/${encodeURIComponent(key)}/conversation`)) {
+              apiGet = originalApiGet;
+              return {
+                conversation: incoming,
+                conversation_revision: "manual-load-next",
+                conversation_block_count: incoming.length,
+                conversation_digest: "manual-load-next-digest",
+              };
+            }
+            return originalApiGet(path);
+          };
           render({ preserveLiveEditor: true });
           const button = document.querySelector("[data-load-pending-conversation]");
           const rootRect = root.getBoundingClientRect();
@@ -5476,6 +5494,7 @@ Saved safely.
           throw new Error(`Manual conversation loading changed the visible snapshot before activation: ${JSON.stringify(stagedConversation)}`);
         }
         await page.click("[data-load-pending-conversation]");
+        await page.waitForSelector("[data-load-pending-conversation]", { state: "detached", timeout: 10_000 });
         const loadedConversation = await page.evaluate((key) => ({
           contentLoaded: state.conversations[key]?.blocks?.some((block) => block.content === "Server message staged for manual loading"),
           pendingCleared: !state.pendingConversationUpdates[key],

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -582,7 +582,8 @@ module HQ
         return ok(service.update_agent_delegation(key, body)) if %w[PATCH PUT].include?(method) && tail == ["delegation"]
         return ok(service.archive_agent(key)) if method == "DELETE" && tail.empty?
         return created(service.create_agent_loop(key, body)) if method == "POST" && tail == ["loop-schedule"]
-        return ok(conversation: service.conversation(key)) if method == "GET" && tail == ["conversation"]
+        return ok(service.conversation_snapshot(key)) if method == "GET" && tail == ["conversation"]
+        return ok(metadata: service.conversation_metadata(key)) if method == "GET" && tail == ["conversation", "metadata"]
         return ok(debug: service.agent_debug(key)) if method == "GET" && tail == ["debug"]
         return ok(log: service.agent_log(key, request&.query_params || {})) if method == "GET" && tail == ["logs"]
         if method == "POST" && tail == ["memory", "capture", "dry-run"]
@@ -3817,8 +3818,27 @@ module HQ
     end
 
     def conversation(key)
+      conversation_snapshot(key).fetch(:conversation)
+    end
+
+    def conversation_snapshot(key)
       target = find_agent_reference!(key)
-      conversation_for_agent(target)
+      blocks = conversation_for_agent(target)
+      {
+        conversation: blocks,
+        conversation_revision: agent_revision(target),
+        conversation_block_count: blocks.length,
+        conversation_digest: Digest::SHA256.hexdigest(JSON.generate(blocks))
+      }
+    end
+
+    def conversation_metadata(key)
+      snapshot = conversation_snapshot(key)
+      {
+        revision: snapshot.fetch(:conversation_revision),
+        block_count: snapshot.fetch(:conversation_block_count),
+        digest: snapshot.fetch(:conversation_digest)
+      }
     end
 
     def conversation_for_agent(target)

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3773,20 +3773,25 @@ function prunePullRequestDiffState(activeAgentKeys) {
 
 async function ensureConversation(agent, force = false) {
   const cached = state.conversations[agent.key];
+  const requestMode = REMOTE_HELPERS.conversationSnapshotRequestMode(cached, agent.revision, {
+    force: force || (personalAssistantAgent(agent) && agent.running),
+  });
+  if (requestMode === "none" || state.loadingConversations[agent.key]) return;
+  const loadSnapshot = requestMode === "snapshot";
   if (personalAssistantAgent(agent)) {
     const requests = state.personalAssistantRequests.conversations;
     const context = personalAssistantSessionContext();
     const requestKey = [agent.key, context?.server_key || "local", context?.active_key || "no-session", context?.generation ?? "no-generation"].join(":");
     if (requests[requestKey]?.promise) return requests[requestKey].promise;
-    if (!force && !agent.running && cached && cached.revision === agent.revision && !cached.loading && !cached.error) return;
 
     const routeHashAtStart = location.hash;
     const capturedRevision = agent.revision;
-    setConversationLoading(agent.key, true, cached);
-    render({ preserveLiveEditor: true });
+    setConversationLoading(agent.key, true, cached, { quiet: !loadSnapshot });
+    if (loadSnapshot) render({ preserveLiveEditor: true });
     return personalAssistantRequest(requests, requestKey, async () => {
       try {
-        const data = await apiGet("/agents/" + encodeURIComponent(agent.key) + "/conversation");
+        const suffix = loadSnapshot ? "/conversation" : "/conversation/metadata";
+        const data = await apiGet("/agents/" + encodeURIComponent(agent.key) + suffix);
         const currentAgent = findAgent(agent.key);
         const revisionMatches = !capturedRevision || !currentAgent?.revision ||
           currentAgent.revision === capturedRevision;
@@ -3796,12 +3801,21 @@ async function ensureConversation(agent, force = false) {
           personalAssistantSessionMatches(context) &&
           revisionMatches;
         if (!current) return null;
-        receiveConversationSnapshot(agent.key, data.conversation || [], capturedRevision, { initial: !cached?.loaded });
-        reconcilePersonalAssistantConversation(agent.key, data.conversation || []);
-        reconcilePersonalAssistantTerminalRuns(agent.key, data.conversation || []);
+        if (loadSnapshot) {
+          receiveConversationSnapshot(
+            agent.key,
+            data.conversation || [],
+            data.conversation_revision || capturedRevision,
+            { initial: true, digest: data.conversation_digest }
+          );
+          reconcilePersonalAssistantConversation(agent.key, data.conversation || []);
+          reconcilePersonalAssistantTerminalRuns(agent.key, data.conversation || []);
+        } else {
+          receiveConversationMetadata(agent.key, data.metadata || {});
+        }
         return data;
       } catch (error) {
-        if (location.hash === routeHashAtStart && parseRoute().type === "personalAssistant" &&
+        if (loadSnapshot && location.hash === routeHashAtStart && parseRoute().type === "personalAssistant" &&
             personalAssistantSessionMatches(context)) {
           state.conversations[agent.key] = {
             ...(state.conversations[agent.key] || {}),
@@ -3818,29 +3832,39 @@ async function ensureConversation(agent, force = false) {
       }
     });
   }
-  if (cached?.loading) return;
-  if (!force && cached && cached.revision === agent.revision && !cached.loading) return;
 
-  setConversationLoading(agent.key, true, cached);
-  render();
+  setConversationLoading(agent.key, true, cached, { quiet: !loadSnapshot });
+  if (loadSnapshot) render();
   try {
-    const data = await apiGet(`/agents/${encodeURIComponent(agent.key)}/conversation`);
-    receiveConversationSnapshot(agent.key, data.conversation || [], agent.revision, { initial: !cached?.loaded });
+    const suffix = loadSnapshot ? "/conversation" : "/conversation/metadata";
+    const data = await apiGet(`/agents/${encodeURIComponent(agent.key)}${suffix}`);
+    if (loadSnapshot) {
+      receiveConversationSnapshot(
+        agent.key,
+        data.conversation || [],
+        data.conversation_revision || agent.revision,
+        { initial: true, digest: data.conversation_digest }
+      );
+    } else {
+      receiveConversationMetadata(agent.key, data.metadata || {});
+    }
   } finally {
     setConversationLoading(agent.key, false);
   }
 }
 
-function setConversationLoading(agentKey, loading, cached = state.conversations[agentKey]) {
+function setConversationLoading(agentKey, loading, cached = state.conversations[agentKey], options = {}) {
   if (!agentKey) return;
 
   if (loading) {
     state.loadingConversations[agentKey] = true;
-    state.conversations[agentKey] = {
-      ...(cached || {}),
-      blocks: cached?.blocks || [],
-      loading: true,
-    };
+    if (!options.quiet) {
+      state.conversations[agentKey] = {
+        ...(cached || {}),
+        blocks: cached?.blocks || [],
+        loading: true,
+      };
+    }
   } else {
     delete state.loadingConversations[agentKey];
     if (state.conversations[agentKey]) state.conversations[agentKey].loading = false;
@@ -8022,46 +8046,92 @@ function receiveConversationSnapshot(agentKey, blocks, revision, options = {}) {
   const current = state.conversations[key];
   const shouldApply = options.initial === true || !current?.loaded;
   if (shouldApply) {
-    state.conversations[key] = { revision, blocks: incoming, loaded: true, loading: false };
+    state.conversations[key] = { revision, blocks: incoming, digest: options.digest || "", loaded: true, loading: false };
     delete state.pendingConversationUpdates[key];
     return { applied: true, unseen: [] };
   }
 
   if (REMOTE_HELPERS.conversationBlocksMatch(current.blocks, incoming)) {
+    current.revision = revision;
+    if (options.digest) current.digest = options.digest;
     delete state.pendingConversationUpdates[key];
     return { applied: false, unseen: [] };
   }
 
   const unseen = REMOTE_HELPERS.unseenConversationBlocks(current.blocks, incoming);
-  state.pendingConversationUpdates[key] = { revision, blocks: incoming, unseen };
+  state.pendingConversationUpdates[key] = { revision, blocks: incoming, unseen, digest: options.digest || "" };
   return { applied: false, unseen };
 }
 
-function loadPendingConversationMessages(agentKey) {
+function receiveConversationMetadata(agentKey, metadata) {
+  const key = String(agentKey || "");
+  const current = state.conversations[key];
+  if (!key || !current?.loaded) return { staged: false, unseenCount: 0 };
+
+  const revision = String(metadata?.revision || "");
+  const blockCount = Number(metadata?.block_count);
+  const digest = String(metadata?.digest || "");
+  if (!Number.isFinite(blockCount) || blockCount < 0) return { staged: false, unseenCount: 0 };
+  if ((digest && digest === String(current.digest || "")) ||
+      (!digest && revision === String(current.revision || "") && blockCount === current.blocks.length)) {
+    current.revision = revision;
+    if (digest) current.digest = digest;
+    delete state.pendingConversationUpdates[key];
+    return { staged: false, unseenCount: 0 };
+  }
+
+  const unseenCount = Math.max(0, blockCount - current.blocks.length);
+  state.pendingConversationUpdates[key] = { revision, blockCount, unseenCount, digest };
+  return { staged: true, unseenCount };
+}
+
+async function loadPendingConversationMessages(agentKey) {
   const key = String(agentKey || "");
   const pending = pendingConversationUpdate(key);
-  if (!pending) return;
+  if (!pending || pending.loading) return;
 
-  state.conversations[key] = {
-    ...(state.conversations[key] || {}),
-    revision: pending.revision,
-    blocks: pending.blocks,
-    loaded: true,
-    loading: false,
-  };
-  delete state.pendingConversationUpdates[key];
+  pending.loading = true;
   state.renderedViewHtml = "";
   render({ preserveLiveEditor: true });
-  window.requestAnimationFrame(scrollAgentConversationToBottom);
+  try {
+    const data = await apiGet(`/agents/${encodeURIComponent(key)}/conversation`);
+    state.conversations[key] = {
+      ...(state.conversations[key] || {}),
+      revision: data.conversation_revision || pending.revision,
+      blocks: Array.isArray(data.conversation) ? data.conversation : [],
+      digest: data.conversation_digest || pending.digest || "",
+      loaded: true,
+      loading: false,
+    };
+    const agent = findAgent(key);
+    if (personalAssistantAgent(agent)) {
+      reconcilePersonalAssistantConversation(key, state.conversations[key].blocks);
+      reconcilePersonalAssistantTerminalRuns(key, state.conversations[key].blocks);
+    }
+    delete state.pendingConversationUpdates[key];
+    state.renderedViewHtml = "";
+    render({ preserveLiveEditor: true });
+    window.requestAnimationFrame(scrollAgentConversationToBottom);
+  } catch (error) {
+    pending.loading = false;
+    state.renderedViewHtml = "";
+    render({ preserveLiveEditor: true });
+    showGrowl(error.message || "Could not load new messages", "need");
+  }
 }
 
 function renderPendingConversationControl(agent) {
   const pending = pendingConversationUpdate(agent?.key);
-  const count = pending?.unseen?.length || 0;
+  const count = pending?.unseenCount ?? pending?.unseen?.length ?? 0;
   if (!pending) return "";
 
-  const label = count ? `${count} new message${count === 1 ? "" : "s"}` : "Conversation updated";
-  return `<div class="new-conversation-messages" role="status" aria-live="polite" aria-atomic="true"><button class="ui-button" type="button" data-load-pending-conversation="${escapeAttr(agent.key)}" aria-label="Load ${escapeAttr(label)}">Load ${escapeHtml(label)}</button></div>`;
+  const label = pending.loading
+    ? "Loading new messages"
+    : count
+      ? `${count} new message${count === 1 ? "" : "s"}`
+      : "Conversation updated";
+  const buttonLabel = pending.loading ? label : `Load ${label}`;
+  return `<div class="new-conversation-messages" role="status" aria-live="polite" aria-atomic="true"><button class="ui-button" type="button" data-load-pending-conversation="${escapeAttr(agent.key)}" aria-label="${escapeAttr(buttonLabel)}" ${pending.loading ? "disabled" : ""}>${escapeHtml(buttonLabel)}</button></div>`;
 }
 
 function renderAgentAttachmentView(agent, attachmentId, options = {}) {
@@ -15194,17 +15264,12 @@ function agentIsRunning(agent) {
   return !!agent?.running || agent?.status === "running";
 }
 
-function agentSucceeded(agent) {
-  if (agent?.last_result) return agent.last_result === "success";
-  return agent?.status === "succeeded" || agent?.status === "success" || agent?.last_result === "success";
-}
-
 function shouldOpenSummaryForSucceededAgent(previousAgents, nextAgents, route = parseRoute()) {
   if (route.type !== "agent") return false;
 
   const previous = previousAgents.find((agent) => agent.key === route.key);
   const next = nextAgents.find((agent) => agent.key === route.key);
-  return !!previous && !!next && !agentSucceeded(previous) && agentSucceeded(next);
+  return REMOTE_HELPERS.shouldOpenSucceededAgentSummary(previous, next, route.type);
 }
 
 function conversationTailMarker(agentKey) {

--- a/lib/hq/remote_ui/assets/app_helpers.js
+++ b/lib/hq/remote_ui/assets/app_helpers.js
@@ -579,6 +579,23 @@
     return left.every((block, index) => conversationBlockIdentity(block) === conversationBlockIdentity(right[index]));
   }
 
+  function conversationSnapshotRequestMode(conversation, agentRevision, options = {}) {
+    if (options.manual === true || !conversation?.loaded) return "snapshot";
+    if (!options.force && conversation.revision === agentRevision && !conversation.loading && !conversation.error) return "none";
+    return "metadata";
+  }
+
+  function agentSucceeded(agent) {
+    if (agent?.last_result) return agent.last_result === "success";
+    return ["succeeded", "success"].includes(String(agent?.status || ""));
+  }
+
+  function shouldOpenSucceededAgentSummary(previous, next, routeType) {
+    if (routeType !== "agent" || !previous || !next) return false;
+    if (previous.scheduled || next.scheduled || previous.schedule_key || next.schedule_key) return false;
+    return !agentSucceeded(previous) && agentSucceeded(next);
+  }
+
   function unseenConversationBlocks(rendered, incoming) {
     const seen = new Map();
     (Array.isArray(rendered) ? rendered : []).forEach((block) => {
@@ -716,6 +733,7 @@
     conversationBlockIdentity,
     conversationBlocksMatch,
     conversationLoading,
+    conversationSnapshotRequestMode,
     controlState,
     currentAgentSortOption,
     decodeHashFragment,
@@ -742,6 +760,7 @@
     safeLocalStorageSet,
     shouldPreserveControl,
     shouldPollServerActivity,
+    shouldOpenSucceededAgentSummary,
     stableConversationValue,
     textSelectionFor,
     unseenConversationBlocks,

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -2879,9 +2879,23 @@ module RemoteServerTest
       end
       summary_index = conversation.index(summary)
       memory_summary = memory.events.find { |event| event["type"] == "run_summary" }
+      server = HQ::RemoteServer.new
+      metadata_response = server.send(
+        :route,
+        service,
+        "GET",
+        "/agents/#{created[:key]}/conversation/metadata",
+        {},
+        nil
+      )
+      metadata = metadata_response.dig(:body, :metadata)
 
       assert(summary&.dig(:content)&.include?("A detailed run summary"),
              "expected Remote UI conversation payload to include run summary blocks")
+      assert(metadata[:block_count] == conversation.length && !metadata_response[:body].key?(:conversation),
+             "expected conversation metadata polling to omit the full block payload")
+      assert(!metadata[:revision].to_s.empty?,
+             "expected conversation metadata polling to expose the current revision")
       assert(summary&.dig(:content)&.include?("Second paragraph"),
              "expected Remote UI conversation payload to expose full run summaries for preview truncation")
       assert(summary&.dig(:metadata, "summary_id").to_s.start_with?("summary-"),
@@ -7059,8 +7073,9 @@ module RemoteServerTest
            "expected Agent detail scrolling to avoid reopening a docked Summary panel")
     assert(js[:body].include?("function shouldOpenSummaryForSucceededAgent"),
            "expected Agent detail to open the Summary page when the active agent succeeds")
-    assert(js[:body].include?("!agentSucceeded(previous) && agentSucceeded(next)"),
-           "expected Summary to open only on a success transition")
+    assert(js[:body].include?("REMOTE_HELPERS.shouldOpenSucceededAgentSummary(previous, next, route.type)") &&
+           helpers_js[:body].include?("previous.scheduled || next.scheduled || previous.schedule_key || next.schedule_key"),
+           "expected Summary to open only for unscheduled agent success transitions")
     assert(js[:body].include?('navigate({ type: "agentSummary", key: currentRoute.key });'),
            "expected successful agent transitions to navigate to the Summary page")
     assert(js[:body].include?("conversationTailMarkers"),

--- a/test/remote_ui_conversation_loading_test.rb
+++ b/test/remote_ui_conversation_loading_test.rb
@@ -21,6 +21,8 @@ module RemoteUIConversationLoadingTest
       const conversationBlocksMatch = context.window.TychoRemoteHelpers.conversationBlocksMatch;
       const unseenConversationBlocks = context.window.TychoRemoteHelpers.unseenConversationBlocks;
       const pendingConversationBlockAcknowledged = context.window.TychoRemoteHelpers.pendingConversationBlockAcknowledged;
+      const conversationSnapshotRequestMode = context.window.TychoRemoteHelpers.conversationSnapshotRequestMode;
+      const shouldOpenSucceededAgentSummary = context.window.TychoRemoteHelpers.shouldOpenSucceededAgentSummary;
       const conversations = {
         alpha: { blocks: [], loaded: true, loading: false },
       };
@@ -82,6 +84,35 @@ module RemoteUIConversationLoadingTest
       const legacyAcknowledged = { id: "server-legacy", kind: "message", role: "user", content: "Same legacy prompt", created_at: "2026-09-10T00:00:02Z" };
       if (!pendingConversationBlockAcknowledged(legacyPending, [legacyAcknowledged])) {
         throw new Error("nearby legacy acknowledgement did not suppress a duplicate optimistic message");
+      }
+
+      const loadedConversation = { revision: "old", blocks: rendered, loaded: true, loading: false };
+      if (conversationSnapshotRequestMode(loadedConversation, "new", { force: true }) !== "metadata") {
+        throw new Error("automatic refresh fetched the full conversation snapshot");
+      }
+      if (conversationSnapshotRequestMode(loadedConversation, "new", { manual: true }) !== "snapshot") {
+        throw new Error("manual loading did not fetch the full conversation snapshot");
+      }
+      if (conversationSnapshotRequestMode(undefined, "new") !== "snapshot") {
+        throw new Error("initial conversation loading did not fetch the full snapshot");
+      }
+      if (conversationSnapshotRequestMode({ ...loadedConversation, revision: "new" }, "new") !== "none") {
+        throw new Error("unchanged conversation revision triggered another request");
+      }
+
+      if (shouldOpenSucceededAgentSummary(
+        { key: "loop", status: "running", scheduled: true },
+        { key: "loop", status: "succeeded", scheduled: true },
+        "agent"
+      )) {
+        throw new Error("scheduled loop completion opened Summary and displaced the conversation scroll");
+      }
+      if (!shouldOpenSucceededAgentSummary(
+        { key: "manual", status: "running", scheduled: false },
+        { key: "manual", status: "succeeded", scheduled: false },
+        "agent"
+      )) {
+        throw new Error("ordinary agent completion stopped opening Summary");
       }
     JAVASCRIPT
 

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -45,6 +45,11 @@ module RemoteUIPersonalAssistantBehaviorTest
         Set,
         REMOTE_HELPERS: {
           conversationBlocksMatch: (left, right) => JSON.stringify(left) === JSON.stringify(right),
+          conversationSnapshotRequestMode: (conversation, revision, options = {}) => {
+            if (!conversation?.loaded) return "snapshot";
+            if (!options.force && conversation.revision === revision) return "none";
+            return "metadata";
+          },
           unseenConversationBlocks: (_left, right) => right,
         },
         PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT: 128,
@@ -85,6 +90,7 @@ module RemoteUIPersonalAssistantBehaviorTest
         "personalAssistantStatusRequestIsCurrent",
         "requestPersonalAssistantStatus",
         "receiveConversationSnapshot",
+        "receiveConversationMetadata",
         "ensureConversation",
       ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
 
@@ -304,14 +310,17 @@ module RemoteUIPersonalAssistantBehaviorTest
           fred: { revision: "rev-1", blocks: [], loaded: true, loading: false },
         };
         context.state.loadingConversations = {};
+        context.state.pendingConversationUpdates = {};
         context.state.personalAssistantRequests = { conversations: {} };
-        context.apiGet = () => {
+        let conversationPath = "";
+        context.apiGet = (path) => {
           conversationReads += 1;
-          return Promise.resolve({ conversation: [] });
+          conversationPath = path;
+          return Promise.resolve({ metadata: { revision: "rev-1", block_count: 0 } });
         };
         await context.ensureConversation(runningAgent, false);
-        assert(conversationReads === 1,
-               "running FRED skipped its focused conversation read on an unchanged revision");
+        assert(conversationReads === 1 && conversationPath.endsWith("/conversation/metadata"),
+               "running FRED did not use a metadata-only focused conversation read");
         const idleAgent = { ...runningAgent, running: false };
         await context.ensureConversation(idleAgent, false);
         assert(conversationReads === 1,


### PR DESCRIPTION
## Summary
- poll compact conversation metadata after the initial full snapshot
- fetch and apply full conversation blocks only from Load x new messages
- keep scheduled-loop completion on the conversation route

## Validation
- focused conversation, Personal Assistant, and Remote Server regressions
- isolated full test coverage (including updater with isolated Tycho state)
- JavaScript/Ruby syntax and git diff --check
- `bin/remote-ui-smoke` reached the metadata endpoint, then stopped at the existing Settings context-menu assertion before the manual-load phase