### PR TITLE
Reduce FRED cold-open agent loading

### DIFF
--- a/lib/hq/domain/personal_assistant.rb
+++ b/lib/hq/domain/personal_assistant.rb
@@ -140,15 +140,32 @@ module HQ
     end
 
     def status
-      synchronize { |state| snapshot_finalized_proposals!(state); reconcile!(state); payload(state) }
+      synchronize do |state|
+        agents = agents_for_reconcile(state)
+        active = active_agent_from(agents, state)
+        snapshot_finalized_proposals!(state, agent: active)
+        reconcile!(state, agents:)
+        payload(state, active_agent: active_agent_from(agents, state))
+      end
     end
 
     def reconcile
-      synchronize { |state| snapshot_finalized_proposals!(state); reconcile!(state); snapshot_finalized_proposals!(state); advance!(state); payload(state) }
+      synchronize do |state|
+        agents = agents_for_reconcile(state)
+        active = active_agent_from(agents, state)
+        snapshot_finalized_proposals!(state, agent: active)
+        reconcile!(state, agents:)
+        snapshot_finalized_proposals!(state, agent: active_agent_from(agents, state))
+        advance!(state)
+        payload(state, active_agent: active_agent_from(agents, state))
+      end
     end
 
-    def finalized_proposals
-      synchronize { |state| snapshot_finalized_proposals!(state); Array(state["finalized_proposals"]).reject { |snapshot| snapshot["registered"] == true } }
+    def finalized_proposals(refresh: true)
+      synchronize do |state|
+        snapshot_finalized_proposals!(state) if refresh
+        Array(state["finalized_proposals"]).reject { |snapshot| snapshot["registered"] == true }
+      end
     end
 
     def mark_finalized_proposals_registered!(run_id)
@@ -618,7 +635,7 @@ module HQ
       path
     end
 
-    def reconcile!(state, dispatch_prompt_queues: true)
+    def reconcile!(state, dispatch_prompt_queues: true, agents: nil)
       unless @registry.personal_assistant["enabled"] == true
         adopt_orphan!(state)
         return unless controlled_shutdown!(state)
@@ -628,11 +645,7 @@ module HQ
         return
       end
       return unless state["active_key"]
-      agents = if @agent_store.respond_to?(:load_with_poll_events)
-                  @agent_store.load_with_poll_events(process_delegations: false, dispatch_prompt_queues:).first
-                else
-                  @agent_store.load
-                end
+      agents ||= agents_for_reconcile(state, dispatch_prompt_queues:)
       unless agents.any? { |agent| agent.key == state["active_key"] && agent.personal_assistant? }
         state.delete("active_key"); state.delete("active_date"); state.delete("active_timezone"); state.delete("active_personality")
         state["phase"] = "dormant"
@@ -777,12 +790,12 @@ module HQ
       FileStore.write_json(@state_path, state.merge("version" => 1))
     end
 
-    def payload(state)
+    def payload(state, active_agent: nil)
       configured = @registry.personal_assistant
       config = configured.slice("model", "reasoning_effort", "timezone")
       config["personality"] = personality(configured)
       config["external_events_prompt"] = external_events_prompt(configured)
