### PR TITLE
Keep FRED recommendations in conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Tycho will be documented in this file.
 
 ## Unreleased
 
+- Keep FRED's dated recommendations visible in the conversation and submit a
+  selected recommendation as a durable, replay-safe user request with its
+  recommendation context preserved.
 - Add validated Balanced, Direct, Steady, and Upbeat FRED personalities with
   accessible Settings previews and stable per-conversation prompt composition.
 - Replace FRED's static starting surface with daily recommendation actions based

--- a/bin/capture-personal-assistant
+++ b/bin/capture-personal-assistant
@@ -167,7 +167,19 @@ Dir.mktmpdir("tycho-pa-capture") do |dir|
           const firstRecommendation = recommendationButtons.first();
           const recommendationPrompt = await firstRecommendation.getAttribute('data-pa-suggestion');
           await firstRecommendation.click();
-          await page.waitForFunction((prompt) => document.querySelector('#composer #prompt-input')?.value === prompt, recommendationPrompt, { timeout: 15000 });
+          const selectedRequest = page.locator('.message.user', { hasText: recommendationPrompt });
+          await selectedRequest.waitFor({ state: 'visible', timeout: 15000 });
+          await page.locator('.pa-recommendations').waitFor({ state: 'visible', timeout: 15000 });
+          if (await page.locator('.pa-recommendations .pa-suggestion.selected:disabled').count() !== 1) throw new Error('Selected recommendation did not become a disabled durable state');
+          const active = await (await page.request.get('http://127.0.0.1:#{PORT}/personal-assistant')).json();
+          const conversationBeforeReload = await (await page.request.get(`http://127.0.0.1:#{PORT}/agents/${encodeURIComponent(active.personal_assistant.active_key)}/conversation`)).json();
+          const recordedSelections = conversationBeforeReload.conversation.filter((block) => block.role === 'user' && block.content === recommendationPrompt && block.metadata?.personal_assistant_recommendation);
+          if (recordedSelections.length !== 1) throw new Error(`Recommendation selection was not persisted exactly once: ${JSON.stringify(recordedSelections)}`);
+          await page.reload();
+          await page.waitForFunction(() => { const boot = document.querySelector('#tycho-boot-shell'); return !boot || getComputedStyle(boot).display === 'none' || getComputedStyle(boot).visibility === 'hidden'; }, null, { timeout: 15000 });
+          await page.locator('.pa-recommendations').waitFor({ state: 'visible', timeout: 15000 });
+          await page.locator('.message.user', { hasText: recommendationPrompt }).waitFor({ state: 'visible', timeout: 15000 });
+          if (await page.locator('.message.user', { hasText: recommendationPrompt }).count() !== 1) throw new Error('Recommendation request duplicated during replay');
           if ((await page.locator('.personal-assistant-page').innerText()).includes('What FRED can do')) throw new Error('FRED retained its static capability list');
           if (await page.locator('.pa-current-work, #pa-project-starter-form').count()) throw new Error('FRED retained a removed starting surface');
           if (#{(ENV["TYCHO_PERSONAL_ASSISTANT_RECOMMENDATIONS_ONLY"] == "1").to_json}) {
@@ -297,6 +309,7 @@ Dir.mktmpdir("tycho-pa-capture") do |dir|
       capture.call("fred-unconfigured-settings-mobile.png", "iPhone 13", "#settings-personal-assistant", "Set up FRED", route: "settings")
     end
     verify_initiate.call
+    exit if ENV["TYCHO_PERSONAL_ASSISTANT_RECOMMENDATIONS_ONLY"] == "1"
     exit if ENV["TYCHO_PERSONAL_ASSISTANT_VERIFY_ONLY"] == "1"
     verify_zero_project_entry.call
     capture.call("fred-compact-settings-menu-desktop.png", "Desktop Chrome", ".personal-assistant-page", "Recommendations", open_menu: true)

--- a/docs/PERSONAL_ASSISTANT.md
+++ b/docs/PERSONAL_ASSISTANT.md
@@ -14,7 +14,9 @@ Personality presets change stable voice and interaction principles: Balanced is 
 
 ## Recommendations
 
-An empty daily conversation starts with recommendation buttons instead of a current-work dashboard or a static capability list. Selecting a recommendation only fills the normal composer; it does not send a prompt or approve a mutation.
+Each daily conversation starts with a FRED recommendation message instead of a current-work dashboard or a static capability list. The message remains at the head of the conversation after chat content loads. Selecting a recommendation immediately creates a normal user request and uses the same durable acceptance, queueing, run, and recovery path as an equivalent typed prompt; it does not approve a mutation.
+
+Tycho records the recommendation date, source, title, prompt, and stable within-day identity on that user message. The selected action stays intelligible after refresh or replay, and its button becomes a disabled Selected state. Interrupted submissions recover from the locally persisted acceptance record with the same client request ID, so checking or replaying acceptance cannot append the request twice.
 
 During daily rollover, the existing summary turn produces three to five bounded recommendation prompts for the next local date. The server-side FRED agent uses its installed skills and local read-only resources to inspect available daily-journal signals and new or updated Miki knowledge, then combines them with unfinished work, useful cleanup, and FRED's documented Tycho capabilities. Unavailable sources are treated as absent rather than invented. Tycho persists one set per date in the Personal Assistant lifecycle state. A same-day restart preserves that set. First use, stale state, and failed summaries show explicit starter or fallback recommendations instead of an empty or misleading generated state.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -101,7 +101,11 @@ Key references:
 ## Current Focus
 
 **FRED experience**: Keep the Personal Assistant compact and task-focused.
-An empty daily conversation now shows only dated recommendation buttons. The
+Each daily conversation begins with a dated recommendation message that remains
+visible after chat content loads. Choosing an item submits its exact prompt as a
+normal durable user request, persists the recommendation context on the message,
+and uses the existing acceptance ID for queueing, replay, and interrupted-delivery
+recovery without duplicate messages. The
 existing rollover summary produces one bounded set for the next local date from
 unfinished work, cleanup, daily journals, available Miki changes, Tycho
 capabilities, and an optional server-side external-events prompt. First use and

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -4443,6 +4443,8 @@ module HQ
       metadata = {
         "personal_assistant_client_request_id" => id
       }
+      recommendation = personal_assistant_recommendation_metadata!(attrs, prompt:)
+      metadata["personal_assistant_recommendation"] = recommendation if recommendation
       event_id = "personal-assistant-message:#{id}"
       if kind == "inquiry_answer"
         target = personal_assistant_target_for_context!(context)
@@ -4695,8 +4697,37 @@ module HQ
         "feedback" => feedback.to_s,
         "start" => truthy?(attrs["start"]),
         "pull_request_contexts" => attrs["pull_request_contexts"],
-        "attachments" => personal_assistant_attachment_fingerprints(attrs["attachments"])
+        "attachments" => personal_assistant_attachment_fingerprints(attrs["attachments"]),
+        "recommendation" => personal_assistant_recommendation_metadata!(attrs, prompt:)
       }.delete_if { |_key, value| value.nil? }
