### PR TITLE
Float conversation catch-up controls

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -747,14 +747,26 @@ def write_smoke_script(path)
             root.scrollTop = 0;
             updateGoRecentVisibility();
             const dock = document.querySelector("[data-agent-dock]");
+            const pane = document.querySelector("[data-agent-conversation-pane]");
             const load = document.querySelector("[data-load-pending-conversation]");
             const recent = document.querySelector("[data-go-recent]");
+            const overlay = document.querySelector("[data-conversation-catchup-overlay]");
+            const dockActions = document.querySelector("[data-agent-floating-actions]");
+            const paneRect = pane?.getBoundingClientRect();
+            const dockRect = dock?.getBoundingClientRect();
+            const overlayRect = overlay?.getBoundingClientRect();
             const loadRect = load?.getBoundingClientRect();
             const recentRect = recent?.getBoundingClientRect();
             return {
               labels: [load?.textContent.trim(), recent?.textContent.trim()],
               group: load?.parentElement?.getAttribute("aria-label"),
-              inDock: [load, recent].every((button) => button?.closest("[data-agent-dock]") === dock),
+              inConversation: [load, recent].every((button) => button?.closest("[data-agent-conversation-pane]") === pane),
+              outsideDockActions: [load, recent].every((button) => !dockActions?.contains(button)),
+              overlayed: Boolean(overlayRect && paneRect && dockRect && loadRect && recentRect &&
+                loadRect.left >= paneRect.left && loadRect.right <= paneRect.right &&
+                recentRect.left >= paneRect.left && recentRect.right <= paneRect.right &&
+                Math.abs(overlayRect.left + overlayRect.width / 2 - (paneRect.left + paneRect.width / 2)) <= 2 &&
+                loadRect.bottom <= dockRect.top - 8 && recentRect.bottom <= dockRect.top - 8),
               visible: [loadRect, recentRect].every((rect) => rect && rect.top >= 0 && rect.bottom <= innerHeight),
               arrow: load?.querySelector(".ui-icon path")?.getAttribute("d"),
               stagedVisible: document.body.textContent.includes("Desktop staged message"),
@@ -762,9 +774,10 @@ def write_smoke_script(path)
             };
           }, agentKey);
           if (desktopCatchUp.labels.join(",") !== "Load 1 new message,Go to recent" || desktopCatchUp.group !== "Conversation catch-up" ||
-              !desktopCatchUp.inDock || !desktopCatchUp.visible || desktopCatchUp.arrow !== "m6 9 6 6 6-6" || desktopCatchUp.stagedVisible || desktopCatchUp.scrollTop > 8) {
-            throw new Error(`Desktop conversation catch-up controls lost their staged bottom-dock behavior: ${JSON.stringify(desktopCatchUp)}`);
+              !desktopCatchUp.inConversation || !desktopCatchUp.outsideDockActions || !desktopCatchUp.overlayed || !desktopCatchUp.visible || desktopCatchUp.arrow !== "m6 9 6 6 6-6" || desktopCatchUp.stagedVisible || desktopCatchUp.scrollTop > 8) {
+            throw new Error(`Desktop conversation catch-up controls lost their floating-overlay behavior: ${JSON.stringify(desktopCatchUp)}`);
           }
