### PR TITLE
Fix queued prompt reconciliation

### DIFF
--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -2080,7 +2080,9 @@ function personalAssistantEndpointAdapter(agentOrKey, options = {}) {
       ? "/personal-assistant/prompt-queue/retry"
       : `/agents/${encodedKey}/prompt-queue/retry`,
     writeBody(body = {}, clientRequestId = "") {
-      if (!personalAssistant) return body;
+      if (!personalAssistant) {
+        return clientRequestId ? { ...body, client_request_id: clientRequestId } : body;
+      }
       if (!context?.active_key || !Number.isInteger(context.generation)) {
         throw new Error("FRED session is unavailable; refresh and try again.");
       }

--- a/test/remote_ui_prompt_queue_test.rb
+++ b/test/remote_ui_prompt_queue_test.rb
@@ -69,6 +69,41 @@ module RemoteUIPromptQueueTest
           !callback.includes('data-delete-queued-prompt="callback" data-agent-key="queue-agent" disabled')) {
         throw new Error("delegated replies must expose captured authority and immutable controls");
       }
+
+      const requestContext = {
+        personalAssistantAgent: () => false,
+        findAgent: () => null,
+        personalAssistantSessionContext: () => null,
+      };
+      vm.createContext(requestContext);
+      vm.runInContext(`${extractFunction("personalAssistantEndpointAdapter")}\nthis.personalAssistantEndpointAdapter = personalAssistantEndpointAdapter;`, requestContext);
+      const clientRequestId = "client-queue-reconciliation";
+      const adapter = requestContext.personalAssistantEndpointAdapter("queue-agent", { personalAssistant: false });
+      const requestBody = adapter.writeBody({ prompt: "One queued prompt", start: true }, clientRequestId);
+      if (requestBody.client_request_id !== clientRequestId) {
+        throw new Error("generic queued submissions must send their optimistic ID for server reconciliation");
+      }
+
+      const queueContext = {
+        escapeAttr: (value) => String(value),
+        escapeHtml: (value) => String(value),
+        iconSvg: () => "",
+        personalAssistantControlError: () => null,
+        optimisticPromptQueueEntries: () => [{
+          id: clientRequestId, prompt: "One queued prompt", state: "queued", attachments: []
+        }],
+      };
+      vm.createContext(queueContext);
+      vm.runInContext(`${extractFunction("renderPromptQueueEntry")}\n${extractFunction("renderPromptQueue")}\nthis.renderPromptQueue = renderPromptQueue;`, queueContext);
+      const queueHtml = queueContext.renderPromptQueue({
+        key: "queue-agent",
+        prompt_queue: { entries: [{
+          id: requestBody.client_request_id, prompt: requestBody.prompt, state: "queued", source: "user"
+        }] },
+      });
+      if ((queueHtml.match(/data-prompt-queue-entry=/g) || []).length !== 1 || !queueHtml.includes("1 queued")) {
+        throw new Error("one accepted queued submission must reconcile to one rendered queue row");
+      }
     JAVASCRIPT
 
     output, status = Open3.capture2e("node", "-e", script, APP_PATH)


### PR DESCRIPTION
Fixes Fizzy #190: https://fizzy.startkit.tech/1/cards/190

## Cause

The running-agent composer created a local optimistic queue entry with a client request ID, but the generic endpoint adapter dropped that ID from the POST body. The server therefore assigned another UUID. Polling merged the one server entry with the unmatched optimistic entry, producing the screenshot’s “User message” and “Message” rows even though only one POST and one durable entry existed.

## Fix

Pass the optimistic client request ID through generic message requests. The existing server contract preserves it as the queue entry ID, so polling reconciles the optimistic row with the durable row.

## Verification

- Regression test fails before the fix and passes after it.
- Prompt queue suite passes, covering multi-client persistence, edits/deletes, attachments, claim races, dispatch failure/retry, consecutive batches, inquiry blocking, and exactly-once prepared prompts.
- Full `bin/test` passes with isolated `TYCHO_HOME`.
- Focused real-Chrome flow passes at 1440x900 and 390x844: one POST, one stored entry, one row across two clients and reload, one dispatch/run; repeated multi-client submissions, edit/delete reconciliation, and a consecutive batch also pass.
- `bin/remote-ui-smoke` currently stops at its unrelated FRED onboarding/history assertion on clean isolated fixtures; this change does not touch that path.