-      active = active_agent(state)
+      active = active_agent || active_agent(state)
       timezone = state["active_timezone"] || config["timezone"]
       {
         state: state["phase"] || (@registry.personal_assistant["enabled"] ? "ready" : "unconfigured"),
@@ -1040,10 +1053,27 @@ module HQ
       state.merge!("active_key" => agent.key, "active_date" => state["active_date"] || @clock.call.strftime("%F"), "active_timezone" => state["active_timezone"] || @registry.personal_assistant["timezone"], "active_personality" => state["active_personality"] || DEFAULT_PERSONALITY, "phase" => "active")
     end
 
-    def snapshot_finalized_proposals!(state)
+    def agents_for_reconcile(state, dispatch_prompt_queues: true)
+      return [] unless state["active_key"]
+
+      if @agent_store.respond_to?(:load_with_poll_events)
+        @agent_store.load_with_poll_events(process_delegations: false, dispatch_prompt_queues:).first
+      else
+        @agent_store.load
+      end
+    end
+
+    def active_agent_from(agents, state)
+      key = state["active_key"].to_s
+      return nil if key.empty?
+
+      agents.find { |candidate| candidate.key == key && candidate.personal_assistant? }
+    end
+
+    def snapshot_finalized_proposals!(state, agent: nil)
       return unless state["active_key"] && %w[active closing].include?(state["phase"])
 
-      agent = @agent_store.load.find { |candidate| candidate.key == state["active_key"] && candidate.personal_assistant? }
+      agent ||= @agent_store.load.find { |candidate| candidate.key == state["active_key"] && candidate.personal_assistant? }
       return unless agent
       snapshots = Array(state["finalized_proposals"])
       agent.runs.each do |run|

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -257,9 +257,10 @@ module HQ
 
       payload = service.personal_assistant_bundle
       finished_signature = personal_assistant_snapshot_signature(service)
+      finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @personal_assistant_snapshot_lock.synchronize do
         if @personal_assistant_snapshot_revision == snapshot_revision && signature == finished_signature
-          @personal_assistant_snapshot = { created_at: now, signature: signature, payload: payload }
+          @personal_assistant_snapshot = { created_at: finished_at, signature: signature, payload: payload }
         end
       end
       payload
@@ -2739,7 +2740,7 @@ module HQ
     end
 
     def ingest_personal_assistant_actions!(status)
-      @personal_assistant.finalized_proposals.each do |snapshot|
+      @personal_assistant.finalized_proposals(refresh: false).each do |snapshot|
         next if snapshot["run_id"].to_s == status[:summary_run_id].to_s && !status[:summary_run_id].to_s.empty?
 
         proposals = @personal_assistant_actions.register_finalized!(snapshot["proposals"], active_key: snapshot["active_key"], source_run_id: snapshot["run_id"])

--- a/test/personal_assistant_test.rb
+++ b/test/personal_assistant_test.rb
@@ -14,8 +14,11 @@ class PersonalAssistantTest
     def call = @now
   end
 
-  FakeStore = Struct.new(:agents, :starts, :stops, :fail_start, :fail_archive, keyword_init: true) do
-    def load = agents
+  FakeStore = Struct.new(:agents, :starts, :stops, :loads, :fail_start, :fail_archive, keyword_init: true) do
+    def load
+      self.loads = loads.to_i + 1
+      agents
+    end
 
     def mutate
       yield agents, []
@@ -113,6 +116,10 @@ class PersonalAssistantTest
       assert(fred_agent.send(:build_command).fetch(:command).include?("--dangerously-bypass-approvals-and-sandbox"),
              "expected FRED to use the normal Codex launch arguments")
       assert(lifecycle.open![:active_key] == first[:active_key], "expected lazy open to avoid overlap")
+      store.loads = 0
+      lifecycle.reconcile
+      assert(store.loads == 1, "expected active FRED reconciliation to load the agent store once, got #{store.loads}")
+      assert_snapshot_ttl_starts_after_bundle_completion
 
       # Keep the configured timezone on the active session. A setup change cannot
       # force an early rollover for a conversation that already started.
@@ -481,6 +488,22 @@ class PersonalAssistantTest
     config = File.join(dir, "hq.yml"); prompts = File.join(dir, "prompts.yml")
     File.write(config, "---\nprojects: []\n"); File.write(prompts, "---\n")
     HQ::Registry.new(path: config, system_prompts_path: prompts)
+  end
+
+  def self.assert_snapshot_ttl_starts_after_bundle_completion
+    calls = 0
+    service = Object.new
+    service.define_singleton_method(:personal_assistant_bundle) do
+      calls += 1
+      sleep 2.05 if calls == 1
+      { personal_assistant: { state: "active" } }
+    end
+    server = HQ::RemoteServer.new
+    server.define_singleton_method(:personal_assistant_snapshot_signature) { |_service| ["stable"] }
+
+    server.send(:personal_assistant_snapshot, service)
+    server.send(:personal_assistant_snapshot, service)
+    assert(calls == 1, "expected a slow FRED bundle to remain reusable for the full snapshot TTL")
   end
 
   def self.assert(condition, message)


### PR DESCRIPTION
## Summary
- reuse one managed-agent snapshot across each FRED lifecycle reconciliation instead of rebuilding the full agent store repeatedly
- reuse reconciled finalized-action state and start the response-cache TTL after bundle construction
- add regression coverage for single-load reconciliation and slow bundle cache reuse

## Diagnosis
Production request logs showed dormant FRED status at 0.5–0.8s and open at about 1.1s, followed by active status/actions requests at 2.8–5.7s. Acceptance lookups stayed near 4ms. The active lifecycle rebuilt the full 1.5MB, 22-agent store six times per bundle; conversation parsing was not on the pre-composer path. A separate cache bug measured its two-second TTL from before bundle construction, so a three-second build expired before the next request.

## Verification
- `bundle exec ruby test/personal_assistant_phase2_test.rb`
- `bundle exec ruby test/personal_assistant_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test` (all affected and subsequent tests passed; the default updater test needed an isolated `TYCHO_LOGS_ROOT` because the real Remote server was intentionally left running)
- Phase 3 isolated Chrome fixture: configured composer usable in 128ms, no setup/resource request on the cold path; unrelated existing progress-marker gates remain blocked with the available cached Playwright package

Fizzy: https://fizzy.startkit.tech/1/cards/186