### PR TITLE
Batch delegated agent callbacks

### DIFF
--- a/lib/hq/domain/agent_store.rb
+++ b/lib/hq/domain/agent_store.rb
@@ -697,8 +697,12 @@ module HQ
 
     def mark_claim_reports_resumed!(claim)
       Array(claim["entries"]).each do |entry|
-        report_id = entry.dig("message_metadata", "delegation_report", "id")
-        @delegation_coordinator.mark_report_resumed!(report_id, now: Time.now) if report_id
+        reports = Array(entry.dig("message_metadata", "delegation_reports"))
+        reports = [entry.dig("message_metadata", "delegation_report")] if reports.empty?
+        reports.each do |report|
+          report_id = report&.fetch("id", nil)
+          @delegation_coordinator.mark_report_resumed!(report_id, now: Time.now) if report_id
+        end
       end
     end
 

--- a/lib/hq/domain/delegation_coordinator.rb
+++ b/lib/hq/domain/delegation_coordinator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "digest"
 
 require_relative "agent_archive_store"
 require_relative "agent_memory"
@@ -52,11 +53,11 @@ module HQ
         changed ||= created
       end
 
-      pending = delegation_store.reports.select do |report|
+      pending_reports = delegation_store.reports.select do |report|
         report["delivered_at"].to_s.empty? && report["suppressed_at"].to_s.empty?
       end
-      pending.each do |report|
-        changed = deliver_report!(report, agents, now:) || changed
+      pending_reports.group_by { |report| report.fetch("parent_agent_key") }.each_value do |reports|
+        changed = deliver_reports!(reports, agents, now:) || changed
       end
 
       resume_parents!(agents, now:) || changed
@@ -121,8 +122,9 @@ module HQ
 
     private
 
-    def deliver_report!(report, agents, now:)
-      parent_key = report.fetch("parent_agent_key")
+    def deliver_reports!(reports, agents, now:)
+      reports = ordered_reports(reports)
+      parent_key = reports.first.fetch("parent_agent_key")
       parent = agents.find { |agent| agent.key == parent_key }
       archived = nil
       unless parent
@@ -130,39 +132,42 @@ module HQ
         parent = archived&.agent
       end
       unless parent
-        delegation_store.update_report!(report.fetch("id"), resume_state: "parent_missing")
+        reports.each { |report| delegation_store.update_report!(report.fetch("id"), resume_state: "parent_missing") }
         return false
       end
 
-      entry_id = "delegation-report:#{report.fetch("id")}"
+      entry_id = "delegation-report-batch:#{batch_id(reports)}"
       parent_authority = ownership_stamp(parent.key) unless archived
       metadata = {
-        "message_author" => { "type" => "agent" }.merge(report.fetch("child")),
+        "message_author" => { "type" => "agent", "name" => "Delegated agents" },
         "delegation_callback" => true,
-        "delegation_report" => report,
-        "agent_reference" => report.fetch("child")
+        "delegation_reports" => reports
       }
+      metadata["delegation_report"] = reports.first if reports.length == 1
+      metadata["agent_reference"] = reports.first.fetch("child") if reports.length == 1
       if archived
         added = AgentMemory.new(parent).append_delegation_report!(
-          report_message(report), report_id: entry_id, created_at: now, metadata:
+          reports_message(reports), report_id: entry_id, created_at: now, metadata:
         )
         @archive_store.save(archived) if added
       elsif parent.respond_to?(:queued_prompts) && parent.respond_to?(:enqueue_prompt!) &&
             parent.queued_prompts.none? { |entry| entry["id"] == entry_id }
         parent.enqueue_prompt!(
-          prompt: report_message(report), id: entry_id, accepted_at: now,
+          prompt: reports_message(reports), id: entry_id, accepted_at: now,
           authority: parent_authority, message_metadata: metadata,
           source: "delegation_callback"
         )
       elsif !parent.respond_to?(:queued_prompts)
         AgentMemory.new(parent).append_delegation_report!(
-          report_message(report), report_id: entry_id, created_at: now, metadata:
+          reports_message(reports), report_id: entry_id, created_at: now, metadata:
         )
       end
       state = archived ? "parent_archived" : (parent.running? ? "parent_running" : "queued")
