### PR TITLE
Align agent switcher avatars

### DIFF
--- a/bin/remote-ui-smoke
+++ b/bin/remote-ui-smoke
@@ -3705,6 +3705,59 @@ Saved safely.
         if (switcherAgentCount < 2) {
           throw new Error(`Agent switcher did not include both smoke agents: ${switcherAgentCount}`);
         }
+        const assertSwitcherAvatarAlignment = async (viewport) => {
+          const alignment = await agentsRegressionPage.evaluate(() => {
+            const rows = Array.from(document.querySelectorAll(".switcher-agent-row"));
+            const measure = (row) => {
+              const avatar = row.querySelector(":scope > .fred-switcher-avatar, :scope > .status-mark, :scope > .agent-status-icon");
+              const title = row.querySelector(":scope > .row-title");
+              const avatarRect = avatar?.getBoundingClientRect();
+              const titleRect = title?.getBoundingClientRect();
+              return avatarRect && titleRect ? {
+                avatarLeft: avatarRect.left,
+                avatarWidth: avatarRect.width,
+                avatarHeight: avatarRect.height,
+                titleLeft: titleRect.left,
+                gap: titleRect.left - avatarRect.right,
+              } : null;
+            };
+            const fred = rows.find((row) => row.classList.contains("switcher-fred-row"));
+            const ordinary = rows.filter((row) => !row.classList.contains("switcher-fred-row"));
+            return {
+              fred: fred ? measure(fred) : null,
+              ordinary: ordinary.map(measure),
+              overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+            };
+          });
+          const fred = alignment.fred;
+          const aligned = fred && alignment.ordinary.length && alignment.ordinary.every((ordinary) => ordinary &&
+            Math.abs(ordinary.avatarLeft - fred.avatarLeft) <= 1 &&
+            Math.abs(ordinary.avatarWidth - fred.avatarWidth) <= 1 &&
+            Math.abs(ordinary.avatarHeight - fred.avatarHeight) <= 1 &&
+            Math.abs(ordinary.titleLeft - fred.titleLeft) <= 1 &&
+            Math.abs(ordinary.gap - fred.gap) <= 1);
+          if (!aligned || alignment.overflow) {
+            throw new Error(`Agent switcher avatar/text columns drifted at ${viewport}: ${JSON.stringify(alignment)}`);
+          }
+        };
+        await assertSwitcherAvatarAlignment("mobile");
+        if (captureDir) {
+          await agentsRegressionPage.screenshot({
+            path: path.join(captureDir, "agent-switcher-avatar-alignment-mobile.png"),
+            fullPage: false,
+          });
+        }
+        await agentsRegressionPage.setViewportSize({ width: 1440, height: 900 });
+        await agentsRegressionPage.waitForTimeout(100);
+        await assertSwitcherAvatarAlignment("desktop");
+        if (captureDir) {
+          await agentsRegressionPage.screenshot({
+            path: path.join(captureDir, "agent-switcher-avatar-alignment-desktop.png"),
+            fullPage: false,
+          });
+        }
+        await agentsRegressionPage.setViewportSize({ width: 390, height: 844 });
+        await agentsRegressionPage.waitForTimeout(100);
         await agentsRegressionPage.locator("#unread-agent-search").evaluate((input) => { input.__tychoSearchNodeProbe = true; });
         await agentsRegressionPage.fill("#unread-agent-search", "unscheduled");
         const switcherSearchNodeStable = await agentsRegressionPage.locator("#unread-agent-search").evaluate((input) => input.__tychoSearchNodeProbe === true);

--- a/lib/hq/remote_ui/assets/app.css
+++ b/lib/hq/remote_ui/assets/app.css
@@ -916,16 +916,27 @@ h3 {
   box-shadow: none;
 }
 
+.switcher-agent-row {
+  --switcher-avatar-size: 34px;
+  grid-template-columns: var(--switcher-avatar-size) minmax(0, 1fr) auto;
+  border-left-width: 3px;
+}
+
 .switcher-fred-row {
   border-left: 3px solid var(--accent);
 }
 
 .fred-switcher-avatar {
-  width: 2rem;
-  height: 2rem;
+  width: var(--switcher-avatar-size);
+  height: var(--switcher-avatar-size);
   border-radius: 50%;
   object-fit: cover;
   flex: 0 0 auto;
+}
+
+.switcher-agent-row > .agent-status-icon {
+  width: var(--switcher-avatar-size);
+  height: var(--switcher-avatar-size);
 }
 
 .unread-agents-panel .switcher-agent-row.selected {


### PR DESCRIPTION
## Summary
- reserve one 34px avatar column for FRED and ordinary agent status/identity icons
- give every switcher row the same left-border geometry so adjacent text starts in a common column
- add desktop and mobile browser geometry assertions plus screenshots to the Remote UI smoke

Fizzy: https://fizzy.startkit.tech/1/cards/195

## Validation
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test` (blocked by pre-existing local Remote server expectation in `test/tycho_updater_test.rb`)
- `bin/remote-ui-smoke` (blocked before the new assertion by pre-existing FRED fixture and Settings-menu expectations)