### PR TITLE
Simplify push notification titles

### DIFF
--- a/docs/captures/fizzy-191/push-notification-previews.json
+++ b/docs/captures/fizzy-191/push-notification-previews.json
@@ -1,0 +1,72 @@
+{
+  "captured_at": "2026-09-13T12:00:00Z",
+  "source": "test/push_notification_contract_test.rb",
+  "previews": [
+    {
+      "variant": "agent_input_required",
+      "title": "Input needed",
+      "body": "Release check: Confirm the rollout. (2 unread agents)",
+      "url": "/#agent/release-check"
+    },
+    {
+      "variant": "agent_succeeded",
+      "title": "Done",
+      "body": "Release check: Confirm the rollout. (2 unread agents)",
+      "url": "/#agent/release-check"
+    },
+    {
+      "variant": "agent_failed",
+      "title": "Failed",
+      "body": "Release check: Confirm the rollout. (2 unread agents)",
+      "url": "/#agent/release-check"
+    },
+    {
+      "variant": "agent_stopped",
+      "title": "Stopped",
+      "body": "Release check: Confirm the rollout. (2 unread agents)",
+      "url": "/#agent/release-check"
+    },
+    {
+      "variant": "agent_blocked",
+      "title": "Blocked",
+      "body": "Release check: Confirm the rollout. (2 unread agents)",
+      "url": "/#agent/release-check"
+    },
+    {
+      "variant": "fred_input_required",
+      "title": "Input needed",
+      "body": "FRED: Choose a release path.",
+      "url": "/#personal-assistant"
+    },
+    {
+      "variant": "schedule_failed",
+      "title": "Failed",
+      "body": "Daily Memory: Confirm archive retention. Schedule stopped.",
+      "url": "/#agent/memory-agent"
+    },
+    {
+      "variant": "schedule_input_required",
+      "title": "Input needed",
+      "body": "Daily Memory: Confirm archive retention. Schedule stopped.",
+      "url": "/#agent/memory-agent"
+    },
+    {
+      "variant": "schedule_first_success",
+      "title": "Done",
+      "body": "Daily Memory: first run succeeded. Next run: 2026-09-14 09:30.",
+      "url": "/#agent/memory-agent"
+    },
+    {
+      "variant": "schedule_recovery",
+      "title": "Recovered",
+      "body": "Daily Memory: succeeded after failure. Next run: 2026-09-14 09:30.",
+      "url": "/#agent/memory-agent"
+    },
+    {
+      "variant": "push_test",
+      "title": "Test notification",
+      "body": "Push notifications are working.",
+      "url": "/#setup"
+    }
+  ]
+}

--- a/lib/hq/domain/scheduler.rb
+++ b/lib/hq/domain/scheduler.rb
@@ -611,8 +611,8 @@ module HQ
         state.last_finished_at&.iso8601 || now.iso8601
       ].join(":")
       payload = {
-        title: "Schedule failed",
-        body: "#{schedule.name}: #{error || agent&.last_summary || state.last_error || "failed"}. Schedule stopped.",
+        title: "Failed",
+        body: stopped_schedule_body(schedule, error || agent&.last_summary || state.last_error || "failed"),
         tag: "hq:schedule:#{schedule.key}:failure",
         url: agent ? "/#agent/#{agent.key}" : "/#setup"
       }
@@ -628,8 +628,8 @@ module HQ
         state.last_finished_at&.iso8601 || now.iso8601
       ].join(":")
       payload = {
-        title: "Schedule needs input",
-        body: "#{schedule.name}: #{agent.last_summary || state.last_error || "waiting for operator input"}. Schedule stopped.",
+        title: "Input needed",
+        body: stopped_schedule_body(schedule, agent.last_summary || state.last_error || "waiting for operator input"),
         tag: "hq:schedule:#{schedule.key}:input-required",
         url: "/#agent/#{agent.key}"
       }