+    end
+
+    def personal_assistant_recommendation_metadata!(attrs, prompt:)
+      requested = attrs["recommendation"]
+      return nil if requested.nil?
+      unless requested.is_a?(Hash) && requested["prompt"].to_s.strip == prompt.to_s.strip
+        raise Error.new("FRED recommendation selection does not match the submitted prompt", status: 409,
+                        details: { code: "recommendation_mismatch" })
+      end
+
+      status = @personal_assistant.status
+      recommendations = status[:recommendations] || status["recommendations"] || {}
+      items = Array(recommendations["items"] || recommendations[:items])
+      index = items.index { |item| (item["prompt"] || item[:prompt]).to_s.strip == prompt.to_s.strip }
+      unless index
+        raise Error.new("FRED recommendation changed; refresh and choose it again", status: 409,
+                        details: { code: "recommendation_stale" })
+      end
+
+      entry = items[index]
+      for_date = (recommendations["for_date"] || recommendations[:for_date]).to_s
+      {
+        "id" => "#{for_date.empty? ? "undated" : for_date}:#{index}",
+        "for_date" => for_date[0, 40],
+        "source" => (recommendations["source"] || recommendations[:source]).to_s[0, 40],
+        "title" => (entry["title"] || entry[:title] || prompt).to_s.strip[0, 96],
+        "prompt" => prompt.to_s.strip[0, 240]
+      }
     end
 
     def personal_assistant_attachment_fingerprints(value)

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -5749,14 +5749,18 @@ select {
 .fred-avatar { display: inline-block; flex: 0 0 auto; width: 32px; height: 32px; border: 1px solid color-mix(in srgb, var(--accent) 52%, var(--border)); border-radius: 50%; object-fit: cover; object-position: center; background: var(--panel-soft); }
 .message-role .fred-avatar { width: 22px; height: 22px; }
 .pa-status-dot { width: 9px; height: 9px; border-radius: 999px; background: var(--success); }
-.pa-welcome { display: grid; gap: 16px; width: calc(100% - 28px); max-width: 100%; margin: 0 28px 0 0; border: 1px solid var(--border); border-radius: 12px; padding: 16px; background: var(--panel); }
-.pa-welcome-heading { display: grid; gap: 4px; }
-.pa-welcome h2 { margin: 0; font-size: 18px; }
-.pa-welcome-heading p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.45; }
+.pa-recommendations { gap: 8px; border-color: color-mix(in srgb, var(--accent) 36%, var(--border)); background: color-mix(in srgb, var(--panel) 96%, var(--accent)); }
+.pa-recommendations-content { display: grid; gap: 14px; white-space: normal; }
+.pa-recommendations-heading { display: grid; gap: 4px; }
+.pa-recommendations h2 { margin: 0; font-size: 17px; }
+.pa-recommendations-heading p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.45; }
 .pa-suggestions { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
 .pa-suggestions > li { min-width: 0; }
-.pa-suggestion { display: grid; width: 100%; min-height: var(--touch-target); border: 1px solid color-mix(in srgb, var(--accent) 54%, var(--border)); border-radius: 10px; padding: 11px 12px; background: transparent; color: var(--text); font: inherit; text-align: left; cursor: pointer; }
+.pa-suggestion { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px; width: 100%; min-height: var(--touch-target); border: 1px solid color-mix(in srgb, var(--accent) 54%, var(--border)); border-radius: 10px; padding: 11px 12px; background: transparent; color: var(--text); font: inherit; text-align: left; cursor: pointer; }
 .pa-suggestion:hover, .pa-suggestion:focus-visible { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 9%, var(--panel-soft)); }
