### PR TITLE
Count answer-required FRED sessions as unread

### DIFF
--- a/lib/hq/domain/agent_activity_snapshot.rb
+++ b/lib/hq/domain/agent_activity_snapshot.rb
@@ -15,12 +15,14 @@ module HQ
       @agents = {}
     end
 
-    def replace!(agents)
+    def replace!(agents, extra_unread_count: 0)
       replacement = Array(agents).to_h { |agent| [agent.key, activity_payload(agent)] }
+      extra_unread = [extra_unread_count.to_i, 0].max
       @mutex.synchronize do
-        return false if @ready && @agents == replacement
+        return false if @ready && @agents == replacement && @extra_unread_count == extra_unread
 
         @agents = replacement
+        @extra_unread_count = extra_unread
         changed!
       end
       true
@@ -55,7 +57,7 @@ module HQ
           revision: @revision,
           generated_at: @generated_at,
           ready: @ready,
-          unread_count: agents.count { |agent| agent[:unread] },
+          unread_count: agents.count { |agent| agent[:unread] } + @extra_unread_count.to_i,
           agents: agents
         }
       end

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -697,7 +697,9 @@ module HQ
       activity = {
         schema_version: AgentActivitySnapshot::SCHEMA_VERSION,
         generated_at: Time.now.utc.iso8601,
-        unread_count: servers.sum { |server| server[:agents].count { |agent| agent[:unread] } },
+        unread_count: servers.sum do |server|
+          server[:local] ? local[:unread_count].to_i : server[:agents].count { |agent| agent[:unread] }
+        end,
         servers: servers
       }
       activity[:revision] = Digest::SHA256.hexdigest(JSON.generate(activity.except(:generated_at)))
@@ -3788,9 +3790,8 @@ module HQ
 
     def dispatch_agent_push_notifications!
       agents, events = load_agents_with_events
-      visible = visible_agents(agents)
       notification_candidates = notification_agents(agents)
-      @agent_activity_snapshot.replace!(visible)
+      replace_agent_activity_snapshot!(agents)
       notification_keys = notification_candidates.map(&:key)
       dispatch_agent_push_events(events.select { |event| notification_keys.include?(event.agent_key) }, agents: notification_candidates)
     end
@@ -4801,6 +4802,15 @@ module HQ
       []
     end
 
+    # FRED remains outside the generic agent catalog, but an active unread FRED
+    # session is still operator attention and belongs in aggregate unread counts.
+    def replace_agent_activity_snapshot!(agents)
+      @agent_activity_snapshot.replace!(
+        visible_agents(agents),
+        extra_unread_count: active_personal_assistant_notification_agents(agents).count(&:unread?)
+      )
+    end
+
     def hidden_setting_value(attrs)
       raise Error.new("Missing hidden value") unless attrs.key?("hidden")
 
@@ -4945,9 +4955,8 @@ module HQ
 
     def load_all_agents
       agents, events = load_agents_with_events
-      visible = visible_agents(agents)
       notification_candidates = notification_agents(agents)
-      @agent_activity_snapshot.replace!(visible)
+      replace_agent_activity_snapshot!(agents)
       notification_keys = notification_candidates.map(&:key)
       dispatch_agent_push_events(events.select { |event| notification_keys.include?(event.agent_key) }, agents: notification_candidates)
       agents
@@ -5091,7 +5100,7 @@ module HQ
 
     def save_agents(agents)
       @agent_store.save(agents)
-      @agent_activity_snapshot.replace!(visible_agents(agents))
+      replace_agent_activity_snapshot!(agents)
     end
 
     def sort_agents(agents)

--- a/test/agent_activity_snapshot_test.rb
+++ b/test/agent_activity_snapshot_test.rb
@@ -35,8 +35,16 @@ module AgentActivitySnapshotTest
     assert(awaiting[:revision] == 2 && awaiting[:unread_count] == 1,
            "expected unread activity to advance the revision")
     assert(awaiting.dig(:agents, 0, :awaiting_input), "expected inquiry activity")