-      delegation_store.update_report!(
-        report.fetch("id"), delivered_at: now, resume_state: state, parent_authority:
-      )
+      reports.each do |report|
+        delegation_store.update_report!(
+          report.fetch("id"), delivered_at: now, resume_state: state, parent_authority:
+        )
+      end
       true
     end
 
@@ -173,10 +178,6 @@ module HQ
         unless parent
           reports.each { |report| delegation_store.update_report!(report.fetch("id"), resume_state: "parent_archived") }
           next
-        end
-
-        if parent.respond_to?(:queued_prompts)
-          reports.each { |report| changed = ensure_report_queued!(parent, report, now:) || changed }
         end
 
         if parent.running?
@@ -229,24 +230,6 @@ module HQ
       changed
     end
 
-    def ensure_report_queued!(parent, report, now:)
-      entry_id = "delegation-report:#{report.fetch("id")}"
-      return false if parent.queued_prompts.any? { |entry| entry["id"] == entry_id }
-
-      metadata = {
-        "message_author" => { "type" => "agent" }.merge(report.fetch("child")),
-        "delegation_callback" => true,
-        "delegation_report" => report,
-        "agent_reference" => report.fetch("child")
-      }
-      parent.enqueue_prompt!(
-        prompt: report_message(report), id: entry_id, accepted_at: report["delivered_at"] || now,
-        authority: report["parent_authority"] || ownership_stamp(parent.key),
-        message_metadata: metadata, source: "delegation_callback"
-      )
-      true
-    end
-
     def resumable_reports
       delegation_store.reports.select do |report|
         !report["delivered_at"].to_s.empty? &&
@@ -254,9 +237,16 @@ module HQ
       end
     end
 
-    def report_message(report)
+    def reports_message(reports)
       payload = {
-        "type" => "delegated_agent_report",
+        "type" => "delegated_agent_reports",
+        "reports" => ordered_reports(reports).map { |report| report_payload(report) }
+      }
+      "Delegated agent reports:\n#{JSON.pretty_generate(payload)}"
+    end
+
+    def report_payload(report)
+      {
         "report_id" => report.fetch("id"),
         "agent" => report.fetch("child"),
         "run_id" => report["child_run_id"],
@@ -268,7 +258,17 @@ module HQ
         "inquiry" => report["inquiry"],
         "attachments" => report["attachments"]
       }.compact
-      "Delegated agent report:\n#{JSON.pretty_generate(payload)}"
+    end
+
+    def ordered_reports(reports)
+      reports.sort_by do |report|
+        [report["created_at"].to_s, report.dig("child", "agent_key").to_s,
+         report["child_run_number"].to_i, report["id"].to_s]
+      end
+    end
+
+    def batch_id(reports)
+      Digest::SHA256.hexdigest("delegation-report-batch-v1\0#{reports.map { |report| report.fetch("id") }.join("\0")}")
     end
 
     def canonical_workspace(path)