+.pa-suggestion.selected, .pa-suggestion:disabled { cursor: default; }
+.pa-suggestion.selected { border-color: color-mix(in srgb, var(--success) 58%, var(--border)); background: color-mix(in srgb, var(--success) 8%, transparent); opacity: 1; }
+.pa-recommendation-state { color: var(--success); font-size: 12px; font-weight: 750; }
 .pa-starter-copy { display: grid; gap: 3px; min-width: 0; }
 .pa-starter-copy strong { color: var(--text); font-size: 14px; }
 .pa-starter-copy span { color: var(--muted); font-size: 13px; line-height: 1.4; }

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2388,7 +2388,7 @@ function personalAssistantSubmissionForQueueEntry(entryId, response = {}) {
   )) || null;
 }
 
-function rememberPersonalAssistantSubmission({ clientRequestId, prompt, agentKey, context, draftRevision }) {
+function rememberPersonalAssistantSubmission({ clientRequestId, prompt, agentKey, context, draftRevision, recommendation = null }) {
   loadPersonalAssistantSubmissionStates();
   const now = new Date().toISOString();
   const record = {
@@ -2400,6 +2400,7 @@ function rememberPersonalAssistantSubmission({ clientRequestId, prompt, agentKey
     generation: context?.generation,
     server_key: context?.server_key || personalAssistantServerKey(),
     draft_revision: Number(draftRevision || 0),
+    ...(recommendation ? { recommendation } : {}),
     state: "sending",
     acceptance_state: "pending",
     message_recorded: false,
@@ -6134,7 +6135,45 @@ function renderPersonalAssistantProposal(proposal) {
   </article>`;
 }
 
-function renderPersonalAssistantRecommendations(item) {
+function personalAssistantRecommendationContext(item, entry, index) {
+  const recommendations = item?.recommendations || {};
+  const prompt = String(entry?.prompt || "").trim();
+  return {
+    id: `${String(recommendations.for_date || item?.active_date || "undated")}:${index}`,
+    for_date: String(recommendations.for_date || item?.active_date || ""),
+    source: String(recommendations.source || "starter"),
+    title: String(entry?.title || prompt).trim(),
+    prompt,
+  };
+}
+
+function personalAssistantSelectedRecommendationIds(blocks) {
+  return new Set((Array.isArray(blocks) ? blocks : []).filter((block) => (
+    block?.kind === "message" && block.role === "user" && block.metadata?.personal_assistant_recommendation
+  )).map((block) => String(block.metadata.personal_assistant_recommendation.id || "")).filter(Boolean));
+}
+
+function submitPersonalAssistantRecommendation(suggestion) {
+  if (!suggestion?.dataset?.paRecommendation || suggestion.disabled || suggestion.dataset.submitting === "true") return false;
+  const input = els.view.querySelector("#composer #prompt-input");
+  const form = input?.closest("form");
+  const submitter = form?.querySelector('button[type="submit"]');
+  if (!input || !form || !submitter || submitter.disabled) {
+    input?.focus();
+    return false;
+  }
+
+  suggestion.dataset.submitting = "true";
+  suggestion.disabled = true;
+  suggestion.setAttribute("aria-busy", "true");
+  input.value = suggestion.dataset.paSuggestion;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  form.dataset.personalAssistantRecommendation = suggestion.dataset.paRecommendation;
+  form.requestSubmit(submitter);
+  return true;
+}
+
+function renderPersonalAssistantRecommendations(item, blocks = [], options = {}) {
   const recommendations = item?.recommendations || {};
   const items = Array.isArray(recommendations.items)
     ? recommendations.items.filter((entry) => entry && String(entry.prompt || "").trim())
@@ -6147,19 +6186,22 @@ function renderPersonalAssistantRecommendations(item) {
       : source === "stale"
         ? "Today’s handoff recommendations are unavailable, so FRED added safe starter prompts."
       : "Daily recommendations will appear after the first handoff. Start with one of these.";
-  const buttons = items.map((entry) => {
-    const prompt = String(entry.prompt || "").trim();
-    const title = String(entry.title || prompt).trim();
-    return `<li><button class="pa-suggestion ui-button" type="button" aria-label="${escapeAttr(prompt)}" title="${escapeAttr(prompt)}" data-pa-suggestion="${escapeAttr(prompt)}"><span class="pa-starter-copy"><strong>${escapeHtml(title)}</strong></span></button></li>`;
+  const selectedIds = personalAssistantSelectedRecommendationIds(blocks);
+  const buttons = items.map((entry, index) => {
+    const recommendation = personalAssistantRecommendationContext(item, entry, index);
+    const selected = selectedIds.has(recommendation.id);
+    const disabled = selected || options.disabled === true;
+    const label = selected
+      ? `Selected recommendation: ${recommendation.prompt}`
+      : options.disabled ? `Recommendation unavailable while FRED is ${item?.state || "unavailable"}: ${recommendation.prompt}`
+        : `Choose recommendation: ${recommendation.prompt}`;
+    return `<li><button class="pa-suggestion ui-button${selected ? " selected" : ""}" type="button" aria-label="${escapeAttr(label)}" title="${escapeAttr(recommendation.prompt)}" data-pa-suggestion="${escapeAttr(recommendation.prompt)}" data-pa-recommendation="${escapeAttr(JSON.stringify(recommendation))}" ${disabled ? "disabled aria-disabled=\"true\"" : ""}><span class="pa-starter-copy"><strong>${escapeHtml(recommendation.title)}</strong><span>${escapeHtml(recommendation.prompt)}</span></span>${selected ? '<span class="pa-recommendation-state">Selected</span>' : ""}</button></li>`;
   }).join("");
   const body = buttons
     ? `<ul class="pa-suggestions" aria-label="FRED recommendations">${buttons}</ul>`
     : emptyState("No recommendations yet", "You can still ask FRED anything about this Tycho server.", { className: "pa-recommendations-empty" });
-  return `<article class="pa-welcome pa-recommendations" data-recommendation-source="${escapeAttr(source)}"><div class="pa-welcome-heading"><h2>Recommendations</h2><p>${escapeHtml(guidance)}</p></div>${body}</article>`;
-}
-
-function personalAssistantHasRealConversation(blocks) {
-  return blocks.some((block) => block?.kind === "message" && ["user", "assistant"].includes(block.role));
+  const version = escapeAttr(document.documentElement.dataset.assetVersion || "");
+  return `<article class="message assistant pa-recommendations" data-recommendation-source="${escapeAttr(source)}"><div class="message-header"><div class="message-role"><img class="fred-avatar" src="/fred-avatar.png?v=${version}" alt="FRED"><span>FRED</span></div></div><div class="message-content pa-recommendations-content"><div class="pa-recommendations-heading"><h2>Recommendations</h2><p>${escapeHtml(guidance)}</p></div>${body}</div></article>`;
 }
 
 function personalAssistantConversationEventIdentity(block) {
@@ -6502,11 +6544,13 @@ function renderPersonalAssistant() {
   const blocks = agent ? (state.conversations[agent.key]?.blocks || []) : [];
   const allBlocks = agent ? conversationBlocksForAgent(agent, blocks) : [];
   const blocked = ["closing", "summarizing", "archiving"].includes(item.state);
-  const starter = agent && item.state === "active" && !personalAssistantHasRealConversation(allBlocks);
   const renderedProposals = new Set();
   const continuity = item.configured ? renderPersonalAssistantContinuity(item, proposals) : "";
+  const recommendations = agent && item.configured
+    ? renderPersonalAssistantRecommendations(item, allBlocks, { disabled: item.state !== "active" })
+    : "";
   const thread = agent
-    ? `${continuity}${starter ? renderPersonalAssistantRecommendations(item) : renderAgentConversationView(agent, blocks, { floatingActions: false, loading: conversationLoading(agent.key), personalAssistant: true, personalAssistantProposals: proposals, renderedPersonalAssistantProposals: renderedProposals })}${renderPersonalAssistantUnattachedProposals(proposals, renderedProposals)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}${blocked ? `<p class="pa-inline-notice">${escapeHtml({ closing: "Finishing today’s conversation. Your draft is kept for the next conversation.", summarizing: "Saving today’s continuity. Your draft is kept for the next conversation.", archiving: "Closing today’s conversation. Your draft is kept for the next conversation." }[item.state] || "FRED is unavailable right now.")}</p>` : ""}${renderPersonalAssistantSubmissionRecovery()}`
+    ? `${continuity}${renderAgentConversationView(agent, blocks, { floatingActions: false, loading: conversationLoading(agent.key), leadingHtml: recommendations, personalAssistant: true, personalAssistantProposals: proposals, renderedPersonalAssistantProposals: renderedProposals })}${renderPersonalAssistantUnattachedProposals(proposals, renderedProposals)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}${blocked ? `<p class="pa-inline-notice">${escapeHtml({ closing: "Finishing today’s conversation. Your draft is kept for the next conversation.", summarizing: "Saving today’s continuity. Your draft is kept for the next conversation.", archiving: "Closing today’s conversation. Your draft is kept for the next conversation." }[item.state] || "FRED is unavailable right now.")}</p>` : ""}${renderPersonalAssistantSubmissionRecovery()}`
     : `${item.configured ? `${continuity}${tychoLoadingState("Loading FRED", { className: "pa-loading-state", body: "Fetching today’s session." })}` : renderPersonalAssistantSetup(item)}${item.error ? feedbackMessage("Sending is paused", item.error, { intent: "danger" }) : ""}${renderPersonalAssistantSubmissionRecovery()}`;
   const composerPlacement = agent && item.state === "active"
     ? renderAgentComposerPlacement(agent, [], {})
@@ -7744,7 +7788,8 @@ function renderAgentConversationView(agent, blocks, options = {}) {
     ) : ""}
     <div class="message-list">
       ${renderAgentRelationshipContext(agent)}
-      ${conversationBlocks.length ? renderConversationBlocks(conversationBlocks, { ...options, agent }) : emptyHtml}
+      ${options.leadingHtml || ""}
+      ${conversationBlocks.length ? renderConversationBlocks(conversationBlocks, { ...options, agent }) : (options.leadingHtml ? "" : emptyHtml)}
     </div>
     <div data-conversation-recent aria-hidden="true"></div>
     ${options.floatingActions === false ? "" : renderAgentFloatingActions(agent, { recent: true })}
@@ -7923,9 +7968,33 @@ function tychoLoadingState(label, options = {}) {
 function conversationBlocksForAgent(agent, blocks) {
   const pending = (state.pendingConversationMessages[agent?.key] || []).filter((block) =>
     !REMOTE_HELPERS.pendingConversationBlockAcknowledged(block, blocks));
-  if (!pending.length) return blocks;
+  const recovered = personalAssistantAgent(agent) ? personalAssistantRecoveredSubmissionBlocks(agent, blocks.concat(pending)) : [];
+  if (!pending.length && !recovered.length) return blocks;
 
-  return blocks.concat(pending);
+  return blocks.concat(pending, recovered);
+}
+
+function personalAssistantRecoveredSubmissionBlocks(agent, blocks) {
+  const session = personalAssistantSessionContext();
+  if (!session || !agent?.key) return [];
+  return personalAssistantSubmissionEntries({ serverKey: session.server_key, session })
+    .filter((record) => record.agent_key === agent.key && record.prompt)
+    .filter((record) => personalAssistantSubmissionNeedsRetention(record))
+    .filter((record) => !blocks.some((block) => personalAssistantBlockMatchesSubmission(block, record)))
+    .map((record) => ({
+      id: `recovered-message-${record.client_request_id}`,
+      kind: "message",
+      role: "user",
+      content: record.prompt,
+      created_at: record.submitted_at || record.updated_at,
+      client_request_id: record.client_request_id,
+      send_status: record.state,
+      send_error: record.error || "",
+      metadata: {
+        personal_assistant_client_request_id: record.client_request_id,
+        ...(record.recommendation ? { personal_assistant_recommendation: record.recommendation } : {}),
+      },
+    }));
 }
 
 function pendingConversationUpdate(agentKey) {
@@ -11028,9 +11097,15 @@ function personalAssistantMessageSendState(block, options = {}) {
 }
 
 function personalAssistantMessageIdentity(block, options = {}) {
-  if (!options.personalAssistant || block?.kind !== "message" || block.role !== "assistant") return "";
-  const version = escapeAttr(document.documentElement.dataset.assetVersion || "");
-  return `<img class="fred-avatar" src="/fred-avatar.png?v=${version}" alt="FRED"><span>FRED</span>`;
+  if (!options.personalAssistant || block?.kind !== "message") return "";
+  if (block.role === "assistant") {
+    const version = escapeAttr(document.documentElement.dataset.assetVersion || "");
+    return `<img class="fred-avatar" src="/fred-avatar.png?v=${version}" alt="FRED"><span>FRED</span>`;
+  }
+  if (block.role === "user" && block.metadata?.personal_assistant_recommendation) {
+    return `<span>You · selected recommendation</span>${blockTimestamp(block) ? `<time class="message-time" datetime="${escapeAttr(blockTimestamp(block))}">${escapeHtml(relativeTimeShort(blockTimestamp(block)))}</time>` : ""}`;
+  }
+  return "";
 }
 
 function blockTimestamp(block) {
@@ -11567,7 +11642,7 @@ function renderPendingAttachment(agentKey, attachment) {
   `;
 }
 
-function pendingPromptMessageBlock(agentKey, prompt, attachments = [], pullRequestContexts = [], clientRequestId = "") {
+function pendingPromptMessageBlock(agentKey, prompt, attachments = [], pullRequestContexts = [], clientRequestId = "", messageMetadata = {}) {
   const metadataAttachments = attachments.map((attachment) => ({
     title: attachment.filename,
     target: attachment.filename,
@@ -11585,6 +11660,7 @@ function pendingPromptMessageBlock(agentKey, prompt, attachments = [], pullReque
     pending: true,
     ...(clientRequestId ? { client_request_id: clientRequestId, send_status: "sending" } : {}),
     metadata: {
+      ...messageMetadata,
       ...(clientRequestId ? { personal_assistant_client_request_id: clientRequestId } : {}),
       ...(metadataAttachments.length ? { attachments: metadataAttachments } : {}),
       ...(pullRequestContexts.length ? { pull_request_contexts: pullRequestContexts.map((context) => ({
@@ -11651,6 +11727,7 @@ async function submitComposerPrompt(options) {
     draftRevision,
     routeHashAtSubmit,
     personalAssistantSubmission,
+    recommendation,
   } = options;
   const adapter = endpointAdapter || personalAssistantEndpointAdapter(key, { personalAssistant: personalAssistant === true });
   const isPersonalAssistant = personalAssistant === undefined ? adapter.personalAssistant : personalAssistant === true;
@@ -11697,6 +11774,7 @@ async function submitComposerPrompt(options) {
       start: true,
       attachments,
       pull_request_contexts: pullRequestContexts,
+      ...(recommendation ? { recommendation } : {}),
       ...(retireInquiryId ? { retire_inquiry_id: retireInquiryId } : {}),
     }, isPersonalAssistant ? submissionId : (optimisticQueueEntry?.id || "")));
     const submissionRecord = isPersonalAssistant ? applyPersonalAssistantResponse(response) : null;
@@ -16488,7 +16566,12 @@ function handleViewClick(event) {
   const suggestion = event.target.closest("[data-pa-suggestion]");
   if (suggestion) {
     const input = els.view.querySelector("#composer #prompt-input");
-    if (input) { input.value = suggestion.dataset.paSuggestion; input.focus(); input.dispatchEvent(new Event("input", { bubbles: true })); }
+    if (suggestion.dataset.paRecommendation) submitPersonalAssistantRecommendation(suggestion);
+    else if (input) {
+      input.value = suggestion.dataset.paSuggestion;
+      input.focus();
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    }
     return;
   }
   const checkPersonalAssistantSubmission = event.target.closest("[data-check-pa-submission]");
@@ -17891,6 +17974,15 @@ els.view.addEventListener("submit", (event) => {
   if (event.target.id === "composer") {
     const form = event.target;
     const button = event.submitter;
+    let recommendation = null;
+    try {
+      recommendation = form.dataset.personalAssistantRecommendation
+        ? JSON.parse(form.dataset.personalAssistantRecommendation)
+        : null;
+    } catch (_error) {
+      recommendation = null;
+    }
+    delete form.dataset.personalAssistantRecommendation;
     const key = button?.dataset.agentKey || form.dataset.agentKey;
     const promptValue = form.querySelector("#prompt-input")?.value.trim() || "";
     const pendingAttachments = pendingAttachmentsFor(key).slice();
@@ -17926,11 +18018,14 @@ els.view.addEventListener("submit", (event) => {
         agentKey: key,
         context: endpointAdapter.context,
         draftRevision,
+        recommendation,
       })
       : null;
     const pendingMessageId = queueing ? "" : addPendingConversationMessage(
       key,
-      pendingPromptMessageBlock(key, prompt, pendingAttachments, submittedPullRequestContexts, clientRequestId)
+      pendingPromptMessageBlock(key, prompt, pendingAttachments, submittedPullRequestContexts, clientRequestId, recommendation ? {
+        personal_assistant_recommendation: recommendation,
+      } : {})
     );
     if (queueing) {
       state.renderedViewHtml = "";
@@ -17956,6 +18051,7 @@ els.view.addEventListener("submit", (event) => {
       draftRevision,
       routeHashAtSubmit,
       personalAssistantSubmission,
+      recommendation,
     });
     return;
   }

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -653,6 +653,42 @@ module RemoteServerTest
       assert(fred.attachments.count { |item| item["source"] == "remote_upload" } == 1,
              "expected duplicate FRED messages to import one attachment")
 
+      recommendation = session.dig(:recommendations, "items", 0)
+      recommendation_request = context.merge(
+        "client_request_id" => "client-recommendation-message",
+        "prompt" => recommendation.fetch("prompt"),
+        "recommendation" => recommendation.merge(
+          "id" => "#{session.dig(:recommendations, "for_date")}:0",
+          "for_date" => session.dig(:recommendations, "for_date"),
+          "source" => session.dig(:recommendations, "source")
+        ),
+        "start" => false
+      )
+      selected = post_message.call(recommendation_request)
+      selected_replay = post_message.call(recommendation_request)
+      assert(selected[:accepted] && selected_replay[:replayed],
+             "expected recommendation selection to use durable message acceptance and replay")
+      recommendation_events = HQ::AgentMemory.new(service.send(:find_agent!, session[:active_key])).events.select do |event|
+        event["type"] == "user_message" &&
+          event.dig("metadata", "personal_assistant_client_request_id") == "client-recommendation-message"
+      end
+      recorded_recommendation = recommendation_events.first&.dig("metadata", "personal_assistant_recommendation")
+      assert(recommendation_events.length == 1 &&
+             recorded_recommendation&.fetch("prompt") == recommendation.fetch("prompt") &&
+             recorded_recommendation&.fetch("id") == "#{session.dig(:recommendations, "for_date")}:0",
+             "expected one replayable user message with authoritative recommendation context")
+
+      begin
+        post_message.call(recommendation_request.merge(
+          "client_request_id" => "client-mismatched-recommendation",
+          "recommendation" => recommendation.merge("prompt" => "A different prompt")
+        ))
+        raise "expected mismatched recommendation rejection"
+      rescue HQ::RemoteServer::Error => e
+        assert(e.status == 409 && e.details[:code] == "recommendation_mismatch",
+               "expected recommendation wording mismatch to fail before persistence")
+      end
+
       begin
         post_message.call(first_request.merge("prompt" => "A different payload."))
         raise "expected client request payload mismatch"
@@ -5691,7 +5727,8 @@ module RemoteServerTest
            "expected the mobile Quick Agent form to fill and scroll within the viewport")
     assert(css[:body].include?("--touch-target: 44px") && css[:body].include?("--control-height: 44px"),
            "expected audited Remote UI controls to share accessible sizing tokens")
-    assert(css[:body].include?(".pa-suggestion { display: grid; width: 100%; min-height: var(--touch-target);"),
+    assert(css[:body].include?(".pa-suggestion { display: grid;") &&
+           css[:body].include?("width: 100%; min-height: var(--touch-target);"),
            "expected FRED first-run list actions to meet the shared 44px touch target")
     assert(css[:body].include?(".top-actions .search-box"),
            "expected Agents tab search to flex inside the action row")
@@ -7525,7 +7562,7 @@ module RemoteServerTest
            "expected first-use FRED flow not to silently submit fixed settings")
     assert(js[:body].include?("personalAssistant ? \"/personal-assistant/messages\""),
            "expected FRED messages to use the dedicated Personal Assistant API")
-    fred_recommendations = js[:body].split("function renderPersonalAssistantRecommendations", 2).last.split("function personalAssistantHasRealConversation", 2).first
+    fred_recommendations = js[:body].split("function renderPersonalAssistantRecommendations", 2).last.split("function personalAssistantConversationEventIdentity", 2).first
     assert(fred_recommendations.include?('<h2>Recommendations</h2>') &&
            fred_recommendations.include?('class="pa-suggestions" aria-label="FRED recommendations"') &&
            fred_recommendations.include?('data-pa-suggestion=') &&

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -35,7 +35,7 @@ module RemoteUIAssetSnapshotTest
       'Technical details',
       'data-confirm-pa-proposal=',
       'data-reject-pa-proposal=',
-      'function renderPersonalAssistantRecommendations(item)',
+      'function renderPersonalAssistantRecommendations(item, blocks = [], options = {})',
       'pendingPersonalAssistantProposalIds: new Set()',
       'state.pendingPersonalAssistantProposalIds.has(id)',
       'function renderConversationWorkspace({',
@@ -71,14 +71,17 @@ module RemoteUIAssetSnapshotTest
     javascript = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.js"))
     css = File.read(File.join(ROOT, "lib", "hq", "remote_ui", "assets", "app.css"))
     required_javascript = [
-      "function personalAssistantHasRealConversation(blocks)",
-      'block?.kind === "message" && ["user", "assistant"].includes(block.role)',
-      "const starter = agent && item.state === \"active\" && !personalAssistantHasRealConversation(allBlocks);",
-      "${starter ? renderPersonalAssistantRecommendations(",
+      "function personalAssistantRecommendationContext(item, entry, index)",
+      "function submitPersonalAssistantRecommendation(suggestion)",
+      'class="message assistant pa-recommendations"',
+      "renderPersonalAssistantRecommendations(item, allBlocks",
+      "leadingHtml: recommendations",
+      "form.requestSubmit(submitter)",
       'querySelector("#composer #prompt-input")',
       '<h2>Recommendations</h2>',
       'aria-label="FRED recommendations"',
       'data-recommendation-source=',
+      'personal_assistant_recommendation',
       'name="external_events_prompt"'
     ]
     missing = required_javascript.reject { |fragment| javascript.include?(fragment) }

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -55,7 +55,8 @@ module RemoteUIPersonalAssistantBehaviorTest
         PERSONAL_ASSISTANT_ANNOUNCEMENT_LIMIT: 128,
         PERSONAL_ASSISTANT_MAX_FAILURE_COUNT: 2,
         PERSONAL_ASSISTANT_POLL_INTERVALS: { activeMs: 1500, idleMs: 12000, hiddenMs: 30000 },
-        document: { hidden: false },
+        document: { hidden: false, documentElement: { dataset: { assetVersion: "test" } } },
+        Event: class Event { constructor(type, options = {}) { this.type = type; this.bubbles = options.bubbles; } },
         state: {
           personalAssistant: { configured: true },
           personalAssistantAnnouncementValues: new Map(),
@@ -83,6 +84,11 @@ module RemoteUIPersonalAssistantBehaviorTest
         "personalAssistantShellRefreshNeeded",
         "personalAssistantConversationEventIdentity",
         "personalAssistantVisibleConversationBlocks",
+        "personalAssistantRecommendationContext",
+        "personalAssistantSelectedRecommendationIds",
+        "submitPersonalAssistantRecommendation",
+        "renderPersonalAssistantRecommendations",
+        "personalAssistantRecoveredSubmissionBlocks",
         "personalAssistantPollDelay",
         "notePersonalAssistantRefreshFailure",
         "personalAssistantStatusRequestIsCurrent",
@@ -119,6 +125,74 @@ module RemoteUIPersonalAssistantBehaviorTest
         { kind: "message", role: "assistant", metadata: { event_id: "event-1" }, content: "Same" },
       ]);
       assert(duplicateEvent.length === 1, "duplicate event IDs were not deduplicated");
+
+      context.escapeHtml = (value) => String(value);
+      context.emptyState = () => "empty";
+      const recommendationItem = {
+        active_date: "2026-09-11",
+        state: "active",
+        recommendations: {
+          for_date: "2026-09-11",
+          source: "daily_handoff",
+          items: [{ title: "Continue review", prompt: "Continue the release review from yesterday." }],
+        },
+      };
+      const initialRecommendations = context.renderPersonalAssistantRecommendations(recommendationItem, []);
+      assert(initialRecommendations.includes('class="message assistant pa-recommendations"') &&
+        initialRecommendations.includes("Continue the release review from yesterday.") &&
+        initialRecommendations.includes('data-pa-recommendation='),
+      "initial recommendations were not rendered as an intelligible FRED conversation block");
+      const selectedBlock = {
+        kind: "message",
+        role: "user",
+        metadata: { personal_assistant_recommendation: { id: "2026-09-11:0" } },
+      };
+      const loadedRecommendations = context.renderPersonalAssistantRecommendations(recommendationItem, [selectedBlock]);
+      assert(loadedRecommendations.includes("Selected") && loadedRecommendations.includes("disabled"),
+             "loaded conversation did not retain and mark its selected recommendation");
+
+      let recommendationSubmits = 0;
+      const submitter = { disabled: false };
+      const form = {
+        dataset: {},
+        querySelector: () => submitter,
+        requestSubmit: (button) => { if (button === submitter) recommendationSubmits += 1; },
+      };
+      const input = {
+        value: "",
+        closest: () => form,
+        dispatchEvent: () => {},
+        focus: () => {},
+      };
+      context.els.view = { querySelector: () => input, querySelectorAll: () => [] };
+      const suggestion = {
+        dataset: {
+          paSuggestion: "Continue the release review from yesterday.",
+          paRecommendation: JSON.stringify(context.personalAssistantRecommendationContext(recommendationItem, recommendationItem.recommendations.items[0], 0)),
+        },
+        disabled: false,
+        setAttribute: () => {},
+      };
+      assert(context.submitPersonalAssistantRecommendation(suggestion) === true && recommendationSubmits === 1 &&
+        input.value === "Continue the release review from yesterday." && form.dataset.personalAssistantRecommendation,
+      "recommendation selection did not enter the normal composer submission path");
+      assert(context.submitPersonalAssistantRecommendation(suggestion) === false && recommendationSubmits === 1,
+             "repeated recommendation activation created a duplicate submission");
+
+      context.personalAssistantSubmissionEntries = () => [{
+        client_request_id: "client-recovered-recommendation",
+        agent_key: "fred",
+        prompt: "Continue the release review from yesterday.",
+        state: "unknown",
+        submitted_at: "2026-09-11T00:00:00Z",
+        recommendation: { id: "2026-09-11:0", prompt: "Continue the release review from yesterday." },
+      }];
+      context.personalAssistantSubmissionNeedsRetention = () => true;
+      context.personalAssistantBlockMatchesSubmission = (_block, record) => record.client_request_id === "already-recorded";
+      const recovered = context.personalAssistantRecoveredSubmissionBlocks({ key: "fred" }, []);
+      assert(recovered.length === 1 && recovered[0].content === "Continue the release review from yesterday." &&
+        recovered[0].metadata.personal_assistant_recommendation.id === "2026-09-11:0",
+      "reload recovery lost the selected recommendation request block");
 
       let mounted = [];
       context.els.view = { querySelectorAll: () => mounted };


### PR DESCRIPTION
Resolves [Fizzy #188](https://fizzy.startkit.tech/1/cards/188).

## Behavior

- Keeps the dated recommendation set as a FRED message at the head of the conversation after chat content loads.
- Submits a selected recommendation immediately through the normal durable FRED acceptance and queue path, with its exact wording and authoritative date/source/title metadata on the user request.
- Restores unresolved selected requests from persisted acceptance state, marks chosen recommendations as selected, and prevents duplicate activation or replay.
- Preserves native button keyboard behavior, explicit busy/disabled states, running-agent queueing, and mobile dock layout.

## Verification

- `TYCHO_HOME=/tmp/tycho-card-188-full-test bin/test`
- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/remote_ui_personal_assistant_behavior_test.rb`
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb`
- `TYCHO_PERSONAL_ASSISTANT_RECOMMENDATIONS_ONLY=1 TYCHO_PERSONAL_ASSISTANT_CAPTURE_OUTPUT=/tmp/tycho-card-188-evidence bin/capture-personal-assistant` (Chromium, 1280x900 and 390x844)