### PR TITLE
Fix FRED quick switch navigation

### DIFF
--- a/bin/remote-ui-phase2-smoke
+++ b/bin/remote-ui-phase2-smoke
@@ -450,6 +450,13 @@ def write_browser_script(path, base_url, capture_dir, executor_barrier_path)
 
       await page.goto(`${baseUrl}/ui#personal-assistant`, { waitUntil: "domcontentloaded" });
       await waitFor(page, () => Boolean(document.querySelector(".personal-assistant-page")), null, "FRED page");
+      const agentSwitcher = page.locator("#header-mark");
+      if (await agentSwitcher.count() !== 1) fail("expected one agent switcher trigger");
+      await agentSwitcher.click();
+      const fredSwitcherEntry = page.locator(".switcher-fred-row");
+      if (await fredSwitcherEntry.count() !== 1) fail("expected one FRED quick-switch entry");
+      await fredSwitcherEntry.click();
+      await waitFor(page, () => window.location.hash === "#personal-assistant", null, "FRED quick-switch route");
       await assertNoNestedForms(page, "initial render");
       const persistedUnknownId = "pa-persisted-unknown-fixture";
       await waitFor(page, (proposalId) => {

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -14103,6 +14103,10 @@ function navigateSwitcherAgent(agent) {
   navigate(agent?.personal_assistant ? { type: "personalAssistant" } : { type: "agent", key: agent.key });
 }
 
+function switcherAgentForKey(key) {
+  return quickSwitchAgents().find((agent) => agent.key === key) || findAgent(key);
+}
+
 function scrollSelectedSwitcherAgentIntoView() {
   const selected = els.unreadPanel?.querySelector("[data-switcher-index].selected");
   selected?.scrollIntoView?.({ block: "nearest" });
@@ -16068,7 +16072,7 @@ els.unreadPanel.addEventListener("click", (event) => {
     const index = Number.parseInt(agentButton.dataset.switcherIndex, 10);
     if (Number.isFinite(index)) state.unreadPanelSelectedIndex = index;
     closeUnreadPanel();
-    navigateSwitcherAgent(findAgent(agentButton.dataset.openAgent) || quickSwitchAgents().find((agent) => agent.key === agentButton.dataset.openAgent));
+    navigateSwitcherAgent(switcherAgentForKey(agentButton.dataset.openAgent));
     return;
   }
 

--- a/test/remote_ui_personal_assistant_behavior_test.rb
+++ b/test/remote_ui_personal_assistant_behavior_test.rb
@@ -96,12 +96,33 @@ module RemoteUIPersonalAssistantBehaviorTest
         "receiveConversationSnapshot",
         "receiveConversationMetadata",
         "ensureConversation",
+        "navigateSwitcherAgent",
+        "switcherAgentForKey",
       ].forEach((name) => vm.runInContext(`${extractFunction(name)}\nthis.${name} = ${name};`, context));
 
       const assert = (condition, message) => {
         if (!condition) throw new Error(message);
       };
       const liveValue = (attributes) => attributes.match(/aria-live="([^"]+)"/)[1];
+
+      const navigations = [];
+      context.navigate = (route) => navigations.push(route);
+      context.navigateSwitcherAgent({ key: "fred-session", personal_assistant: true });
+      context.navigateSwitcherAgent({ key: "ordinary-agent" });
+      assert(JSON.stringify(navigations) === JSON.stringify([
+        { type: "personalAssistant" },
+        { type: "agent", key: "ordinary-agent" },
+      ]), "switcher navigation did not keep FRED separate from ordinary agents");
+
+      const fredQuickEntry = { key: "fred-session", personal_assistant: true };
+      const storedFredAgent = { key: "fred-session", role: "personal_assistant_daily" };
+      const storedOrdinaryAgent = { key: "ordinary-agent" };
+      context.quickSwitchAgents = () => [fredQuickEntry, storedOrdinaryAgent];
+      context.findAgent = (key) => key === "fred-session" ? storedFredAgent : storedOrdinaryAgent;
+      assert(context.switcherAgentForKey("fred-session") === fredQuickEntry,
+             "switcher selected the underlying FRED managed-agent record instead of the FRED quick entry");
+      assert(context.switcherAgentForKey("ordinary-agent") === storedOrdinaryAgent,
+             "switcher no longer preserved ordinary agent navigation");
 
       context.state.personalAssistant = { configured: true };
       assert(context.personalAssistantShellRefreshNeeded() === false,


### PR DESCRIPTION
## Summary
- Route the FRED quick-switch entry to the dedicated Personal Assistant conversation.
- Keep ordinary quick-list agent navigation unchanged.
- Cover the selector ordering in the Remote UI behavior test and verify it in the Phase 2 Chrome smoke.

## Verification
- `bundle exec ruby test/remote_ui_personal_assistant_behavior_test.rb`
- `bundle exec ruby test/remote_ui_agent_search_test.rb`
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb`
- `bin/remote-ui-phase2-smoke`
- `bin/test` (all tests passed except pre-existing/environmental `test/tycho_updater_test.rb`: a separate local Remote server was already listening on port 7373)

Fizzy card: https://fizzy.startkit.tech/1/cards/197