--- a/lib/hq/remote_ui/assets/app.js
+++ b/lib/hq/remote_ui/assets/app.js
@@ -10920,12 +10920,20 @@ function renderSystemEventBlock(block, index, options = {}) {
 }
 
 function renderDelegationCallbackBlock(block, index, options = {}) {
-  const report = block?.metadata?.delegation_report || {};
-  const reference = contextualAgentReference(block?.metadata?.agent_reference || report.child, options.agent);
+  const reports = Array.isArray(block?.metadata?.delegation_reports) && block.metadata.delegation_reports.length
+    ? block.metadata.delegation_reports
+    : [block?.metadata?.delegation_report || {}];
+  const report = reports[0];
+  const bundled = reports.length > 1;
+  const reference = bundled ? null : contextualAgentReference(block?.metadata?.agent_reference || report.child, options.agent);
   const runNumber = Number(report.child_run_number);
-  const runLabel = Number.isInteger(runNumber) && runNumber > 0 ? `Run #${runNumber}` : "Child run";
-  const status = String(report.status || "completed");
-  const summary = String(report.summary || "Delegated work completed.").trim();
+  const runLabel = bundled
+    ? `${reports.length} delegated runs completed`
+    : (Number.isInteger(runNumber) && runNumber > 0 ? `Run #${runNumber}` : "Child run");
+  const status = bundled ? "completed" : String(report.status || "completed");
+  const summary = bundled
+    ? reports.map((item) => `${item?.child?.name || item?.child?.agent_key || "Child"}: ${String(item?.summary || "Completed.").trim()}`).join(" · ")
+    : String(report.summary || "Delegated work completed.").trim();
   const reportDetails = String(block?.content || "");
   const stateKey = `delegation-callback:${index}:${blockStateToken(block)}`;
   return `

--- a/lib/hq/skill_assets.json
+++ b/lib/hq/skill_assets.json
@@ -6,7 +6,7 @@
     {
       "name": "tycho",
       "files": {
-        "SKILL.md": "9ba47eeca73f3682d6da98a1638cee885ec32ece62c607d03a26fd0d7ae4d16d"
+        "SKILL.md": "7dc1e7aa4b789618862eeefd98cb9fe114cbe89937a2e18cb1353b61ca5077f6"
       }
     }
   ]

--- a/lib/hq/skill_assets/tycho/SKILL.md
+++ b/lib/hq/skill_assets/tycho/SKILL.md
@@ -65,7 +65,7 @@ tycho agent create global-web "Review the auth boundary" --parent-agent global-w
 
 ### Delegating from a managed Tycho agent
 
-Pass this managed agent's key explicitly. Tycho treats `--parent-agent` as the trusted declaration that the prompt came from the parent, links the child, and returns each terminal delegated run to that parent:
+Pass this managed agent's key explicitly. Tycho treats `--parent-agent` as the trusted declaration that the prompt came from the parent, links the child, and returns terminal delegated runs to that parent:
 
 ```bash
 "${TYCHO_EXECUTABLE:-tycho}" agent create global-web "Review the auth boundary" \
@@ -91,7 +91,7 @@ The declaration is not cryptographic authentication. Use it only with the actual
 - Treat a direct user prompt to a delegated child as Takeover. It changes the edge owner to `user`, advances its ownership generation, suppresses pending reports, and cancels queued parent resumes.
 - Let only a prompt declared with the recorded parent key restore Delegation. Parent reclaim advances the generation and cancels any unresolved child inquiry before storing the prompt.
 - Expect every terminal delegated run to create one deduplicated report when callbacks are connected. Tycho stamps ownership at launch and rejects stale generations.
-- Let Tycho deliver eligible terminal reports and resume the parent. It waits while the parent or another agent in the same workspace is running.
+- Let Tycho accumulate eligible terminal reports for the same parent into one deterministic callback and resume. It waits while the parent or another agent in the same workspace is running.
 - Treat callback disconnect as suppression, not deletion. Disconnected runs are not replayed after reconnect, and archived parents receive history without being resumed.
 - Read the UI conservatively: Tycho shows `Takeover` only while a delegated edge is user-owned. It does not show a normal `Delegation` badge.
 

--- a/test/delegation_test.rb
+++ b/test/delegation_test.rb
@@ -82,6 +82,26 @@ class DelegationTest
     end
   end
 
+  class FakeQueuedAgent < FakeAgent
+    attr_reader :queued_prompts
+
+    def initialize(**)
+      super
+      @queued_prompts = []
+    end
+
+    def enqueue_prompt!(prompt:, id:, accepted_at:, authority:, message_metadata:, source:)
+      @queued_prompts << {
+        "prompt" => prompt,
+        "id" => id,
+        "accepted_at" => accepted_at,
+        "authority" => authority,
+        "message_metadata" => message_metadata,
+        "source" => source
+      }
+    end
+  end
+
   def self.run!
     Dir.mktmpdir("tycho-delegation") do |dir|
       identity = { "id" => "server-1", "name" => "Test host" }
@@ -294,6 +314,31 @@ class DelegationTest
       quiet_events = File.readlines(quiet_parent.memory_path).map { |line| JSON.parse(line) }
       assert(quiet_events.count { |event| event.dig("metadata", "delegation_callback") } == 1,
              "expected later child runs to report after reconnect")
+
+      batch_parent = FakeQueuedAgent.new(key: "batch-parent", root: dir,
+                                         workspace: File.join(dir, "batch-parent-workspace"))
+      batch_zeta = FakeAgent.new(key: "batch-zeta", root: dir,
+                                 summary: "Zeta finished", workspace: File.join(dir, "batch-zeta-workspace"))
+      batch_alpha = FakeAgent.new(key: "batch-alpha", root: dir,
+                                  summary: "Alpha finished", workspace: File.join(dir, "batch-alpha-workspace"))
+      batch_agents = [batch_parent, batch_zeta, batch_alpha]
+      coordinator.attach!(agents: batch_agents, child: batch_zeta, parent_key: batch_parent.key)
+      coordinator.attach!(agents: batch_agents, child: batch_alpha, parent_key: batch_parent.key)
+      coordinator.process!(batch_agents, now: Time.utc(2026, 9, 13, 1, 2, 3))
+      assert(batch_parent.queued_prompts.length == 1,
+             "expected simultaneous child completions to queue one parent callback")
+      batch_entry = batch_parent.queued_prompts.first
+      batch_reports = batch_entry.dig("message_metadata", "delegation_reports")
+      assert(batch_entry["source"] == "delegation_callback" && batch_entry["prompt"].include?("delegated_agent_reports"),
+             "expected the parent callback to carry one bulk report payload")
+      assert(batch_reports.map { |report| report.dig("child", "agent_key") } == %w[batch-alpha batch-zeta],
+             "expected bulk report ordering to be deterministic independent of child polling order")
+      batch_ledger = store.reports.select { |report| report["parent_agent_key"] == batch_parent.key }
+      assert(batch_ledger.length == 2 && batch_ledger.all? { |report| report["delivered_at"] },
+             "expected every child report in a bulk callback to retain its delivery ledger entry")
+      coordinator.process!(batch_agents, now: Time.utc(2026, 9, 13, 1, 2, 4))
+      assert(batch_parent.queued_prompts.length == 1,
+             "expected replayed polling to deliver a bulk callback exactly once")
 
       %w[failed blocked input_required].each do |status|
         terminal = FakeAgent.new(key: "child-#{status}", root: dir, status: status, workspace: File.join(dir, status))

--- a/test/remote_ui_asset_snapshot_test.rb
+++ b/test/remote_ui_asset_snapshot_test.rb
@@ -263,6 +263,8 @@ module RemoteUIAssetSnapshotTest
     required = [
       "block?.metadata?.delegation_callback === true",
       "renderDelegationCallbackBlock(block, index, options)",
+      "block?.metadata?.delegation_reports",
+      "delegated runs completed",
       'class="message delegation-callback-event"',
       "Number(report.child_run_number)",
       'success: "succeeded"',


### PR DESCRIPTION
## Summary
- batch eligible completed-child reports by parent into one deterministic queued callback and resume
- preserve per-run ledger delivery, ownership/takeover suppression, and callback deduplication
- render bundled callbacks compactly and cover ordering plus exactly-once behavior

Fixes [Fizzy #199](https://fizzy.do/1/cards/199).

## Verification
- `bin/test`
- `bundle exec ruby test/delegation_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bundle exec ruby test/remote_ui_asset_snapshot_test.rb`