@@ -639,7 +639,7 @@ module HQ
     def notify_schedule_first_success(schedule, state, agent, now:)
       id = ["schedule", schedule.key, "first-success"].join(":")
       payload = {
-        title: "Schedule succeeded",
+        title: "Done",
         body: "#{schedule.name}: first run succeeded. Next run: #{format_time(state.next_due_at)}.",
         tag: "hq:schedule:#{schedule.key}:first-success",
         url: "/#agent/#{agent.key}"
@@ -650,7 +650,7 @@ module HQ
     def notify_schedule_recovery(schedule, state, agent, now:)
       id = ["schedule", schedule.key, "recovery", state.failure_started_at&.iso8601 || now.iso8601].join(":")
       payload = {
-        title: "Schedule succeeded after failure",
+        title: "Recovered",
         body: "#{schedule.name}: succeeded after failure. Next run: #{format_time(state.next_due_at)}.",
         tag: "hq:schedule:#{schedule.key}:recovery",
         url: "/#agent/#{agent.key}"
@@ -669,6 +669,12 @@ module HQ
 
     def format_time(value)
       value ? value.strftime("%Y-%m-%d %H:%M") : "unknown"
+    end
+
+    def stopped_schedule_body(schedule, detail)
+      summary = detail.to_s.strip
+      punctuation = summary.end_with?(".", "!", "?") ? "" : "."
+      "#{schedule.name}: #{summary}#{punctuation} Schedule stopped."
     end
 
     def publish(event, schedule, state, attrs = {})

--- a/lib/hq/domain/web_push_notifier.rb
+++ b/lib/hq/domain/web_push_notifier.rb
@@ -35,8 +35,8 @@ module HQ
           "configured=#{push_config.fetch(:configured)} subscriptions=#{push_config.fetch(:subscription_count)}"
       end
       payload = {
-        title: "Tycho",
-        body: "Test notification from Tycho.",
+        title: "Test notification",
+        body: "Push notifications are working.",
         tag: "hq:test",
         url: "/#setup"
       }

--- a/lib/hq/remote_server.rb
+++ b/lib/hq/remote_server.rb
@@ -5285,11 +5285,15 @@ module HQ
       status = agent.status
       if status == "awaiting-input"
         event = "input_required"
-        title = agent.personal_assistant? ? "FRED requires response" : "Agent requires response"
+        title = "Input needed"
       elsif %w[succeeded failed stopped blocked].include?(status)
         event = "finished"
-        prefix = agent.personal_assistant? ? "FRED finished" : "Agent finished"
-        title = status == "succeeded" ? prefix : "#{prefix}: #{status}"
+        title = {
+          "succeeded" => "Done",
+          "failed" => "Failed",
+          "stopped" => "Stopped",
+          "blocked" => "Blocked"
+        }.fetch(status)
       else
         return nil
       end

--- a/test/push_notification_contract_test.rb
+++ b/test/push_notification_contract_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "time"
+
+require_relative "../lib/hq/remote_server"
+
+module PushNotificationContractTest
+  module_function
+
+  Agent = Struct.new(:key, :status, :display_name, :last_summary, :personal, keyword_init: true) do
+    def personal_assistant?
+      personal
+    end
+
+    def no_action_needed?
+      false
+    end
+
+    def last_run_from_prompt_queue?
+      false
+    end
+  end
+
+  Schedule = Struct.new(:key, :name, keyword_init: true)
+  ScheduleState = Struct.new(:last_target_key, :last_finished_at, :last_error, :next_due_at, :failure_started_at,
+                             keyword_init: true)
+  ScheduleAgent = Struct.new(:key, :last_summary, keyword_init: true)
+
+  def run!
+    assert_agent_payload_contract
+    assert_schedule_payload_contract
+    assert_test_payload_contract
+    puts "push_notification_contract_test: ok"
+  end
+
+  def assert_agent_payload_contract
+    service = HQ::RemoteService.allocate
+    expected_titles = {
+      "awaiting-input" => "Input needed",
+      "succeeded" => "Done",
+      "failed" => "Failed",
+      "stopped" => "Stopped",
+      "blocked" => "Blocked"
+    }
+
+    expected_titles.each do |status, title|
+      payload = service.send(:agent_push_payload, Agent.new(
+                               key: "release-check", status:, display_name: "Release check",
+                               last_summary: "Confirm the rollout.", personal: false
+                             ), unread_count: 2).fetch(:payload)
+      assert(payload == {
+               title:,
+               body: "Release check: Confirm the rollout. (2 unread agents)",
+               tag: "hq:agents",
+               renotify: status == "awaiting-input",
+               silent: status != "awaiting-input",
+               badge_count: 2,
+               url: "/#agent/release-check"
+             }, "expected concise generic #{status} notification contract")
+    end
+
+    fred_payload = service.send(:agent_push_payload, Agent.new(
+                                     key: "fred-today", status: "awaiting-input", display_name: "ignored",
+                                     last_summary: "Choose a release path.", personal: true
+                                   ), unread_count: 1).fetch(:payload)
+    assert(fred_payload == {
+             title: "Input needed",
+             body: "FRED: Choose a release path.",
+             tag: "hq:agents",
+             renotify: true,
+             silent: false,
+             badge_count: 1,
+             url: "/#personal-assistant"
+           }, "expected FRED notification to retain its identity and route in the concise contract")
+  end
+
+  def assert_schedule_payload_contract
+    notifier = RecordingNotifier.new
+    scheduler = HQ::Scheduler.allocate
+    scheduler.instance_variable_set(:@push_notification_store, RecordingPushStore.new)
+    scheduler.instance_variable_set(:@web_push_notifier, notifier)
+    schedule = Schedule.new(key: "daily-memory", name: "Daily Memory")
+    state = ScheduleState.new(
+      last_target_key: "memory-agent", last_finished_at: Time.utc(2026, 9, 13, 12, 0, 0),
+      last_error: "Archive quota reached.", next_due_at: Time.utc(2026, 9, 14, 9, 30, 0),
+      failure_started_at: Time.utc(2026, 9, 13, 11, 0, 0)
+    )
+    agent = ScheduleAgent.new(key: "memory-agent", last_summary: "Confirm archive retention.")
+
+    scheduler.send(:notify_schedule_failure, schedule, state, now: Time.utc(2026, 9, 13, 12, 0, 0), agent: agent)
+    scheduler.send(:notify_schedule_input_required, schedule, state, agent, now: Time.utc(2026, 9, 13, 12, 0, 0))
+    scheduler.send(:notify_schedule_first_success, schedule, state, agent, now: Time.utc(2026, 9, 13, 12, 0, 0))
+    scheduler.send(:notify_schedule_recovery, schedule, state, agent, now: Time.utc(2026, 9, 13, 12, 0, 0))
+
+    assert(notifier.payloads == [
+      [{ title: "Failed", body: "Daily Memory: Confirm archive retention. Schedule stopped.",
+         tag: "hq:schedule:daily-memory:failure", url: "/#agent/memory-agent" }, { urgency: "high", ttl: 3600 }],
+      [{ title: "Input needed", body: "Daily Memory: Confirm archive retention. Schedule stopped.",
+         tag: "hq:schedule:daily-memory:input-required", url: "/#agent/memory-agent" }, { urgency: "high", ttl: 3600 }],
+      [{ title: "Done", body: "Daily Memory: first run succeeded. Next run: 2026-09-14 09:30.",
+         tag: "hq:schedule:daily-memory:first-success", url: "/#agent/memory-agent" }, { urgency: "normal", ttl: 900 }],
+      [{ title: "Recovered", body: "Daily Memory: succeeded after failure. Next run: 2026-09-14 09:30.",
+         tag: "hq:schedule:daily-memory:recovery", url: "/#agent/memory-agent" }, { urgency: "normal", ttl: 900 }]
+    ], "expected concise schedule notification title and body contracts")
+  end
+
+  def assert_test_payload_contract
+    notifier = TestNotifier.new
+    notifier.send_test!(endpoint: "https://push.example.test/test")
+    assert(notifier.payload == [
+      { title: "Test notification", body: "Push notifications are working.", tag: "hq:test", url: "/#setup" },
+      { endpoint: "https://push.example.test/test", urgency: "normal", ttl: 120 }
+    ], "expected concise test notification contract")
+  end
+
+  def assert(condition, message)
+    raise message unless condition
+  end
+
+  class RecordingPushStore
+    def record!(*, **)
+      true
+    end
+  end
+
+  class RecordingNotifier
+    attr_reader :payloads
+
+    def initialize
+      @payloads = []
+    end
+
+    def send_payload!(payload, **options)
+      @payloads << [payload, options]
+    end
+  end
+
+  class TestNotifier < HQ::WebPushNotifier
+    attr_reader :payload
+
+    def config
+      { configured: true, subscription_count: 1 }
+    end
+
+    def send_payload!(payload, **options)
+      @payload = [payload, options]
+    end
+  end
+end
+
+PushNotificationContractTest.run! if $PROGRAM_NAME == __FILE__

--- a/test/remote_server_test.rb
+++ b/test/remote_server_test.rb
@@ -5023,9 +5023,9 @@ module RemoteServerTest
       assert(input_activity[:awaiting_input] && input_activity[:unread],
              "expected notification reconciliation to publish finalized inquiry activity")
       assert(notifier.payloads.length == 2, "expected two push payloads")
-      assert(notifier.payloads.any? { |payload| payload[:title] == "Agent requires response" },
+      assert(notifier.payloads.any? { |payload| payload[:title] == "Input needed" },
              "expected requires-response notification")
-      assert(notifier.payloads.any? { |payload| payload[:title] == "Agent finished" },
+      assert(notifier.payloads.any? { |payload| payload[:title] == "Done" },
              "expected finished notification")
       assert(notifier.payloads.all? { |payload| payload[:url].start_with?("/#agent/") },
              "expected notification click URLs to target agent detail")
@@ -5127,7 +5127,7 @@ module RemoteServerTest
       result = service.dispatch_agent_push_notifications!
       assert(result[:events] == 1, "expected a protected FRED session to dispatch one notification")
       payload = notifier.payloads.first
-      assert(payload[:title] == "FRED requires response" && payload[:url] == "/#personal-assistant",
+      assert(payload[:title] == "Input needed" && payload[:url] == "/#personal-assistant",
              "expected FRED answer-required push to use distinct copy and its dedicated route")
       assert(payload[:badge_count] == 1 && payload[:body].start_with?("FRED:"),
              "expected FRED push to participate in the shared unread badge")

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -867,7 +867,7 @@ module SchedulerTest
 
       assert(state.stopped?, "expected failed scheduled agent to stop the schedule")
       assert(state.last_status == "failed", "expected schedule state to record failed status")
-      assert(notifier.payloads.any? { |payload| payload[:title] == "Schedule failed" },
+      assert(notifier.payloads.any? { |payload| payload[:title] == "Failed" },
              "expected failure to send a web push payload")
     end
   end

--- a/test/service_worker_test.rb
+++ b/test/service_worker_test.rb
@@ -59,7 +59,7 @@ module ServiceWorkerTest
       (async () => {
         await dispatch("push", {
           data: { json: () => ({
-            title: "Agent finished",
+            title: "Done",
             body: "Windows check",
             tag: "hq:agents",
             renotify: true,
@@ -70,7 +70,7 @@ module ServiceWorkerTest
         });
         assert.deepStrictEqual(badges, [2]);
         assert.strictEqual(notifications.length, 1);
-        assert.strictEqual(notifications[0].title, "Agent finished");
+        assert.strictEqual(notifications[0].title, "Done");
         assert.strictEqual(notifications[0].options.body, "Windows check");
         assert.strictEqual(notifications[0].options.tag, "hq:agents");
         assert.strictEqual(notifications[0].options.renotify, true);


### PR DESCRIPTION
## Summary
- replace verbose agent, FRED, schedule, and test push titles with concise status labels
- retain agent/schedule identity, summaries, unread context, routes, notification tags, urgency, and silent/renotify behavior in payloads
- add exact payload-contract coverage and deterministic previews

## Verification
- `bundle exec ruby test/push_notification_contract_test.rb`
- `bundle exec ruby test/web_push_notifier_test.rb`
- `bundle exec ruby test/service_worker_test.rb`
- `bundle exec ruby test/scheduler_test.rb`
- `bundle exec ruby test/remote_server_test.rb`
- `bin/test` (with the existing local Remote-server control record temporarily isolated and restored; all tests passed)

Fizzy: https://fizzy.startkit.tech/1/public/boards/JL9SBKBA7kAWp4a7fsFFFpXk/cards/191