+
+    assert(snapshot.replace!([finished], extra_unread_count: 1),
+           "expected an unread protected session to update aggregate activity")
+    assert(snapshot.snapshot[:unread_count] == 2,
+           "expected protected-session attention to contribute without entering the agent catalog")
+    assert(snapshot.snapshot[:agents].length == 1,
+           "expected protected-session attention not to duplicate a catalog agent")
     assert(snapshot.remove!(agent.key), "expected activity removal")
-    assert(snapshot.snapshot[:agents].empty?, "expected the removed agent to leave the snapshot")
+    assert(snapshot.snapshot[:agents].empty? && snapshot.snapshot[:unread_count] == 1,
+           "expected removing a catalog agent to retain protected-session attention")
 
     parent = fake_agent(key: "parent-agent", status: "running", unread: false)
     child = fake_agent(

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5105,8 +5105,9 @@ module RemoteServerTest
       fred = HQ::ManagedAgent.new(
         key: "personal-assistant-test-1", name: "Personal Assistant · today", project_key: "__personal_assistant__",
         template_key: "personal_assistant_daily", workspace: workspace, prompt: "Assist.", role: "personal_assistant_daily",
-        started_at: finished_at, finished_at: finished_at, last_exit_code: 0, summary: "Prepared the release request.", unread: true,
-        runs: [HQ::ManagedAgent::AgentRun.new(started_at: finished_at, finished_at: finished_at, exit_code: 0, status: "succeeded")]
+        started_at: finished_at, finished_at: finished_at, last_exit_code: 0, summary: "Choose the release path.", unread: true,
+        structured_result: { "status" => "input_required", "summary" => "Choose the release path.", "inquiry" => { "message" => "Release now?" } },
+        runs: [HQ::ManagedAgent::AgentRun.new(started_at: finished_at, finished_at: finished_at, exit_code: 0, status: "input_required")]
       )
       historical_fred = HQ::ManagedAgent.new(
         key: "personal-assistant-yesterday-0", name: "Personal Assistant · yesterday", project_key: "__personal_assistant__",
@@ -5126,11 +5127,17 @@ module RemoteServerTest
       result = service.dispatch_agent_push_notifications!
       assert(result[:events] == 1, "expected a protected FRED session to dispatch one notification")
       payload = notifier.payloads.first
-      assert(payload[:title] == "FRED finished" && payload[:url] == "/#personal-assistant",
-             "expected FRED push to use distinct copy and its dedicated route")
+      assert(payload[:title] == "FRED requires response" && payload[:url] == "/#personal-assistant",
+             "expected FRED answer-required push to use distinct copy and its dedicated route")
       assert(payload[:badge_count] == 1 && payload[:body].start_with?("FRED:"),
              "expected FRED push to participate in the shared unread badge")
       assert(service.agents.empty?, "expected FRED to remain outside the generic agent catalog")
+      activity = service.agent_activity
+      assert(activity[:unread_count] == 1 && activity[:agents].empty?,
+             "expected an unread answer-required FRED to count without entering the generic activity catalog")
+      read = service.mark_personal_assistant_read("active_key" => fred.key, "generation" => 1)
+      assert(!read[:unread] && service.agent_activity[:unread_count].zero?,
+             "expected opening FRED to durably dismiss its answer-required unread count")
       service.dispatch_agent_push_notifications!
       assert(notifier.payloads.length == 1, "expected FRED notification deduplication to survive polling")
       HQ::FileStore.write_json(File.join(HQ::PERSONAL_ASSISTANT_DIR, "state.json"), {


### PR DESCRIPTION
Fixes #189

Treat an active FRED session awaiting a structured answer as unread in activity snapshots and aggregate resource-catalog counts, without exposing FRED in the generic agent list. Opening FRED through its protected read endpoint clears the durable unread state.

Validation:
- bundle exec ruby test/agent_activity_snapshot_test.rb
- bundle exec ruby test/remote_server_test.rb
- bin/test (unrelated existing failure: test/tycho_updater_test.rb local Remote server control no-op assertion)
- bin/remote-ui-smoke (unrelated existing FRED conversation-shell fixture failure: onboarding or history block missing)