+          if (captureDir) await ordinaryPage.screenshot({ path: path.join(captureDir, "ordinary-catchup-overlay-desktop.png"), fullPage: false });
           await ordinaryPage.click("[data-load-pending-conversation]");
           await ordinaryPage.waitForSelector("[data-load-pending-conversation]", { state: "detached", timeout: 10_000 });
           const desktopCatchUpLoaded = await ordinaryPage.evaluate((key) => ({
@@ -844,15 +857,26 @@ def write_smoke_script(path)
               root.scrollTop = 0;
               updateGoRecentVisibility();
               const dock = document.querySelector("[data-agent-dock]");
+              const pane = document.querySelector("[data-agent-conversation-pane]");
               const load = document.querySelector("[data-load-pending-conversation]");
               const recent = document.querySelector("[data-go-recent]");
+              const overlay = document.querySelector("[data-conversation-catchup-overlay]");
+              const dockActions = document.querySelector("[data-agent-floating-actions]");
               const dockRect = dock?.getBoundingClientRect();
+              const paneRect = pane?.getBoundingClientRect();
+              const overlayRect = overlay?.getBoundingClientRect();
               const loadRect = load?.getBoundingClientRect();
               const recentRect = recent?.getBoundingClientRect();
               return {
                 labels: [load?.textContent.trim(), recent?.textContent.trim()],
                 group: load?.parentElement?.getAttribute("aria-label"),
-                inDock: [load, recent].every((button) => button?.closest("[data-agent-dock]") === dock),
+                inConversation: [load, recent].every((button) => button?.closest("[data-agent-conversation-pane]") === pane),
+                outsideDockActions: [load, recent].every((button) => !dockActions?.contains(button)),
+                overlayed: Boolean(overlayRect && paneRect && dockRect && loadRect && recentRect &&
+                  loadRect.left >= paneRect.left && loadRect.right <= paneRect.right &&
+                  recentRect.left >= paneRect.left && recentRect.right <= paneRect.right &&
+                  Math.abs(overlayRect.left + overlayRect.width / 2 - (paneRect.left + paneRect.width / 2)) <= 2 &&
+                  loadRect.bottom <= dockRect.top - 8 && recentRect.bottom <= dockRect.top - 8),
                 visible: [loadRect, recentRect].every((rect) => rect && rect.top >= 0 && rect.bottom <= innerHeight),
                 targetHeights: [loadRect, recentRect].every((rect) => rect?.height >= 38),
                 noOverlap: Boolean(loadRect && recentRect && !(loadRect.right < recentRect.left || recentRect.right < loadRect.left || loadRect.bottom < recentRect.top || recentRect.bottom < loadRect.top)),
@@ -860,9 +884,10 @@ def write_smoke_script(path)
               };
             }, agentKey);
             if (mobileCatchUp.labels.join(",") !== "Load 2 new messages,Go to recent" || mobileCatchUp.group !== "Conversation catch-up" ||
-                !mobileCatchUp.inDock || !mobileCatchUp.visible || !mobileCatchUp.targetHeights || mobileCatchUp.noOverlap) {
-              throw new Error(`Mobile conversation catch-up controls lost their bottom dock layout: ${JSON.stringify(mobileCatchUp)}`);
+                !mobileCatchUp.inConversation || !mobileCatchUp.outsideDockActions || !mobileCatchUp.overlayed || !mobileCatchUp.visible || !mobileCatchUp.targetHeights || mobileCatchUp.noOverlap) {
+              throw new Error(`Mobile conversation catch-up controls lost their floating-overlay behavior: ${JSON.stringify(mobileCatchUp)}`);
             }
+            if (captureDir) await mobileOrdinaryPage.screenshot({ path: path.join(captureDir, "ordinary-catchup-overlay-mobile.png"), fullPage: false });
             ["bottomBorder"].forEach((key) => equalMetric(mobileOrdinary.header[key], mobileFred.header[key], `mobile header ${key}`));
             if (mobileFred.header.title !== "FRED" || !mobileFred.header.subtitleHidden || mobileOrdinary.header.subtitleHidden) {
               throw new Error(`FRED mobile header did not hide Agent-only metadata: ${JSON.stringify({ mobileOrdinary: mobileOrdinary.header, mobileFred: mobileFred.header })}`);
@@ -5597,25 +5622,26 @@ Saved safely.
           render({ preserveLiveEditor: true });
           const button = document.querySelector("[data-load-pending-conversation]");
           const dock = document.querySelector("[data-agent-dock]");
-          const composer = document.querySelector("#composer");
+          const pane = document.querySelector("[data-agent-conversation-pane]");
           const buttonRect = button?.getBoundingClientRect();
           const dockRect = dock?.getBoundingClientRect();
-          const composerRect = composer?.getBoundingClientRect();
+          const paneRect = pane?.getBoundingClientRect();
           return {
             before,
             after: document.querySelector("[data-agent-conversation-scroll]").scrollTop,
             draft: document.querySelector("#prompt-input")?.value,
             button: button?.getAttribute("aria-label"),
             catchUpGroup: button?.closest(".conversation-catchup-actions")?.getAttribute("aria-label"),
-            buttonInBottomDock: Boolean(buttonRect && dockRect && button.closest("[data-agent-dock]") === dock && buttonRect.top >= dockRect.top && buttonRect.bottom <= dockRect.bottom),
-            buttonAboveComposer: Boolean(buttonRect && composerRect && buttonRect.bottom <= composerRect.top),
+            buttonInConversationOverlay: Boolean(buttonRect && paneRect && dockRect && button.closest("[data-agent-conversation-pane]") === pane &&
+              !button.closest("[data-agent-dock]") && buttonRect.bottom <= dockRect.top - 8 &&
+              Math.abs(buttonRect.left + buttonRect.width / 2 - (paneRect.left + paneRect.width / 2)) <= 2),
             downArrow: button?.querySelector(".ui-icon path")?.getAttribute("d"),
             stagedVisible: document.body.textContent.includes("Server message staged for manual loading"),
             optimisticCount: document.body.textContent.split(pending.content).length - 1,
           };
         }, agentKey);
         if (stagedConversation.button !== "Load 2 new messages" || stagedConversation.catchUpGroup !== "Conversation catch-up" ||
-            !stagedConversation.buttonInBottomDock || !stagedConversation.buttonAboveComposer || stagedConversation.downArrow !== "m6 9 6 6 6-6" ||
+            !stagedConversation.buttonInConversationOverlay || stagedConversation.downArrow !== "m6 9 6 6 6-6" ||
             stagedConversation.stagedVisible || stagedConversation.optimisticCount !== 1 ||
             stagedConversation.draft !== draft || Math.abs(stagedConversation.after - stagedConversation.before) > 8) {
           throw new Error(`Manual conversation loading changed the visible snapshot before activation: ${JSON.stringify(stagedConversation)}`);

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -1518,10 +1518,18 @@ select {
   min-width: 0;
 }
 
+.agent-conversation-pane {
+  position: relative;
+}
+
 .agent-conversation-scroll {
   display: grid;
   align-content: start;
   gap: 8px;
+}
+
+.agent-workspace:not(.personal-assistant-page) .agent-conversation-scroll {
+  padding-bottom: 64px;
 }
 
 .agent-workspace.has-detail .agent-conversation-pane {
@@ -5868,6 +5876,25 @@ select {
   gap: 8px;
 }
 
+.conversation-catchup-overlay {
+  position: fixed;
+  bottom: calc(var(--agent-dock-height, 220px) + 12px);
+  left: 50%;
+  z-index: 6;
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+  max-width: calc(100vw - 24px);
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+
+.conversation-catchup-overlay .conversation-catchup-actions {
+  justify-content: center;
+  max-width: 100%;
+  pointer-events: auto;
+}
+
 .agent-floating-pill {
   display: inline-flex;
   align-items: center;
@@ -5925,6 +5952,11 @@ select {
     display: grid;
     min-height: 0;
     overflow: hidden;
+  }
+
+  .agent-workspace .conversation-catchup-overlay {
+    position: absolute;
+    bottom: 12px;
   }
 
   .agent-workspace.conversation-only .agent-conversation-scroll {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -3016,8 +3016,8 @@ function syncAgentFloatingActions(agent, route = parseRoute()) {
   const options = route.type === "agentSummary"
     ? { summary: false }
     : route.type === "agentPullRequests"
-      ? { pullRequests: false, recent: true }
-      : { recent: false };
+      ? { pullRequests: false }
+      : {};
   const fragment = document.createElement("div");
   fragment.innerHTML = renderAgentFloatingActions(agent, options);
   const incoming = fragment.firstElementChild;
@@ -3031,6 +3031,19 @@ function syncAgentFloatingActions(agent, route = parseRoute()) {
   else if (incoming) document.querySelector("[data-agent-dock]")?.prepend(incoming);
   if (restoreActionFocus) {
     document.querySelector(`#composer[data-agent-key="${CSS.escape(agent.key)}"] button[type="submit"]`)?.focus({ preventScroll: true });
+  }
+  syncConversationCatchUpOverlay(agent);
+}
+
+function syncConversationCatchUpOverlay(agent) {
+  const current = document.querySelector("[data-conversation-catchup-overlay]");
+  if (!current) return;
+
+  const fragment = document.createElement("div");
+  fragment.innerHTML = renderConversationCatchUpOverlay(agent);
+  const incoming = fragment.firstElementChild;
+  if (incoming && current.dataset.conversationCatchupState !== incoming.dataset.conversationCatchupState) {
+    current.replaceWith(incoming);
   }
 }
 
@@ -7397,8 +7410,8 @@ function renderAgent(key, options = {}) {
   const dockFloatingOptions = summaryMode
     ? { summary: false }
     : pullRequestMode
-      ? { pullRequests: false, recent: true }
-      : { recent: false };
+      ? { pullRequests: false }
+      : {};
   const composerPlacement = renderAgentComposerPlacement(agent, skills, { attachmentMode: focusedMode });
   setHeader(agent.name || agent.key, agentHeaderLabel(agent), "A", { agentTitle: agent });
   setAgentSettings(agent);
@@ -7425,7 +7438,7 @@ function renderAgentWorkspace(agent, blocks, options = {}) {
     options.fullView ? "agent-workspace-full-view" : "",
     agentDetailViewMode(`${agent.key}:${detailKind}`) === "wide" ? "agent-workspace-detail-wide" : "",
   ].filter(Boolean);
-  const floatingOptions = { recent: !["summary", "attachment"].includes(detailKind) };
+  const floatingOptions = {};
   if (detailKind === "summary") floatingOptions.summary = false;
   const composerPlacement = renderAgentComposerPlacement(agent, skills, { attachmentMode: focusedMode });
 
@@ -7433,6 +7446,7 @@ function renderAgentWorkspace(agent, blocks, options = {}) {
     classNames,
     conversationStateKey: `agent-conversation:${agent.key}`,
     conversationHtml: renderAgentConversationView(agent, blocks, { floatingActions: false, loading: options.conversationLoading }),
+    conversationOverlayHtml: ["summary", "attachment"].includes(detailKind) ? "" : renderConversationCatchUpOverlay(agent),
     detailHtml,
     detailKind,
     detailStateKey: `agent-detail-pane:${agent.key}:${cssIdent(detailKind)}`,
@@ -7449,6 +7463,7 @@ function renderConversationWorkspace({
   detailKind = "detail",
   detailStateKey = "",
   dockHtml = "",
+  conversationOverlayHtml = "",
   overlayHtml = "",
   attributes = "",
 }) {
@@ -7461,6 +7476,7 @@ function renderConversationWorkspace({
         <div class="agent-conversation-scroll" data-agent-conversation-scroll data-preserve-scroll data-state-key="${escapeAttr(conversationStateKey)}">
           ${conversationHtml}
         </div>
+        ${conversationOverlayHtml}
       </section>
       ${detail ? `<aside class="agent-detail-pane" aria-label="${escapeAttr(detailKind)}" data-preserve-scroll data-state-key="${escapeAttr(detailStateKey || `agent-detail-pane:${detailKind}`)}">${detail}</aside>` : ""}
       ${dock ? `<section class="agent-dock" data-agent-dock>${dock}</section>` : ""}
@@ -8501,16 +8517,21 @@ function renderAgentFloatingActions(agent, options = {}) {
   const inquiryLoading = REMOTE_HELPERS.agentComposerState(agent) === "inquiry-loading";
   const summary = options.summary === false || inquiryLoading ? "" : renderAgentSummaryToggle(agent);
   const pullRequests = options.pullRequests === false ? "" : renderAgentPullRequestsToggle(agent);
-  const catchUp = options.recent ? renderConversationCatchUpActions(agent) : "";
   const stop = agentIsRunning(agent) ? renderAgentStopToggle(agent) : "";
-  const actions = `${summary}${pullRequests}${catchUp}${stop}`;
+  const actions = `${summary}${pullRequests}${stop}`;
   if (!actions) return "";
 
   return `
-    <div class="agent-floating-actions" data-agent-floating-actions data-agent-floating-action-state="${agentIsRunning(agent) ? "running" : "idle"}:${pendingConversationUpdate(agent?.key)?.loading ? "loading" : pendingConversationUpdate(agent?.key) ? "pending" : "current"}" aria-label="Agent shortcuts">
+    <div class="agent-floating-actions" data-agent-floating-actions data-agent-floating-action-state="${agentIsRunning(agent) ? "running" : "idle"}" aria-label="Agent shortcuts">
       ${actions}
     </div>
   `;
+}
+
+function renderConversationCatchUpOverlay(agent) {
+  const pending = pendingConversationUpdate(agent?.key);
+  const state = pending?.loading ? "loading" : pending ? "pending" : "current";
+  return `<div class="conversation-catchup-overlay" data-conversation-catchup-overlay data-conversation-catchup-state="${state}">${renderConversationCatchUpActions(agent)}</div>`;
 }
 
 function renderConversationCatchUpActions(agent) {

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -7109,12 +7109,18 @@ module RemoteServerTest
            js[:body].include?("data-load-pending-conversation") &&
            js[:body].include?("Conversation catch-up"),
            "expected staged-message and Go to recent controls to share an accessible catch-up group")
+    assert(js[:body].include?("conversationOverlayHtml") &&
+           js[:body].include?("renderConversationCatchUpOverlay(agent)") &&
+           css[:body].include?(".conversation-catchup-overlay") &&
+           css[:body].include?("bottom: calc(var(--agent-dock-height, 220px) + 12px)") &&
+           !js[:body].include?("const catchUp = options.recent"),
+           "expected conversation catch-up controls to overlay the conversation independently from dock actions")
     assert(js[:body].include?("iconSvg(\"chevronDown\")") &&
            css[:body].include?(".load-new-messages-fab") &&
            !css[:body].include?(".new-conversation-messages"),
            "expected bottom catch-up controls to reuse the downward chevron without a top-sticky message control")
-    assert(js[:body].include?('!["summary", "attachment"].includes(detailKind)'),
-           "expected Summary and Attachment views to omit Go to recent")
+    assert(js[:body].include?('["summary", "attachment"].includes(detailKind) ? "" : renderConversationCatchUpOverlay(agent)'),
+           "expected Summary and Attachment views to omit the conversation catch-up overlay")
     assert(js[:body].include?("function updateGoRecentVisibility"),
            "expected Agent detail to hide Go to recent at the bottom")
     assert(js[:body].include?("function scrollConversationToRecent"),


### PR DESCRIPTION
## Summary
- render Load new messages and Go to recent as a centered conversation overlay above the dock
- keep Summary, PR Diff, Stop, and composer layout independent
- cover DOM ownership and desktop/mobile overlay geometry in the Remote UI smoke

## Verification
- `node --check lib/hq/remote_ui/assets/app.js`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/remote-ui-smoke` reaches and captures the new desktop overlay; its unrelated FRED onboarding/history fixture assertion fails before the mobile phase